### PR TITLE
Addrhash

### DIFF
--- a/memHierarchy/cacheFactory.cc
+++ b/memHierarchy/cacheFactory.cc
@@ -134,10 +134,6 @@ Cache* Cache::cacheFactory(ComponentId_t id, Params &params){
       ht = new LinearHashFunction;
     } else if (hashFunc == 2) {
       ht = new XorHashFunction;
-    } else if (hashFunc == 3) {
-      ht = new SHA1HashFunction;
-    } else if (hashFunc == 4) {
-      ht = new H3HashFunction;
     } else {
       ht = new PureIdHashFunction;
     }

--- a/memHierarchy/cacheFactory.cc
+++ b/memHierarchy/cacheFactory.cc
@@ -134,6 +134,10 @@ Cache* Cache::cacheFactory(ComponentId_t id, Params &params){
       ht = new LinearHashFunction;
     } else if (hashFunc == 2) {
       ht = new XorHashFunction;
+    } else if (hashFunc == 3) {
+      ht = new SHA1HashFunction;
+    } else if (hashFunc == 4) {
+      ht = new H3HashFunction;
     } else {
       ht = new PureIdHashFunction;
     }

--- a/memHierarchy/cacheFactory.cc
+++ b/memHierarchy/cacheFactory.cc
@@ -50,9 +50,10 @@ Cache* Cache::cacheFactory(ComponentId_t id, Params &params){
     string frequency            = params.find_string("cache_frequency", "" );            //Hertz
     string replacement          = params.find_string("replacement_policy", "LRU");
     int associativity           = params.find_integer("associativity", -1);
+    int hashFunc                = params.find_integer("hash_function", 0);
     string sizeStr              = params.find_string("cache_size", "");                  //Bytes
     int lineSize                = params.find_integer("cache_line_size", -1);            //Bytes
-    int accessLatency           = params.find_integer("access_latency_cycles", -1);                 //ns
+    int accessLatency           = params.find_integer("access_latency_cycles", -1);      //ns
     int mshrSize                = params.find_integer("mshr_num_entries", -1);           //number of entries
     string preF                 = params.find_string("prefetcher");
     int L1int                   = params.find_integer("L1", 0);
@@ -128,7 +129,14 @@ Cache* Cache::cacheFactory(ComponentId_t id, Params &params){
     if (dirAtNextLvl) bottomNetwork = "directory";
     
     /* ---------------- Initialization ----------------- */
-    HashFunction* ht = new PureIdHashFunction;
+    HashFunction* ht;
+    if (hashFunc == 1) {
+      ht = new LinearHashFunction;
+    } else if (hashFunc == 2) {
+      ht = new XorHashFunction;
+    } else {
+      ht = new PureIdHashFunction;
+    }
     
     long cacheSize  = SST::MemHierarchy::convertToBytes(sizeStr);
     uint numLines = cacheSize/lineSize;

--- a/memHierarchy/hash.h
+++ b/memHierarchy/hash.h
@@ -33,27 +33,6 @@ public:
     virtual uint64_t hash(uint32_t _ID, uint64_t _value) = 0;
 };
 
-class SHA1HashFunction : public HashFunction {
-private:
-    uint64_t dynamicValues_;
-    uint32_t* dynamicHashes_;
-    int numFunctions_;
-    int numPasses_;
-public:
-    SHA1HashFunction(int _numFunctions);
-    uint64_t hash(uint32_t _ID, uint64_t _value);
-};
-
-class H3HashFunction : public HashFunction {
-private:
-    uint64_t* hashMatrixPt_;
-    uint32_t resShift_;
-    uint32_t numFunctions_;
-public:
-    H3HashFunction( uint32_t _numFunctions, uint32_t _outputBits, uint64_t _randomSeed = 123132127);
-    uint64_t hash(uint32_t _ID, uint64_t _value);
-};
-
 /* Simplest ID hashing */
 class PureIdHashFunction : public HashFunction {
 public:

--- a/memHierarchy/hash.h
+++ b/memHierarchy/hash.h
@@ -62,6 +62,34 @@ public:
     }
 };
 
