### PR TITLE
Fix Ember Random Gen Header File Guard Error

### DIFF
--- a/ember/mpi/motifs/emberrandomgen.h
+++ b/ember/mpi/motifs/emberrandomgen.h
@@ -10,7 +10,7 @@
 // distribution.
 
 
-#ifndef _H_EMBER_RANDOM_GEM
+#ifndef _H_EMBER_RANDOM_GEN
 #define _H_EMBER_RANDOM_GEN
 
 #include "mpi/embermpigen.h"


### PR DESCRIPTION
Fixes an error in the Ember Random Gen Header file. Preprocessor guard is not correctly matched. Caught by LLVM compiler on Mac OSX.