### PR TITLE
Miranda - Don't Allow Split of L1 Cache Link in Tests to Improve Performance in Multithreaded Environments

### DIFF
--- a/miranda/tests/copybench.py
+++ b/miranda/tests/copybench.py
@@ -53,5 +53,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/inorderstream.py
+++ b/miranda/tests/inorderstream.py
@@ -53,5 +53,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/randomgen.py
+++ b/miranda/tests/randomgen.py
@@ -52,5 +52,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/revsinglestream.py
+++ b/miranda/tests/revsinglestream.py
@@ -54,5 +54,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "50ps"), (comp_l1cache, "high_network_0", "50ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/singlestream.py
+++ b/miranda/tests/singlestream.py
@@ -53,5 +53,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/stencil3dbench.py
+++ b/miranda/tests/stencil3dbench.py
@@ -54,5 +54,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/miranda/tests/streambench.py
+++ b/miranda/tests/streambench.py
@@ -53,5 +53,7 @@ comp_memory.addParams({
 # Define the simulation links
 link_cpu_cache_link = sst.Link("link_cpu_cache_link")
 link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
 link_mem_bus_link = sst.Link("link_mem_bus_link")
 link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )


### PR DESCRIPTION
Can address some slow down on Miranda tests in parallel environments by prevent cut on the link to L1 cache where traffic is heaviest.