### PR TITLE
Addition of idle_time Statistic to portControl

### DIFF
--- a/merlin/merlin.cc
+++ b/merlin/merlin.cc
@@ -92,6 +92,7 @@ static const ElementInfoStatistic hr_router_statistics[] = {
     { "send_packet_count", "Count number of packets sent on link", "packets", 1},
     { "output_port_stalls", "Time output port is stalled (in units of core timebase)", "time in stalls", 1},
     { "xbar_stalls", "Count number of cycles the xbar is stalled", "cycles", 1},
+    { "idle_time", "number of nanoseconds that port was idle", "nanoseconds", 1},
     { NULL, NULL, NULL, 0 }
 };
 

--- a/merlin/portControl.h
+++ b/merlin/portControl.h
@@ -97,6 +97,10 @@ private:
     // current virtual channel.
     int curr_out_vc;
 
+    // Represents the start of when a port was idle
+    // If the buffer was empty we instantiate this to the current time
+    SimTime_t idle_start;
+
     // Vairable to tell us if we are waiting for something to happen
     // before we begin more output.  The two things we are waiting on
     // is: 1 - adding new data to output buffers, or 2 - getting
@@ -114,6 +118,7 @@ private:
     Statistic<uint64_t>* send_bit_count;
     Statistic<uint64_t>* send_packet_count;
     Statistic<uint64_t>* output_port_stalls;
+    Statistic<uint64_t>* idle_time;
 
     Output& output;
     


### PR DESCRIPTION
Added a new statistic for idle_time in portControl.  This records the amount of time that a port was not transmitting data (due to a lack of credits or lack of data).  Needs to be reviewd by Scott H.