### PR TITLE
memH: Fix requested size vs. size of message discrepancy in memEvent

### DIFF
--- a/memHierarchy/IncoherentController.cc
+++ b/memHierarchy/IncoherentController.cc
@@ -304,8 +304,8 @@ CacheAction IncoherentController::handleDataResponse(MemEvent* responseEvent, Ca
 void IncoherentController::sendWriteback(Command cmd, CacheLine* cacheLine, string origRqstr){
     MemEvent* newCommandEvent = new MemEvent((SST::Component*)owner_, cacheLine->getBaseAddr(), cacheLine->getBaseAddr(), cmd);
     newCommandEvent->setDst(getDestination(cacheLine->getBaseAddr()));
+    newCommandEvent->setSize(cacheLine->getSize());
     if (cmd == PutM || writebackCleanBlocks_) {
-        newCommandEvent->setSize(cacheLine->getSize());
         newCommandEvent->setPayload(*cacheLine->getData());
         if (DEBUG_ALL || DEBUG_ADDR == cacheLine->getBaseAddr()) printData(cacheLine->getData(), false);
     }

--- a/memHierarchy/L1IncoherentController.cc
+++ b/memHierarchy/L1IncoherentController.cc
@@ -298,6 +298,7 @@ void L1IncoherentController::sendResponseUp(MemEvent * event, State grantedState
             /* If write (GetX) and LLSC set, then check if operation was Atomic */
   	    if (finishedAtomically) responseEvent->setAtomic(true);
             else responseEvent->setAtomic(false);
+            responseEvent->setSize(event->getSize()); // Return size that was written
         }
     } else {
         responseEvent->setPayload(*data);
@@ -318,8 +319,8 @@ void L1IncoherentController::sendResponseUp(MemEvent * event, State grantedState
 void L1IncoherentController::sendWriteback(Command cmd, CacheLine* cacheLine, string origRqstr){
     MemEvent* writeback = new MemEvent((SST::Component*)owner_, cacheLine->getBaseAddr(), cacheLine->getBaseAddr(), cmd);
     writeback->setDst(getDestination(cacheLine->getBaseAddr()));
+    writeback->setSize(cacheLine->getSize());
     if (cmd == PutM || writebackCleanBlocks_) {
-        writeback->setSize(cacheLine->getSize());
         writeback->setPayload(*cacheLine->getData());
     }
     writeback->setRqstr(origRqstr);

--- a/memHierarchy/cacheArray.h
+++ b/memHierarchy/cacheArray.h
@@ -56,10 +56,10 @@ public:
         vector<uint8_t>* getData() { return &data_; }
 
         void setData(vector<uint8_t> data, MemEvent* ev) {
-            if (ev->getSize() == size_) data_ = data;
+            if (ev->getPayloadSize() == size_) data_ = data;
             else {
                 Addr offset = ev->getAddr() - ev->getBaseAddr();
-                for(uint32_t i = 0; i < ev->getSize() ; i++ ) {
+                for(uint32_t i = 0; i < ev->getPayloadSize() ; i++ ) {
                     data_[offset + i] = ev->getPayload()[i];
                 }
             }
@@ -219,10 +219,10 @@ public:
 
         /** Setter for cache line data - write only specified bits*/
         void setData(vector<uint8_t> data, MemEvent* memEvent) {
-            if (memEvent->getSize() == size_) data_ = data;
+            if (memEvent->getPayloadSize() == size_) data_ = data;
             else {
                 Addr offset = memEvent->getAddr() - baseAddr_;
-                for(uint32_t i = 0; i < memEvent->getSize() ; i++ ) {
+                for(uint32_t i = 0; i < memEvent->getPayloadSize() ; i++ ) {
                     data_[offset + i] = memEvent->getPayload()[i];
                 }
             }

--- a/memHierarchy/cacheController.cc
+++ b/memHierarchy/cacheController.cc
@@ -102,7 +102,7 @@ void Cache::processCacheRequest(MemEvent* event, Command cmd, Addr baseAddr, boo
 
         // Forward instead of allocating for non-inclusive caches
         vector<uint8_t> * data = &event->getPayload();
-        coherenceMgr->forwardMessage(event, baseAddr, event->getSize(), data);
+        coherenceMgr->forwardMessage(event, baseAddr, event->getSize(), data); // Event to forward, address, requested size, data (if any)
         event->setInProgress(true);
         return;
     }

--- a/memHierarchy/cacheEventProcessing.cc
+++ b/memHierarchy/cacheEventProcessing.cc
@@ -209,11 +209,11 @@ void Cache::processEvent(MemEvent* event, bool replay) {
 
     if (DEBUG_ALL || DEBUG_ADDR == baseAddr) {
         if (replay) {
-            d_->debug(_L3_,"Replay. Name: %s, Cmd: %s, BsAddr: %" PRIx64 ", Addr: %" PRIx64 ", VAddr: %" PRIx64 ", iPtr: %" PRIx64 ", Rqstr: %s, Src: %s, Dst: %s, PreF:%s, Size = %u, cycles: %" PRIu64 ", %s\n",
+            d_->debug(_L3_,"Replay. Name: %s, Cmd: %s, BsAddr: %" PRIx64 ", Addr: %" PRIx64 ", VAddr: %" PRIx64 ", iPtr: %" PRIx64 ", Rqstr: %s, Src: %s, Dst: %s, PreF:%s, Bytes requested = %u, cycles: %" PRIu64 ", %s\n",
                        this->getName().c_str(), CommandString[event->getCmd()], baseAddr, event->getAddr(), event->getVirtualAddress(), event->getInstructionPointer(), event->getRqstr().c_str(), 
                        event->getSrc().c_str(), event->getDst().c_str(), event->isPrefetch() ? "true" : "false", event->getSize(), timestamp_, noncacheable ? "noncacheable" : "cacheable");
         } else {
-            d_->debug(_L3_,"New Event. Name: %s, Cmd: %s, BsAddr: %" PRIx64 ", Addr: %" PRIx64 ", VAddr: %" PRIx64 ", iPtr: %" PRIx64 ", Rqstr: %s, Src: %s, Dst: %s, PreF:%s, Size = %u, cycles: %" PRIu64 ", %s\n",
+            d_->debug(_L3_,"New Event. Name: %s, Cmd: %s, BsAddr: %" PRIx64 ", Addr: %" PRIx64 ", VAddr: %" PRIx64 ", iPtr: %" PRIx64 ", Rqstr: %s, Src: %s, Dst: %s, PreF:%s, Bytes requested = %u, cycles: %" PRIu64 ", %s\n",
                        this->getName().c_str(), CommandString[event->getCmd()], baseAddr, event->getAddr(), event->getVirtualAddress(), event->getInstructionPointer(), event->getRqstr().c_str(), 
                        event->getSrc().c_str(), event->getDst().c_str(), event->isPrefetch() ? "true" : "false", event->getSize(), timestamp_, noncacheable ? "noncacheable" : "cacheable");
         }

--- a/memHierarchy/cacheFactory.cc
+++ b/memHierarchy/cacheFactory.cc
@@ -289,7 +289,7 @@ Cache::Cache(ComponentId_t id, Params &params, CacheConfig config) : Component(i
         MemNIC::ComponentTypeInfo typeInfo;
         typeInfo.blocksize = cf_.lineSize_;
 
-        bottomNetworkLink_ = new MemNIC(this, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
+        bottomNetworkLink_ = new MemNIC(this, d_, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
         bottomNetworkLink_->addTypeInfo(typeInfo);
 
         topNetworkLink_ = NULL;
@@ -314,7 +314,8 @@ Cache::Cache(ComponentId_t id, Params &params, CacheConfig config) : Component(i
         MemNIC::ComponentTypeInfo typeInfo;
         typeInfo.blocksize = cf_.lineSize_;
 
-        bottomNetworkLink_ = new MemNIC(this, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
+        bottomNetworkLink_ = new MemNIC(this, d_, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
+
         bottomNetworkLink_->addTypeInfo(typeInfo);
         
         topNetworkLink_ = NULL;
@@ -355,7 +356,7 @@ Cache::Cache(ComponentId_t id, Params &params, CacheConfig config) : Component(i
         typeInfo.interleaveStep = interleaveStep;
         typeInfo.blocksize      = cf_.lineSize_;
         
-        bottomNetworkLink_ = new MemNIC(this, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
+        bottomNetworkLink_ = new MemNIC(this, d_, myInfo, new Event::Handler<Cache>(this, &Cache::processIncomingEvent));
         bottomNetworkLink_->addTypeInfo(typeInfo);
         
         topNetworkLink_ = bottomNetworkLink_;

--- a/memHierarchy/directoryController.cc
+++ b/memHierarchy/directoryController.cc
@@ -110,7 +110,7 @@ DirectoryController::DirectoryController(ComponentId_t id, Params &params) :
         myInfo.type                             = MemNIC::TypeDirectoryCtrl;
         myInfo.link_inbuf_size                  = params.find_string("network_input_buffer_size", "1KB");
         myInfo.link_outbuf_size                 = params.find_string("network_output_buffer_size", "1KB");
-        network = new MemNIC(this, myInfo, new Event::Handler<DirectoryController>(this, &DirectoryController::handlePacket));
+        network = new MemNIC(this, &dbg, myInfo, new Event::Handler<DirectoryController>(this, &DirectoryController::handlePacket));
 
         MemNIC::ComponentTypeInfo typeInfo;
         typeInfo.rangeStart     = addrRangeStart;
@@ -135,7 +135,7 @@ DirectoryController::DirectoryController(ComponentId_t id, Params &params) :
         myInfo.type                             = MemNIC::TypeNetworkDirectory;
         myInfo.link_inbuf_size                  = params.find_string("network_input_buffer_size", "1KB");
         myInfo.link_outbuf_size                 = params.find_string("network_output_buffer_size", "1KB");
-        network = new MemNIC(this, myInfo, new Event::Handler<DirectoryController>(this, &DirectoryController::handlePacket));
+        network = new MemNIC(this, &dbg, myInfo, new Event::Handler<DirectoryController>(this, &DirectoryController::handlePacket));
         
         MemNIC::ComponentTypeInfo typeInfo;
         typeInfo.rangeStart     = addrRangeStart;

--- a/memHierarchy/dmaEngine.cc
+++ b/memHierarchy/dmaEngine.cc
@@ -42,7 +42,7 @@ DMAEngine::DMAEngine(ComponentId_t id, Params &params) :
     myInfo.name = getName();
     myInfo.network_addr = params.find_integer("netAddr");
     myInfo.type = MemNIC::TypeDMAEngine;
-    networkLink = new MemNIC(this, myInfo);
+    networkLink = new MemNIC(this, &dbg, myInfo);
 
     blocksize = 0;
 }

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -586,7 +586,7 @@ static Module* create_MemInterface(Component *comp, Params &params) {
 
 
 static Module* create_MemNIC(Component *comp, Params &params) {
-    return new MemNIC(comp);
+    return new MemNIC(comp, params);
 }
 
 

--- a/memHierarchy/memEvent.h
+++ b/memHierarchy/memEvent.h
@@ -149,7 +149,7 @@ public:
 
     typedef std::vector<uint8_t> dataVec;       /** Data Payload type */
 
-    /** Creates a new MemEvent - Genetic */
+    /** Creates a new MemEvent - Generic */
     MemEvent(const Component *_src, Addr _addr, Addr _baseAddr, Command _cmd) : SST::Event(){
         initialize(_src, _addr, _baseAddr, _cmd);
     }
@@ -353,6 +353,7 @@ public:
      * @param[in] data  Vector from which to copy data
      */
     void setPayload(std::vector<uint8_t>& _data) {
+        setSize(_data.size());
         payload_ = _data;
     }
     
@@ -366,6 +367,10 @@ public:
         for ( uint32_t i = 0 ; i < _size ; i++ ) {
             payload_[i] = _data[i];
         }
+    }
+
+    uint32_t getPayloadSize() {
+        return payload_.size();
     }
 
     /** Sets the Granted State */
@@ -473,7 +478,7 @@ private:
     id_type         eventID_;           // Unique ID for this event
     id_type         responseToID_;      // For responses, holds the ID to which this event matches
     uint32_t        flags_;             // Any flags (atomic, noncacheabel, etc.)
-    uint32_t        size_;              // Size in bytes for the request
+    uint32_t        size_;              // Size in bytes that are being requested
     uint32_t        groupID_;           // ???
     Addr            addr_;              // Address
     Addr            baseAddr_;          // Base (line) address

--- a/memHierarchy/memNIC.cc
+++ b/memHierarchy/memNIC.cc
@@ -30,7 +30,7 @@ int MemNIC::addrForDest(const std::string &target) const
 {
   std::map<std::string, int>::const_iterator addrIter = addrMap.find(target);
   if ( addrIter == addrMap.end() )
-      dbg.fatal(CALL_INFO, -1, "Address for target %s not found in addrMap.\n", target.c_str());
+      dbg->fatal(CALL_INFO, -1, "Address for target %s not found in addrMap.\n", target.c_str());
   return addrIter->second;
 }
 
@@ -42,14 +42,12 @@ bool MemNIC::isValidDestination(std::string target) {
 int MemNIC::getFlitSize(MemEvent *ev)
 {
     /* addr (8B) + cmd (1B) + size */
-    return 8 + ev->getSize();
+    return 8 + ev->getPayloadSize();
 }
 
 
 void MemNIC::moduleInit(ComponentInfo &ci, Event::HandlerBase *handler)
 {
-    dbg.init("@t:MemNIC::@p():@l " + comp->getName() + ": ", 0, 0, Output::NONE); //TODO: Parameter
-
     this->ci = ci;
     this->recvHandler = handler;
 
@@ -65,14 +63,15 @@ void MemNIC::moduleInit(ComponentInfo &ci, Event::HandlerBase *handler)
 }
 
 
-MemNIC::MemNIC(Component *comp, ComponentInfo &ci, Event::HandlerBase *handler) :
+MemNIC::MemNIC(Component *comp, Output* output, ComponentInfo &ci, Event::HandlerBase *handler) :
     typeInfoSent(false), comp(comp)
 {
+    dbg = output;
     moduleInit(ci, handler);
 }
 
 
-MemNIC::MemNIC(Component *comp) :
+MemNIC::MemNIC(Component *comp, Params& params) :
     typeInfoSent(false), comp(comp)
 {
 }
@@ -114,7 +113,7 @@ void MemNIC::init(unsigned int phase)
             }
         }
         typeInfoSent = true;
-        dbg.debug(_L10_, "Sent init data!\n");
+        dbg->debug(_L10_, "Sent init data!\n");
     }
     // while ( SST::Event *ev = link_control->recvInitData() ) {
     while ( SimpleNetwork::Request *req = link_control->recvInitData() ) {
@@ -185,7 +184,7 @@ std::string MemNIC::findTargetDestination(Addr addr)
             i != destinations.end() ; ++i ) {
         if ( i->first.contains(addr) ) return i->second;
     }
-    dbg.fatal(CALL_INFO,-1,"MemNIC %s cannot find a target for address 0x%" PRIx64 "\n",comp->getName().c_str(),addr);
+    dbg->fatal(CALL_INFO,-1,"MemNIC %s cannot find a target for address 0x%" PRIx64 "\n",comp->getName().c_str(),addr);
     return "";
 }
 
@@ -202,7 +201,7 @@ bool MemNIC::clock(void)
             if ( sent ) {
                 if ( static_cast<MemRtrEvent*>(head->inspectPayload())->hasClientData() ) {
                     MemEvent* event = static_cast<MemEvent*>((static_cast<MemRtrEvent*>(head->inspectPayload()))->event);
-                    dbg.debug(_L10_, "Sent message ((%" PRIx64 ", %d) %s %" PRIx64 ") to (%" PRIu64 ") [%s]\n", event->getID().first, event->getID().second, CommandString[event->getCmd()], event->getAddr(), head->dest, event->getDst().c_str());
+                    dbg->debug(_L10_, "Sent message ((%" PRIx64 ", %d) %s %" PRIx64 ") to (%" PRIu64 ") [%s]\n", event->getID().first, event->getID().second, CommandString[event->getCmd()], event->getAddr(), head->dest, event->getDst().c_str());
                 }
                 sendQueue.pop_front();
             }
@@ -270,6 +269,8 @@ void MemNIC::send(MemEvent *ev)
     req->dest = addrForDest(ev->getDst());
     req->size_in_bits = 8 * getFlitSize(ev);
     req->vn = 0;
+    dbg->debug(_L4_, "%s, memNIC send: dst: %s; bits: %d. (Cmd: %s, Rqst size: %u, Payload size: %u)\n", 
+            comp->getName().c_str(), ev->getDst().c_str(), req->size_in_bits, CommandString[ev->getCmd()], ev->getSize(), ev->getPayloadSize());
     req->givePayload(mre);
     
     sendQueue.push_back(req);

--- a/memHierarchy/memNIC.h
+++ b/memHierarchy/memNIC.h
@@ -160,7 +160,7 @@ public:
 
 private:
 
-    Output dbg;
+    Output* dbg;
     int num_vcs;
     size_t flitSize;
     bool typeInfoSent; // True if TypeInfo has already been sent
@@ -193,10 +193,10 @@ private:
     void sendNewTypeInfo(const ComponentTypeInfo &cti);
 
 public:
-    MemNIC(Component *comp, ComponentInfo &ci, Event::HandlerBase *handler = NULL);
+    MemNIC(Component *comp, Output* output, ComponentInfo &ci, Event::HandlerBase *handler = NULL);
     /** Constructor to be used when loading as a module.
      */
-    MemNIC(Component *comp);
+    MemNIC(Component *comp, Params& params);
     /** To be used when loading MemNIC as a module.  Not necessary to call
      * when using the full-featured constructor
      */

--- a/memHierarchy/memoryController.cc
+++ b/memHierarchy/memoryController.cc
@@ -144,7 +144,7 @@ MemController::MemController(ComponentId_t id, Params &params) : Component(id) {
         myInfo.type             = MemNIC::TypeMemory;
         myInfo.link_inbuf_size  = params.find_string("network_input_buffer_size", "1KB");
         myInfo.link_outbuf_size = params.find_string("network_output_buffer_size", "1KB");
-        networkLink_ = new MemNIC(this, myInfo, new Event::Handler<MemController>(this, &MemController::handleEvent));
+        networkLink_ = new MemNIC(this, &dbg, myInfo, new Event::Handler<MemController>(this, &MemController::handleEvent));
 
         MemNIC::ComponentTypeInfo typeInfo;
         typeInfo.rangeStart       = rangeStart_;


### PR DESCRIPTION
memNIC now computes message size based on payload size (not # bytes requested)
Set #bytes requested correctly throughout coherence controllers (instead of assuming cache line granularity)
memNIC output stream is inherited from its component now