### PR TITLE
Fixes error when compiling Zodiac and DUMPI is Enabled.

### DIFF
--- a/zodiac/zdumpi.cc
+++ b/zodiac/zdumpi.cc
@@ -28,9 +28,9 @@ ZodiacDUMPITraceReader::ZodiacDUMPITraceReader(ComponentId_t id, Params& params)
     string msgiface = params.find_string("msgapi");
 
     if ( msgiface == "" ) {
-        msgapi = new MessageInterface();
+        msgapi = new SST::Hermes::MP::Interface();
     } else {
-	msgapi = dynamic_cast<MessageInterface*>(loadModule(msgiface, params));
+	msgapi = dynamic_cast<SST::Hermes::MP::Interface*>(loadModule(msgiface, params));
 
         if(NULL == msgapi) {
 		std::cerr << "Message API: " << msgiface << " could not be loaded." << std::endl;

--- a/zodiac/zdumpi.h
+++ b/zodiac/zdumpi.h
@@ -52,7 +52,7 @@ private:
 
   ////////////////////////////////////////////////////////
 
-  MessageInterface* msgapi;
+  SST::Hermes::MP::Interface* msgapi;
   DUMPIReader* trace;
   std::queue<ZodiacEvent*>* eventQ;
 


### PR DESCRIPTION
When DUMPI is enabled during configure the Zodiac interface does not contain updated code for the Hermes interface.