### PR TITLE
Support for C-standard malloc/free Calls in Ariel Simple Front End

### DIFF
--- a/ariel/arielmemmgr.h
+++ b/ariel/arielmemmgr.h
@@ -63,6 +63,7 @@ class ArielMemoryManager {
 		std::map<uint64_t, uint64_t>* translationCache;
 		const uint32_t translationCacheEntries;
 		bool translationEnabled;
+		bool reportUnmatchedFree;
 };
 
 }


### PR DESCRIPTION
Support calls for standard malloc/free with mapping in the Ariel Simple Front End. This means all heap managed application memory can be tracked via Ariel.