### PR TITLE
fixed memory leak

### DIFF
--- a/memHierarchy/Sieve/sieveController.cc
+++ b/memHierarchy/Sieve/sieveController.cc
@@ -75,6 +75,7 @@ void Sieve::processAllocEvent(SST::Event* event) {
         } else {
             actAllocMap.erase(targ);
         }
+        delete ev;
     } else {
         output_->fatal(CALL_INFO, -1, "Unrecognized Ariel Allocation Tracking Event Type \n");
     }


### PR DESCRIPTION
Small fix - patching a memory leak. 

It used to not de-allocate "free" events, so we leaked a few bytes every time the front-end did a free().