### PR TITLE
memHierarchy Stat, HMC_FLAG for VaultSim, minor fixes

### DIFF
--- a/VaultSimC/Makefile.am
+++ b/VaultSimC/Makefile.am
@@ -2,7 +2,9 @@
 #
 #
 
-AM_CPPFLAGS = -g
+AM_CPPFLAGS = \ 
+            $(HMC_FLAG) \ 
+            -g
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libVaultSimC.la
@@ -17,7 +19,7 @@ libVaultSimC_la_SOURCES = \
     globals.h \
     libVaultSimGen.cpp
 
-libVaultSimC_la_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) -DUSE_VAULTSIM_HMC 
+libVaultSimC_la_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) $(HMC_FLAG) 
 libVaultSimC_la_LDFLAGS = -module -avoid-version
 libVaultSimC_la_LIBADD = 
 

--- a/VaultSimC/VaultSimC.cpp
+++ b/VaultSimC/VaultSimC.cpp
@@ -42,7 +42,7 @@ VaultSimC::VaultSimC(ComponentId_t id, Params& params) : IntrospectedComponent( 
         dbg.fatal(CALL_INFO, -1, "numVaults2 not set! should be log2(number of vaults per cube)\n");
     numVaults2 = nv2;
 
-    memChan = configureLink("bus", "1 ns");
+    memChan = configureLink("bus");     //link delay is configurable by python scripts
 
     int vid = params.find_integer("vault.id", -1);
     if (-1 == vid) 
@@ -172,7 +172,7 @@ bool VaultSimC::clock(Cycle_t currentCycle)
             ret = false;
         }
     }
-    
+
     return false;
 }
 

--- a/VaultSimC/VaultSimC.cpp
+++ b/VaultSimC/VaultSimC.cpp
@@ -144,17 +144,26 @@ bool VaultSimC::clock(Cycle_t currentCycle)
 
         // add to the Q
         transaction_c transaction (isWrite, event->getAddr());
+
+        #ifdef USE_VAULTSIM_HMC
         if (event->getHMCInstType() == HMC_NONE) {
             transaction.resetAtomic();
             dbg.debug(_L6_, "VaultSimC %d got a req for %p in clock=%lu (%lu %d)\n", 
                     vaultID, (void*)event->getAddr(), currentCycle, event->getID().first, event->getID().second);
-        } else {
+        } 
+        else {
             transaction.setAtomic();
             transaction.resetIsWrite(); //FIXME: all hmc ops come as read. true?
             transaction.setHmcOpType(event->getHMCInstType());
             dbg.debug(_L6_, "VaultSimC %d got an atomic req for %p of type %s in clock=%lu\n", 
                     vaultID, (void *)transaction.getAddr(), transaction.getHmcOpTypeStr(), currentCycle);
         }
+        #else
+        transaction.resetAtomic();
+        dbg.debug(_L6_, "VaultSimC %d got a req for %p in clock=%lu (%lu %d)\n", 
+                vaultID, (void*)event->getAddr(), currentCycle, event->getID().first, event->getID().second);
+        #endif
+        
         transQ.push_back(transaction);
     }
 

