### PR TITLE
changes to allow ariel to drop stats based on front-end command

### DIFF
--- a/ariel/arielalloctrackev.h
+++ b/ariel/arielalloctrackev.h
@@ -20,7 +20,8 @@ class arielAllocTrackEvent : public SST::Event
 public:
     enum arielAllocTrackType {
         ALLOC,
-        FREE
+        FREE,
+        BUOY
     };
 
     arielAllocTrackEvent(arielAllocTrackType t, uint64_t va, uint64_t len, uint32_t lev, uint64_t ip) : 

--- a/ariel/arielcore.cc
+++ b/ariel/arielcore.cc
@@ -267,6 +267,19 @@ bool ArielCore::refillQueue() {
 
         // There is data on the pipe
         switch(ac.command) {
+        case ARIEL_OUTPUT_STATS:
+            fprintf(stdout, "Performing statistics output at simulation time = %" PRIu64 "\n", owner->getCurrentSimTimeNano());
+            Simulation::getSimulation()->getStatisticsProcessingEngine()->performGlobalStatisticOutput();
+            if (allocLink) {
+                // tell the allocate montior to dump stats. We
+                // optionally pass a marker number back in the instruction field
+                arielAllocTrackEvent *e 
+                    = new arielAllocTrackEvent(arielAllocTrackEvent::BUOY,
+                                               0, 0, 0, ac.instPtr);
+                allocLink->send(e);
+            }
+            break;
+
         case ARIEL_START_INSTRUCTION:
 	    if(ARIEL_INST_SP_FP == ac.inst.instClass) {
 		statFPSPIns->addData(1);
@@ -333,11 +346,6 @@ bool ArielCore::refillQueue() {
 
         case ARIEL_SWITCH_POOL:
             createSwitchPoolEvent(ac.switchPool.pool);
-            break;
-
-        case ARIEL_OUTPUT_STATS:
-            fprintf(stdout, "Performing statistics output at simulation time = %" PRIu64 "\n", owner->getCurrentSimTimeNano());
-            Simulation::getSimulation()->getStatisticsProcessingEngine()->performGlobalStatisticOutput();
             break;
 
         case ARIEL_PERFORM_EXIT:

--- a/ariel/frontend/simple/fesimple.cc
+++ b/ariel/frontend/simple/fesimple.cc
@@ -363,6 +363,14 @@ void mapped_ariel_output_stats() {
     tunnel->writeMessage(0, ac);
 }
 
+// same effect as mapped_ariel_output_stats(), but it also sends a user-defined reference number back
+void mapped_ariel_output_stats_buoy(uint64_t marker) {
+    ArielCommand ac;
+    ac.command = ARIEL_OUTPUT_STATS;
+    ac.instPtr = (uint64_t) marker; //user the instruction pointer slot to send the marker number
+    tunnel->writeMessage(0, ac);
+}
+
 #if ! defined(__APPLE__)
 int mapped_clockgettime(clockid_t clock, struct timespec *tp) {
     if (tp == NULL) { errno = EINVAL; return -1; }
@@ -657,6 +665,11 @@ VOID InstrumentRoutine(RTN rtn, VOID* args) {
     } else if (RTN_Name(rtn) == "ariel_output_stats" || RTN_Name(rtn) == "_ariel_output_stats") {
         fprintf(stderr, "Identified routine: ariel_output_stats, replacing with Ariel equivalent..\n");
         RTN_Replace(rtn, (AFUNPTR) mapped_ariel_output_stats);
+        fprintf(stderr, "Replacement complete\n");
+        return;
+    } else if (RTN_Name(rtn) == "ariel_output_stats_buoy" || RTN_Name(rtn) == "_ariel_output_stats_buoy") {
+        fprintf(stderr, "Identified routine: ariel_output_stats_buoy, replacing with Ariel equivalent..\n");
+        RTN_Replace(rtn, (AFUNPTR) mapped_ariel_output_stats_buoy);
         fprintf(stderr, "Replacement complete\n");
         return;
     }

--- a/memHierarchy/Sieve/sieveController.cc
+++ b/memHierarchy/Sieve/sieveController.cc
@@ -76,6 +76,10 @@ void Sieve::processAllocEvent(SST::Event* event) {
             actAllocMap.erase(targ);
         }
         delete ev;
+    } else if (ev->getType() == ArielComponent::arielAllocTrackEvent::BUOY) {
+        // output stats
+        outputStats(ev->getInstructionPointer());
+        delete ev;
     } else {
         output_->fatal(CALL_INFO, -1, "Unrecognized Ariel Allocation Tracking Event Type \n");
     }
@@ -161,9 +165,18 @@ void Sieve::init(unsigned int phase) {
     }
 }
 
-void Sieve::finish(){
+void Sieve::outputStats(int marker) {
+    // create name <outFileName> + <sequence> + marker (optional)
+    stringstream fileName;
+    fileName << outFileName << "-" << outCount;
+    outCount++;
+    if (-1 != marker)  {
+        fileName << "-" << marker;
+    }
+    fileName << ".txt";
 
-    listener_->printStats(*output_);
+    // create new file
+    Output* output_file = new Output("",0,0,SST::Output::FILE, fileName.str());
 
     // print out all the allocations and how often they were touched
     output_file->output(CALL_INFO, "#Printing out allocation hits (addr, IP, len, reads, writes, 'density'):\n");
@@ -171,7 +184,7 @@ void Sieve::finish(){
     for(allocList_t::iterator i = allocList.begin(); 
         i != allocList.end(); ++i) {
         ArielComponent::arielAllocTrackEvent *ev = *i;
-	rwCount_t counts = allocMap[ev];
+	rwCount_t &counts = allocMap[ev];
 	double density = double(counts.first + counts.second) / double(ev->getAllocateLength());
         output_file->output(CALL_INFO, "%#" PRIx64 " %#" PRIx64 " %" PRId64 " %" PRId64 " %" PRId64 " %.3f\n", 
 			    ev->getVirtualAddress(), 
@@ -179,9 +192,22 @@ void Sieve::finish(){
 			    ev->getAllocateLength(),
 			    counts.first, counts.second, density);
         tMiss = tMiss + counts.first + counts.second;
+
+        // clear the counts
+        counts.first = 0;
+        counts.second = 0;
     }
     output_file->output(CALL_INFO, "#Unassociated Misses: %" PRId64 " (%.2f%%)\n", unassociatedMisses, 
 			double(100*unassociatedMisses)/(double(tMiss)+double(unassociatedMisses)));
+
+    // clean up
+    delete output_file;
+}
+
+void Sieve::finish(){
+    listener_->printStats(*output_);
+
+    outputStats(-1);
 }
 
 

--- a/memHierarchy/Sieve/sieveController.h
+++ b/memHierarchy/Sieve/sieveController.h
@@ -61,6 +61,10 @@ private:
     typedef pair<uint64_t, uint64_t> rwCount_t;
     typedef map<ArielComponent::arielAllocTrackEvent*, 
                 rwCount_t > allocCountMap_t;
+    /** Name of the output file */
+    string outFileName;
+    /** output file counter */
+    uint64_t outCount;
     /** All Allocations */
     allocCountMap_t allocMap;
      /** All allocations in list form */
@@ -85,10 +89,12 @@ private:
     void processEvent(SST::Event* event);
     /** Handler for incoming allocation events.  */
     void processAllocEvent(SST::Event* event);
+
+    /** output and clear stats to file  */
+    void outputStats(int marker);
     
     CacheArray*         cacheArray_;
     Output*             output_;
-    Output*             output_file;
     CacheListener*      listener_;
     vector<SST::Link*>  cpuLinks_;
     uint32_t            cpuLinkCount_;

--- a/memHierarchy/Sieve/sieveFactory.cc
+++ b/memHierarchy/Sieve/sieveFactory.cc
@@ -65,11 +65,11 @@ Sieve::Sieve(ComponentId_t id, Params &params, CacheArray * cacheArray, Output *
     output_->debug(_INFO_,"--------------------------- Initializing [Sieve]: %s... \n", this->Component::getName().c_str());
 
     /* file output */ 
-    string outFileName  = params.find_string("output_file");
+    outFileName  = params.find_string("output_file");
     if (outFileName.empty()) {
-      outFileName = "sieveMallocRank.txt";
+      outFileName = "sieveMallocRank";
     }
-    output_file = new Output("",0,0,SST::Output::FILE,outFileName);
+    outCount = 0;
     
     /* --------------- Sieve profiler - implemented as a cassini prefetcher subcomponent ---------------*/
     string listener   = params.find_string("profiler");

--- a/memHierarchy/libmemHierarchy.cc
+++ b/memHierarchy/libmemHierarchy.cc
@@ -337,7 +337,7 @@ static const ElementInfoParam sieve_params[] = {
     {"profiler",                "Optional, string   - Name of profiling module. Currently only configured to work with cassini.AddrHistogrammer. Add params using 'profiler.paramName'", ""},
     {"debug",                   "Optional, int      - Print debug information. Options: 0[no output], 1[stdout], 2[stderr], 3[file]", "0"},
     {"debug_level",             "Optional, int      - Debugging level. Between 0 and 10", "0"},
-    {"output_file",             "Optional, string   – Name of file to output malloc information to", "sieveMallocRank.txt"},
+    {"output_file",             "Optional, string   – Name of file to output malloc information to. Will have sequence number (and optional marker number) and .txt appended to it. E.g. sieveMallocRank-3.txt", "sieveMallocRank"},
     {NULL, NULL, NULL}
 };
 


### PR DESCRIPTION
Allows an application in ariel to use a ariel_output_stats_buoy() call to direct SST to drop stats. the _buoy() call can pass back a user-defined marker for the backend to label these stats. Currently, SieveController uses this to drop regular malloc() lists.