+/* This function is taken from the C99 standard's RNG and should uniquely map
+   each input to an output. */
+class LinearHashFunction : public HashFunction {
+public:
+  uint64_t hash(uint32_t _ID, uint64_t x) {
+    return 1103515245*x + 12345;
+  }
+};
+
+/* Just a simple xor-based hash. */
+class XorHashFunction : public HashFunction {
+public:
+  uint64_t hash(uint32_t _ID, uint64_t x) {
+    unsigned char b[8];
+    for (unsigned i = 0; i < 8; ++i)
+      b[i] = (x >> (i*8))&0xff;
+
+    for (unsigned i = 0; i < 7; ++i)
+      b[i] ^= b[i + 1];
+
+    uint64_t result = 0;
+    for (unsigned i = 0; i < 8; ++i)
+      result |= (b[i]<<(i*8));
+
+    return result;
+  }
+};
+
 }}
 #endif	
 /* HASH_H */

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -68,7 +68,7 @@ static const ElementInfoParam cache_params[] = {
     {"access_latency_cycles",   "Required, int      - Latency (in cycles) to access the cache array."},
     {"coherence_protocol",      "Required, string   - Coherence protocol. Options: MESI, MSI, NONE"},
     {"cache_line_size",         "Required, int      - Size of a cache line (aka cache block) in bytes."},
-    {"hash_function",           "Optional, int      - 0 - none (default), 1 - linear, 2 - XOR, 2 - SHA1, 3 - H3"},
+    {"hash_function",           "Optional, int      - 0 - none (default), 1 - linear, 2 - XOR"},
     {"L1",                      "Required, int      - Required for L1s, specifies whether cache is an L1. Options: 0[not L1], 1[L1]"},
     {"LLC",                     "Required, int      - Required for LLCs, specifies whether cache is a last-level cache. Options: 0[not LLC], 1[LLC]"},
     {"LL",                      "Required, int      - Required for LLCs, specifies whether an LLC is also the lowest-level coherence entity in the system (e.g., no dir below). Options: 0[not LL entity], 1[LL entity]"},

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -68,7 +68,7 @@ static const ElementInfoParam cache_params[] = {
     {"access_latency_cycles",   "Required, int      - Latency (in cycles) to access the cache array."},
     {"coherence_protocol",      "Required, string   - Coherence protocol. Options: MESI, MSI, NONE"},
     {"cache_line_size",         "Required, int      - Size of a cache line (aka cache block) in bytes."},
-    {"hash_function",           "Optional, int      - 0 - none (default), 1 - linear, 2 - XOR"},
+    {"hash_function",           "Optional, int      - 0 - none (default), 1 - linear, 2 - XOR, 2 - SHA1, 3 - H3"},
     {"L1",                      "Required, int      - Required for L1s, specifies whether cache is an L1. Options: 0[not L1], 1[L1]"},
     {"LLC",                     "Required, int      - Required for LLCs, specifies whether cache is a last-level cache. Options: 0[not LLC], 1[LLC]"},
     {"LL",                      "Required, int      - Required for LLCs, specifies whether an LLC is also the lowest-level coherence entity in the system (e.g., no dir below). Options: 0[not LL entity], 1[LL entity]"},

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -68,6 +68,7 @@ static const ElementInfoParam cache_params[] = {
     {"access_latency_cycles",   "Required, int      - Latency (in cycles) to access the cache array."},
     {"coherence_protocol",      "Required, string   - Coherence protocol. Options: MESI, MSI, NONE"},
     {"cache_line_size",         "Required, int      - Size of a cache line (aka cache block) in bytes."},
+    {"hash_function",           "Optional, int      - 0 - none (default), 1 - linear, 2 - XOR"},
     {"L1",                      "Required, int      - Required for L1s, specifies whether cache is an L1. Options: 0[not L1], 1[L1]"},
     {"LLC",                     "Required, int      - Required for LLCs, specifies whether cache is a last-level cache. Options: 0[not LLC], 1[LLC]"},
     {"LL",                      "Required, int      - Required for LLCs, specifies whether an LLC is also the lowest-level coherence entity in the system (e.g., no dir below). Options: 0[not LL entity], 1[LL entity]"},


### PR DESCRIPTION
Add address hashing to memHierarchy caches. This works very well for eliminating set contention and the associated very high latencies. For the particularly pathological case of a simulated HARP core, this reduced the 20k-cycle peak latencies to ~200cyc.