--- a/VaultSimC/libVaultSimGen.cpp
+++ b/VaultSimC/libVaultSimGen.cpp
@@ -39,7 +39,7 @@ static const ElementInfoStatistic logicLayer_statistics[] = {
 static const ElementInfoParam logicLayer_params[] = {
   {"clock",              "Logic Layer Clock Rate."},
   {"llID",               "Logic Layer ID (Unique id within chain)"},
-  {"bwlimit",            "Number of memory events which can be processed per cycle per link."},
+  {"req_LimitPerCycle",  "Number of memory events which can be processed per cycle per link."},
   {"LL_MASK",            "Bitmask to determine 'ownership' of an address by a cube. A cube 'owns' an address if ((((addr >> LL_SHIFT) & LL_MASK) == llID) || (LL_MASK == 0)). LL_SHIFT is set in vaultGlobals.h and is 8 by default."},
   {"terminal",           "Is this the last cube in the chain?"},
   {"vaults",             "Number of vaults per cube."},

--- a/VaultSimC/libVaultSimGen.cpp
+++ b/VaultSimC/libVaultSimGen.cpp
@@ -43,7 +43,6 @@ static const ElementInfoParam logicLayer_params[] = {
   {"LL_MASK",            "Bitmask to determine 'ownership' of an address by a cube. A cube 'owns' an address if ((((addr >> LL_SHIFT) & LL_MASK) == llID) || (LL_MASK == 0)). LL_SHIFT is set in vaultGlobals.h and is 8 by default."},
   {"terminal",           "Is this the last cube in the chain?"},
   {"vaults",             "Number of vaults per cube."},
-  {"vaults_LinkDelay",   "Link delay between each Vault and Logic layer"},
   {"debug",              "0 (default): No debugging, 1: STDOUT, 2: STDERR, 3: FILE."},
   {"debug_level",        "debug verbosity level (0-10)"},
   {"statistics_format",  "Optional, Stats format. Options: 0[default], 1[MacSim]", "0"},

--- a/VaultSimC/logicLayer.cpp
+++ b/VaultSimC/logicLayer.cpp
@@ -115,8 +115,11 @@ bool logicLayer::clock(Cycle_t current)
         dbg.debug(_L4_, "LogicLayer%d got req for %p (%" PRIu64 " %d)\n", llID, (void*)event->getAddr(), event->getID().first, event->getID().second);
         if (NULL == event)
             dbg.fatal(CALL_INFO, -1, "LogicLayer%d got bad event\n", llID);
+
+        #ifdef USE_VAULTSIM_HMC
         if (event->getHMCInstType() >= NUM_HMC_TYPES)
             dbg.fatal(CALL_INFO, -1, "LogicLayer%d got bad HMC type %d for address %p\n", llID, event->getHMCInstType(), (void*)event->getAddr());
+        #endif
 
         toCpu[0]++;
         reqUsedToCpu[0]->addData(1);

--- a/VaultSimC/logicLayer.cpp
+++ b/VaultSimC/logicLayer.cpp
@@ -50,11 +50,6 @@ logicLayer::logicLayer(ComponentId_t id, Params& params) : IntrospectedComponent
     bool terminal = params.find_integer("terminal", 0);
 
     // VaultSims Initializations (Links)
-    std::string vaultsLinkDelay;
-    vaultsLinkDelay = params.find_string("vaults_LinkDelay", "");
-    if ("" == vaultsLinkDelay)
-        dbg.fatal(CALL_INFO, -1, " no vaults_LinkDelay param defined for logiclayer\n");
-
     int numVaults = params.find_integer("vaults", -1);
     if (-1 == numVaults) 
         dbg.fatal(CALL_INFO, -1, " no vaults param defined for LogicLayer\n");
@@ -62,7 +57,7 @@ logicLayer::logicLayer(ComponentId_t id, Params& params) : IntrospectedComponent
     for (int i = 0; i < numVaults; ++i) {
         char bus_name[50];
         snprintf(bus_name, 50, "bus_%d", i);
-        memChan_t *chan = configureLink(bus_name, vaultsLinkDelay);
+        memChan_t *chan = configureLink(bus_name);      //link delay is configurable by python scripts
         if (chan) {
             memChans.push_back(chan);
             dbg.debug(_INFO_, "\tConnected %s\n", bus_name);

--- a/memHierarchy/cacheController.h
+++ b/memHierarchy/cacheController.h
@@ -355,6 +355,14 @@ private:
     Statistic<uint64_t>* statFetchInvX_recv;
     Statistic<uint64_t>* statInv_recv;
     Statistic<uint64_t>* statNACK_recv;
+#ifdef USE_VAULTSIM_HMC
+    Statistic<uint64_t>* statCacheHits_hmc;
+    Statistic<uint64_t>* statCacheHits_nonhmc;
+    Statistic<uint64_t>* statCacheMisses_hmc;
+    Statistic<uint64_t>* statCacheMisses_nonhmc;
+    Statistic<uint64_t>* statRequest_hmc;
+    Statistic<uint64_t>* statRequest_nonhmc;
+#endif
 };
 
 /*  Implementation Details

--- a/memHierarchy/cacheFactory.cc
+++ b/memHierarchy/cacheFactory.cc
@@ -395,7 +395,14 @@ Cache::Cache(ComponentId_t id, Params &params, CacheConfig config) : Component(i
     statFetchInvX_recv          = registerStatistic<uint64_t>("FetchInvX_recv");
     statInv_recv                = registerStatistic<uint64_t>("Inv_recv");
     statNACK_recv               = registerStatistic<uint64_t>("NACK_recv");
-
+#ifdef USE_VAULTSIM_HMC
+    statCacheHits_hmc           = registerStatistic<uint64_t>("hmcCacheHits");
+    statCacheHits_nonhmc        = registerStatistic<uint64_t>("nonhmcCacheHits");
+    statCacheMisses_hmc         = registerStatistic<uint64_t>("hmcCacheMisses");
+    statCacheMisses_nonhmc      = registerStatistic<uint64_t>("nonhmcCacheMisses");
+    statRequest_hmc             = registerStatistic<uint64_t>("hmcRequest");
+    statRequest_nonhmc          = registerStatistic<uint64_t>("nonhmcRequest");
+#endif
     if(groupStats_){
         for(unsigned int i = 0; i < cf_.statGroupIds_.size(); i++) {
             if (i > 0 && (cf_.statGroupIds_[i] == 0 || cf_.statGroupIds_[i] == -1)) 

--- a/memHierarchy/coherenceControllers.h
+++ b/memHierarchy/coherenceControllers.h
@@ -95,7 +95,29 @@ public:
     virtual void printStats(int _statsFile, vector<int> statGroupIds, map<int, CtrlStats> _ctrlStats, uint64_t _updgradeLatency, uint64_t lat_GetS_IS, uint64_t lat_GetS_M, uint64_t lat_GetX_IM, uint64_t lat_GetX_SM, uint64_t lat_GetX_M, uint64_t lat_GetSEx_IM, uint64_t lat_GetSEx_SM, uint64_t lat_GetSEx_M) =0;
     virtual void printStatsForMacSim(int _statsFile, vector<int> statGroupIds, map<int, CtrlStats> _ctrlStats, uint64_t _updgradeLatency, uint64_t lat_GetS_IS, uint64_t lat_GetS_M, uint64_t lat_GetX_IM, uint64_t lat_GetX_SM, uint64_t lat_GetX_M, uint64_t lat_GetSEx_IM, uint64_t lat_GetSEx_SM, uint64_t lat_GetSEx_M) =0;
 
+#ifdef USE_VAULTSIM_HMC
+    void printStatsForMacSimHMC(uint64_t _CacheHits_hmc, uint64_t _CacheHits_nonhmc,
+            uint64_t _CacheMisses_hmc, uint64_t _CacheMisses_nonhmc,
+            uint64_t _Request_hmc, uint64_t _Request_nonhmc)
+    {
+        stringstream ss;
+        ss << name_.c_str() << ".stat.out";
+        string filename = ss.str();
 
+        ofstream ofs;
+        ofs.exceptions(std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit);
+        ofs.open(filename.c_str(), std::ios_base::out | std::ios_base::app);
+
+        writeTo(ofs, name_, string("CacheHits_hmc"), _CacheHits_hmc);
+        writeTo(ofs, name_, string("CacheHits_nonhmc"), _CacheHits_nonhmc);
+        writeTo(ofs, name_, string("CacheMisses_hmc"), _CacheMisses_hmc);
+        writeTo(ofs, name_, string("CacheMisses_nonhmc"), _CacheMisses_nonhmc);
+        writeTo(ofs, name_, string("Request_hmc"), _Request_hmc);
+        writeTo(ofs, name_, string("Request_nonhmc"), _Request_nonhmc);
+
+        ofs.close();
+    }
+#endif
 
     // Send NACK in response to a request. Could be made virtual if needed.
     void sendNACK(MemEvent * event, bool up) {

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -322,6 +322,15 @@ static const ElementInfoStatistic cache_statistics[] = {
     {"latency_GetSEx_IM",       "Latency for read-exclusive misses in I state", "cycles", 1},
     {"latency_GetSEx_SM",       "Latency for read-exclusive misses in S state", "cycles", 1},
     {"latency_GetSEx_M",        "Latency for read-exclusive misses that find the block owned by another cache in M state", "cycles", 1},
+#ifdef USE_VAULTSIM_HMC    
+    /* hmc counters */
+    {"hmcCacheHits", "cache hit number for hmc instructions", "count", 1},
+    {"nonhmcCacheHits", "cache hit number for nonhmc instructions", "count", 1},
+    {"hmcCacheMisses", "cache miss number for hmc instructions", "count", 1},
+    {"nonhmcCacheMisses", "cache miss number for nonhmc instructions", "count", 1},
+    {"hmcRequest", "number of received hmc requests", "count", 1},
+    {"nonhmcRequest", "number of received nonhmc requests", "count", 1},
+#endif
     {NULL, NULL, NULL, 0}
 };
 


### PR DESCRIPTION
- memHierarchy stat for hmc info
- HMC_FLAG used inside VaultSim to disable accessing HMC Type filed in memEvent when it is not defined
- remove warning message for param req_LimitPerCycle