### PR TITLE
onFlyHMCop Debugs, Compute phase costs, small fixes

### DIFF
--- a/VaultSimC/Vault.cpp
+++ b/VaultSimC/Vault.cpp
@@ -22,10 +22,9 @@ Vault::Vault(Component *comp, Params &params) : SubComponent(comp)
     out.init("", 0, 0, Output::STDOUT);
 
     int debugLevel = params.find_integer("debug_level", 0);
-    dbg.init("@R:Vault::@p():@l: ", debugLevel, 0, (Output::output_location_t)params.find_integer("debug", 0));
     if (debugLevel < 0 || debugLevel > 10) 
         dbg.fatal(CALL_INFO, -1, "Debugging level must be between 0 and 10. \n");
-    dbg.init("Vault", 0, 0, (Output::output_location_t)params.find_integer("debug", 0));
+    dbg.init("@R:Vault::@p():@l: ", debugLevel, 0, (Output::output_location_t)params.find_integer("debug", 0));
 
     statsFormat = params.find_integer("statistics_format", 0);
 

--- a/VaultSimC/Vault.h
+++ b/VaultSimC/Vault.h
@@ -165,8 +165,14 @@ public:
     DRAMSim::MultiChannelMemorySystem *memorySystem;
 
 private:
+    //Debugs
     Output dbg;                                  // VaulSimC wrapper dbg, for printing debuging commands
     Output out;                                  // VaulSimC wrapper output, for printing always printed info and stats
+    Output dbgOnFlyHmcOps;                       // For debugging long lasting hmc_ops in queue
+    int dbgOnFlyHmcOpsIsOn;                      // For debuggung late onFlyHMC ops (bool variable)
+    int dbgOnFlyHmcOpsThresh;                    // For debuggung late onFlyHMC ops (threshhold Value)
+
+    //Stat Format
     int statsFormat;                             // Type of Stat output 0:Defualt 1:Macsim (Default Value is set to 0)
 
     addr2TransactionMap_t onFlyHmcOps;           // Currently issued atomic ops

--- a/VaultSimC/Vault.h
+++ b/VaultSimC/Vault.h
@@ -151,7 +151,8 @@ private:
      *  Stats
      */
     // Helper function for printing statistics in MacSim format
-    void writeTo(ofstream &ofs, string prefix, string name, uint64_t count);
+    template<typename T>
+    void writeTo(ofstream &ofs, string prefix, string name, T count);
     void printStatsForMacSim();
 
 public:
@@ -183,6 +184,13 @@ private:
     Statistic<uint64_t>* statIssueHmcLatency;
     Statistic<uint64_t>* statReadHmcLatency;
     Statistic<uint64_t>* statWriteHmcLatency;
+
+    // internal stats
+    uint64_t statTotalHmcLatencyInt;   //statapi does not provide any non-collection type addData (ORno documentation)
+    uint64_t statIssueHmcLatencyInt;
+    uint64_t statReadHmcLatencyInt;
+    uint64_t statWriteHmcLatencyInt;
+
 
 };
 #endif

--- a/VaultSimC/Vault.h
+++ b/VaultSimC/Vault.h
@@ -182,6 +182,17 @@ private:
     bank2CycleMap_t computeDoneCycleMap;         // Current Compute Done Cycle ((same size as bankBusyMap)
     bank2AddrMap_t addrComputeMap;
 
+    // HMC ops Cost in Cycles
+    int HMCCostLogicalOps;
+    int HMCCostCASOps;
+    int HMCCostCompOps;
+    int HMCCostAdd8;
+    int HMCCostAdd16;
+    int HMCCostAddDual;
+    int HMCCostFPAdd;
+    int HMCCostSwap;
+    int HMCCostBitW;
+
     // stats
     Statistic<uint64_t>* statTotalTransactions;
     Statistic<uint64_t>* statTotalHmcOps;

