### PR TITLE
Add destructor call to Ariel cores in the main CPU definition

### DIFF
--- a/ariel/arielcpu.cc
+++ b/ariel/arielcpu.cc
@@ -480,12 +480,16 @@ bool ArielCPU::tick( SST::Cycle_t cycle) {
 }
 
 ArielCPU::~ArielCPU() {
+	// Delete all of the cores
+	for(uint32_t i = 0; i < core_count; i++) {
+		delete cpu_cores[i];
+	}
+
 	delete memmgr;
 	delete tunnel;
-    unlink(shmem_region_name);
+        unlink(shmem_region_name);
 	free(page_sizes);
 	free(page_counts);
-
 }
 
 void ArielCPU::emergencyShutdown() {


### PR DESCRIPTION
Fix destructor doesn't call ArielCore