### PR TITLE
Fix Type Print Warnings in Clang for Merlin and SimpleMessageGenerator

### DIFF
--- a/merlin/test/nic.cc
+++ b/merlin/test/nic.cc
@@ -107,23 +107,14 @@ void nic::setup()
 {
     link_control->setup();
     if ( link_control->getEndpointID() != net_id ) {
-        output.output("NIC ids don't match: parem = %" PRIi64 ", LinkControl = %" PRIi64 "\n",net_id, link_control->getEndpointID());
-        // output.output("NIC ids don't match: parem = %d, LinkControl = %" PRIi64 "\n",net_id, link_control->getEndpointID());
+        output.output("NIC ids don't match: param = %" PRIi64 ", LinkControl = %" PRIi64 "\n", 
+		(int64_t) net_id, (int64_t) link_control->getEndpointID());
     }
     if ( !initialized ) {
-        // output.output("Nic %" PRIi64 ": Broadcast failed!\n", id);
         output.output("Nic %d: Broadcast failed!\n", id);
     }
-    // else {
-    //     output.output("Nic %d: Broadcast succeeded!\n", id);
-    // }
 
     net_map.bind("global");
-    // if ( Simulation::getSimulation()->getRank() == 1 ) {
-    //     for ( int i = 0; i < num_peers; i++ ) {
-    //         std::cout << id << ": " << net_map[i] << std::endl;
-    //     }
-    // }
 }
 
 void

--- a/simpleElementExample/simpleMessageGeneratorComponent.h
+++ b/simpleElementExample/simpleMessageGeneratorComponent.h
@@ -24,18 +24,16 @@ public:
     simpleMessageGeneratorComponent(SST::ComponentId_t id, SST::Params& params);
     void setup()  { }
     void finish() 
-    { 
-//      std::cout << "Component completed at: " << getCurrentSimTimeMilli() 
-//  	   <<  " milliseconds" << std::endl;
-        fprintf(stdout, "Component completed at: %lu milliseconds\n", getCurrentSimTimeMilli() );
-//    	return 0; 
+    {
+        fprintf(stdout, "Component completed at: %" PRIu64 " milliseconds\n",
+		(uint64_t) getCurrentSimTimeMilli() );
     }
 
 private:
     simpleMessageGeneratorComponent();  // for serialization only
     simpleMessageGeneratorComponent(const simpleMessageGeneratorComponent&); // do not implement
     void operator=(const simpleMessageGeneratorComponent&); // do not implement
-    
+
     void handleEvent(SST::Event *ev);
     virtual bool tick(SST::Cycle_t);
     


### PR DESCRIPTION
Fixes some printf type warnings.