--- a/VaultSimC/libVaultSimGen.cpp
+++ b/VaultSimC/libVaultSimGen.cpp
@@ -27,15 +27,17 @@ const char *memEventList[] = {
 };
 
 static const ElementInfoParam VaultSimC_params[] = {
-  {"clock",                     "Vault Clock Rate.", "1.0 Ghz"},
-  {"numVaults2",                "Number of bits to determine vault address (i.e. log_2(number of vaults per cube))"},
-  {"debug",                     "VaultSimC debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE."},
-  {"debug_level",               "VaultSimC debug verbosity level (0-10)"},
-  {"statistics_format",         "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
-  {"vault.id",                  "Vault Unique ID (Unique to cube)."},
-  {"vault.debug",               "Vault debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE."},
-  {"vault.debug_level",         "Vault debug verbosity level (0-10)"},
-  {"vault.statistics_format",   "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
+  {"clock",                           "Vault Clock Rate.", "1.0 Ghz"},
+  {"numVaults2",                      "Number of bits to determine vault address (i.e. log_2(number of vaults per cube))"},
+  {"debug",                           "VaultSimC debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE."},
+  {"debug_level",                     "VaultSimC debug verbosity level (0-10)"},
+  {"statistics_format",               "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
+  {"vault.id",                        "Vault Unique ID (Unique to cube)."},
+  {"vault.debug",                     "Vault debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE."},
+  {"vault.debug_level",               "Vault debug verbosity level (0-10)"},
+  {"vault.debug_OnFlyHmcOps",         "Vault debugging for hmc queue"},
+  {"vault.debug_OnFlyHmcOpsThresh",   "Vault debugging for hmc queue threshhold value"},
+  {"vault.statistics_format",         "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
   { NULL, NULL }
 };
 
@@ -105,15 +107,17 @@ static SubComponent* create_Vault(Component* comp, Params& params) {
 }
 
 static const ElementInfoParam Vault_params[] = {
-    {"id",                  "Unique ID number of Vault", NULL},
-    {"device_ini",          "Name of DRAMSim Device config file", NULL},
-    {"debug",               "VaultSimC debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE.", 0},
-    {"debug_level",         "VaultSimC debug verbosity level (0-10)", 0},
-    {"system_ini",          "Name of DRAMSim System config file", NULL},
-    {"pwd",                 "Path of DRAMSim input files (ignored if file name is an absoluth path)", NULL},
-    {"logfile",             "DRAMSim output path", NULL},
-    {"mem_size",            "Size of physical memory in MB", "0"},
-    {"statistics_format",   "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
+    {"id",                        "Unique ID number of Vault", NULL},
+    {"device_ini",                "Name of DRAMSim Device config file", NULL},
+    {"debug",                     "Vault debug: 0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE.", 0},
+    {"debug_level",               "Vault debug verbosity level (0-10)", 0},
+    {"debug_OnFlyHmcOps",         "Vault debugging for hmc queue"},
+    {"debug_OnFlyHmcOpsThresh",   "Vault debugging for hmc queue threshhold value"},
+    {"system_ini",                "Name of DRAMSim System config file", NULL},
+    {"pwd",                       "Path of DRAMSim input files (ignored if file name is an absoluth path)", NULL},
+    {"logfile",                   "DRAMSim output path", NULL},
+    {"mem_size",                  "Size of physical memory in MB", "0"},
+    {"statistics_format",         "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
     {NULL, NULL, NULL}
 };
 

--- a/VaultSimC/libVaultSimGen.cpp
+++ b/VaultSimC/libVaultSimGen.cpp
@@ -38,6 +38,15 @@ static const ElementInfoParam VaultSimC_params[] = {
   {"vault.debug_OnFlyHmcOps",         "Vault debugging for hmc queue"},
   {"vault.debug_OnFlyHmcOpsThresh",   "Vault debugging for hmc queue threshhold value"},
   {"vault.statistics_format",         "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
+  {"vault.HMCCost_LogicalOps",        "Compute Cost of Logical Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_CASOps",            "Compute Cost of CAS Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_CompOps",           "Compute Cost of Compare Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_Add8",              "Compute Cost of Add 8b Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_Add16",             "Compute Cost of Add 16b Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_AddDual",           "Compute Cost of Add Dual Ops in Vault's cycles", "0"},
+  {"vault.HMCCost_FPAdd",             "Compute Cost of FP Add in Vault's cycles", "0"},
+  {"vault.HMCCost_Swap",              "Compute Cost of Swap Op in Vault's cycles", "0"},
+  {"vault.HMCCost_BitW",              "Compute Cost of Bit W Op in Vault's cycles", "0"},
   { NULL, NULL }
 };
 
@@ -118,6 +127,15 @@ static const ElementInfoParam Vault_params[] = {
     {"logfile",                   "DRAMSim output path", NULL},
     {"mem_size",                  "Size of physical memory in MB", "0"},
     {"statistics_format",         "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},
+    {"HMCCost_LogicalOps",        "Compute Cost of Logical Ops in Vault's cycles", "0"},
+    {"HMCCost_CASOps",            "Compute Cost of CAS Ops in Vault's cycles", "0"},
+    {"HMCCost_CompOps",           "Compute Cost of Compare Ops in Vault's cycles", "0"},
+    {"HMCCost_Add8",              "Compute Cost of Add 8b Ops in Vault's cycles", "0"},
+    {"HMCCost_Add16",             "Compute Cost of Add 16b Ops in Vault's cycles", "0"},
+    {"HMCCost_AddDual",           "Compute Cost of Add Dual Ops in Vault's cycles", "0"},
+    {"HMCCost_FPAdd",             "Compute Cost of FP Add in Vault's cycles", "0"},
+    {"HMCCost_Swap",              "Compute Cost of Swap Op in Vault's cycles", "0"},
+    {"HMCCost_BitW",              "Compute Cost of Bit W Op in Vault's cycles", "0"},
     {NULL, NULL, NULL}
 };
 

--- a/VaultSimC/transaction.h
+++ b/VaultSimC/transaction.h
@@ -86,10 +86,10 @@ public:
      * @param isWrite is it a write?
      * @param addr address for memory operation
      */
-    transaction_c() : isWrite(false), addr(0), isAtomic(false), hmcType(HMC_NONE), hmcOpState(NO_STATE) {}
+    transaction_c() : isWrite(false), addr(0), isAtomic(false), hmcType(HMC_NONE), hmcOpState(NO_STATE), flagPrintDbgHMC(0) {}
 
     transaction_c(bool _isWrite, uint64_t _addr) : 
-        isWrite(_isWrite), addr(_addr), isAtomic(false), hmcType(HMC_NONE), hmcOpState(NO_STATE) {}
+        isWrite(_isWrite), addr(_addr), isAtomic(false), hmcType(HMC_NONE), hmcOpState(NO_STATE), flagPrintDbgHMC(0) {}
 
     /** 
      * addr functions 
@@ -190,19 +190,31 @@ public:
     void setBankNo (unsigned _bankNo) { bankNo = _bankNo; }
     unsigned getBankNo () { return bankNo; } 
 
+    /**
+     * Stats
+     */
+    void setFlagPrintDbgHMC() { flagPrintDbgHMC = true; }
+    void resetFlagPrintDbgHMC() { flagPrintDbgHMC = false; }
+    bool getFlagPrintDbgHMC() { return flagPrintDbgHMC; }
+
 private:
+    //transaction properties
     bool isWrite;
     uint64_t addr;
     unsigned int bankNo;
     bool isAtomic;
     uint8_t hmcType;              //HMC_Type Enum
+
+    //stats
     HMC_Op_State hmcOpState;
+    bool flagPrintDbgHMC;
 
 public:
+    //stats
     uint64_t inCycle;
     uint64_t issueCycle;
     uint64_t readDoneCycle;       // Same as write issue cycle (without computing)
-    uint64_t writeDoneCycle;      // Same as done cycle 
+    uint64_t writeDoneCycle;      // Same as done cycle
 };
 
 #endif


### PR DESCRIPTION
- on fly hmc op debugging: to debug if any hmc op is stocked in vaults or not. The program will give just a warning for once for each single HMC op and continue to execute
   - use vault.debug_OnFlyHmcOps to enable it
   - use vault.debug_OnFlyHmcOpsThresh to set what is the threshold
- Compute cost in cycles for each type of HMC operation has been added
  - the default value is 0 cycle