### PR TITLE
Add a Command to Run Prospero Profiling from SST Tool Directory

### DIFF
--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -53,7 +53,7 @@ sst_prospero_trace_SOURCES = runprosperotrace.cc
 
 if SST_COMPILE_OSX
 
-install-exec-hook: tracetool/sstmemtrace.cc
+all-local: tracetool/sstmemtrace.cc
 	$(CXX) -O3 -shared \
 	$(CPPFLAGS) \
 	$(BOOST_CPPFLAGS) \
@@ -73,17 +73,14 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.dylib tracetool/sstmemtrace.cc \
 	-stdlib=libstdc++ \
-<<<<<<< HEAD
-	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS) && \
-	cp prosperotrace.dylib 4(libexecdir)/prosperotrace.dylib
-=======
-	-lpin -lxed -lpindwarf -lpthread && \
+	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS)
+	
+install-exec-hook: prosperotrace.dylib
 	cp prosperotrace.dylib $(libexecdir)/prosperotrace.dylib
->>>>>>> b3b37b85f8202f0c81d15adfebc384fae445ab0e
 
 else
 
-install-exec-hook: tracetool/sstmemtrace.cc
+all-local: tracetool/sstmemtrace.cc
 	$(CXX) -shared -Wl,--hash-style=sysv -Wl,-Bsymbolic \
 	-fPIC -O3 \
 	-fomit-frame-pointer \
@@ -102,7 +99,9 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/intel64/runtime/glibc \
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.so tracetool/sstmemtrace.cc \
-	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt $(LIBZ_LDFLAGS) && \
+	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt $(LIBZ_LDFLAGS)
+	
+install-exec-hook: prosperotrace.so
 	cp prosperotrace.so $(libexecdir)/prosperotrace.so
 
 endif

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -6,6 +6,8 @@ AM_CPPFLAGS = \
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libprospero.la
 
+libexec_PROGRAMS =
+
 libprospero_la_SOURCES = \
 	libprospero.cc \
         proscpu.h \
@@ -38,10 +40,6 @@ EXTRA_DIST = \
 
 libprospero_la_LDFLAGS = -module -avoid-version
 
-bin_PROGRAMS = sst-prospero-trace
-
-sst_prospero_trace_SOURCES = runprosperotrace.cc
-
 if USE_LIBZ
 libprospero_la_LIBADD = -lz
 
@@ -50,14 +48,71 @@ libprospero_la_SOURCES += \
 	prosbingzreader.cc
 endif
 
+if HAVE_PINTOOL
+
+bin_PROGRAMS = sst-prospero-trace
+sst_prospero_trace_SOURCES = runprosperotrace.cc
+
 if SST_COMPILE_OSX
 
-libexec_PROGRAMS += fesimple.dylib
+libexec_PROGRAMS += prosperotrace.dylib
 prosperotrace_dylib_SOURCES = tracetool/sstmemtrace.cc
+
+prosperotrace.dylib: prosperotrace.o
+        $(CXX) -shared \
+        -Wl,-exported_symbols_list \
+        -Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
+        -stdlib=libstdc++ \
+        -L$(PINTOOL_DIR)/intel64/lib \
+        -L$(PINTOOL_DIR)/intel64/lib-ext \
+        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+        -o prosperotrace.dylib prosperotrace.o  \
+        -lpin -lxed -lpindwarf -lpthread
+
+prosperotrace.o: tracetool/sstmemtrace.cc
+        $(CXX) -O3 \
+        $(CPPFLAGS) \
+        $(BOOST_CPPFLAGS) \
+        -DBIGARRAY_MULTIPLIER=1 \
+        -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_MAC \
+        -I$(PINTOOL_DIR)/source/include/pin \
+        -I$(PINTOOL_DIR)/ \
+        -I$(PINTOOL_DIR)/extras/components/include \
+        -I$(PINTOOL_DIR)/source/include/pin/gen/ \
+        -I$(PINTOOL_DIR)/extras/xed-intel64/include \
+        -fomit-frame-pointer -fno-stack-protector \
+        -stdlib=libstdc++ \
+        -o prosperotrace.o -c \
+	tracetool/sstmemtrace.cc
 
 else
 
-libexec_PROGRAMS += fesimple.so
+libexec_PROGRAMS += prosperotrace.so
 prosperotrace_so_SOURCES = tracetool/sstmemtrace.cc
 
+prosperotrace.so: prosperotrace.o
+        $(CXX) -shared -Wl,--hash-style=sysv -Wl,-Bsymbolic \
+        -Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
+        -L$(PINTOOL_DIR)/intel64/lib \
+        -L$(PINTOOL_DIR)/intel64/lib-ext \
+        -L$(PINTOOL_DIR)/intel64/runtime/glibc \
+        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+        -o prosperotrace.so prosperotrace.o  \
+        -ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt
+
+prosperotrace.o: tracetool/sstmemtrace.cc
+        $(CXX) -fPIC -O3 \
+        -fomit-frame-pointer \
+        $(CPPFLAGS) \
+        $(BOOST_CPPFLAGS) \
+        -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX \
+        -I$(PINTOOL_DIR)/source/include/pin \
+        -I$(PINTOOL_DIR)/ \
+        -I$(PINTOOL_DIR)/extras/components/include \
+        -I$(PINTOOL_DIR)/source/include/pin/gen/ \
+        -I$(PINTOOL_DIR)/extras/xed-intel64/include \
+        -o prosperotrace.o -c \
+        tracetool/sstmemtrace.cc
+
+endif
 endif

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -65,6 +65,7 @@ all-local: tracetool/sstmemtrace.cc
 	-I$(PINTOOL_DIR)/extras/components/include \
 	-I$(PINTOOL_DIR)/source/include/pin/gen/ \
 	-I$(PINTOOL_DIR)/extras/xed-intel64/include \
+	-I$(top_srcdir)/sst \
 	-fomit-frame-pointer -fno-stack-protector \
 	-Wl,-exported_symbols_list \
 	-Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
@@ -93,6 +94,7 @@ all-local: tracetool/sstmemtrace.cc
 	-I$(PINTOOL_DIR)/extras/components/include \
 	-I$(PINTOOL_DIR)/source/include/pin/gen/ \
 	-I$(PINTOOL_DIR)/extras/xed-intel64/include \
+	-I$(top_srcdir)/sst \
 	-Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
 	-L$(PINTOOL_DIR)/intel64/lib \
 	-L$(PINTOOL_DIR)/intel64/lib-ext \

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -57,6 +57,7 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	$(CXX) -O3 -shared \
 	$(CPPFLAGS) \
 	$(BOOST_CPPFLAGS) \
+	$(LIBZ_CPPFLAGS) \
 	-DBIGARRAY_MULTIPLIER=1 \
 	-DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_MAC \
 	-I$(PINTOOL_DIR)/source/include/pin \
@@ -72,7 +73,7 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.dylib tracetool/sstmemtrace.cc \
 	-stdlib=libstdc++ \
-	-lpin -lxed -lpindwarf -lpthread && \
+	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS) && \
 	cp prosperotrace.dylib 4(libexecdir)/prosperotrace.dylib
 
 else
@@ -83,6 +84,7 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	-fomit-frame-pointer \
 	$(CPPFLAGS) \
 	$(BOOST_CPPFLAGS) \
+	$(LIBZ_CPPFLAGS) \
 	-DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX \
 	-I$(PINTOOL_DIR)/source/include/pin \
 	-I$(PINTOOL_DIR)/ \
@@ -95,7 +97,7 @@ install-exec-hook: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/intel64/runtime/glibc \
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.so tracetool/sstmemtrace.cc \
-	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt && \
+	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt $(LIBZ_LDFLAGS) && \
 	cp prosperotrace.so $(libexecdir)/prosperotrace.so
 
 endif

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -4,9 +4,7 @@ AM_CPPFLAGS = \
         $(MPI_CPPFLAGS)
 
 compdir = $(pkglibdir)
-comp_LTLIBRARIES = libprospero.la
-
-libexec_PROGRAMS =
+comp_LTLIBRARIES = libprospero.la 
 
 libprospero_la_SOURCES = \
 	libprospero.cc \
@@ -55,22 +53,9 @@ sst_prospero_trace_SOURCES = runprosperotrace.cc
 
 if SST_COMPILE_OSX
 
-libexec_PROGRAMS += prosperotrace.dylib
-prosperotrace_dylib_SOURCES = tracetool/sstmemtrace.cc
-
-prosperotrace.dylib: prosperotrace.o
-        $(CXX) -shared \
-        -Wl,-exported_symbols_list \
-        -Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
-        -stdlib=libstdc++ \
-        -L$(PINTOOL_DIR)/intel64/lib \
-        -L$(PINTOOL_DIR)/intel64/lib-ext \
-        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
-        -o prosperotrace.dylib prosperotrace.o  \
-        -lpin -lxed -lpindwarf -lpthread
-
-prosperotrace.o: tracetool/sstmemtrace.cc
-        $(CXX) -O3 \
+install-exec-hook: tracetool/sstmemtrace.cc
+        $(CXX) -O3 -shared \
+	-O3 \
         $(CPPFLAGS) \
         $(BOOST_CPPFLAGS) \
         -DBIGARRAY_MULTIPLIER=1 \
@@ -81,27 +66,22 @@ prosperotrace.o: tracetool/sstmemtrace.cc
         -I$(PINTOOL_DIR)/source/include/pin/gen/ \
         -I$(PINTOOL_DIR)/extras/xed-intel64/include \
         -fomit-frame-pointer -fno-stack-protector \
+        -Wl,-exported_symbols_list \
+        -Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
         -stdlib=libstdc++ \
-        -o prosperotrace.o -c \
-	tracetool/sstmemtrace.cc
+        -L$(PINTOOL_DIR)/intel64/lib \
+        -L$(PINTOOL_DIR)/intel64/lib-ext \
+        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+        -o prosperotrace.dylib tracetool/sstmemtrace.cc \
+        -stdlib=libstdc++ \
+        -lpin -lxed -lpindwarf -lpthread && \
+	cp prosperotrace.dylib 4(libexecdir)/libexec/prosperotrace.dylib
 
 else
 
-libexec_PROGRAMS += prosperotrace.so
-prosperotrace_so_SOURCES = tracetool/sstmemtrace.cc
-
-prosperotrace.so: prosperotrace.o
+install-exec-hook: tracetool/sstmemtrace.cc
         $(CXX) -shared -Wl,--hash-style=sysv -Wl,-Bsymbolic \
-        -Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
-        -L$(PINTOOL_DIR)/intel64/lib \
-        -L$(PINTOOL_DIR)/intel64/lib-ext \
-        -L$(PINTOOL_DIR)/intel64/runtime/glibc \
-        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
-        -o prosperotrace.so prosperotrace.o  \
-        -ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt
-
-prosperotrace.o: tracetool/sstmemtrace.cc
-        $(CXX) -fPIC -O3 \
+	-fPIC -O3 \
         -fomit-frame-pointer \
         $(CPPFLAGS) \
         $(BOOST_CPPFLAGS) \
@@ -111,8 +91,14 @@ prosperotrace.o: tracetool/sstmemtrace.cc
         -I$(PINTOOL_DIR)/extras/components/include \
         -I$(PINTOOL_DIR)/source/include/pin/gen/ \
         -I$(PINTOOL_DIR)/extras/xed-intel64/include \
-        -o prosperotrace.o -c \
-        tracetool/sstmemtrace.cc
+        -Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
+        -L$(PINTOOL_DIR)/intel64/lib \
+        -L$(PINTOOL_DIR)/intel64/lib-ext \
+        -L$(PINTOOL_DIR)/intel64/runtime/glibc \
+        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+        -o prosperotrace.so tracetool/sstmemtrace.cc \
+        -ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt && \
+	cp prosperotrace.so $(libexecdir)/libexec/prosperotrace.so
 
 endif
 endif

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libprospero.la
+
 libprospero_la_SOURCES = \
 	libprospero.cc \
         proscpu.h \
@@ -37,10 +38,26 @@ EXTRA_DIST = \
 
 libprospero_la_LDFLAGS = -module -avoid-version
 
+bin_PROGRAMS = sst-prospero-trace
+
+sst_prospero_trace_SOURCES = runprosperotrace.cc
+
 if USE_LIBZ
 libprospero_la_LIBADD = -lz
 
 libprospero_la_SOURCES += \
 	prosbingzreader.h \
 	prosbingzreader.cc
+endif
+
+if SST_COMPILE_OSX
+
+libexec_PROGRAMS += fesimple.dylib
+prosperotrace_dylib_SOURCES = tracetool/sstmemtrace.cc
+
+else
+
+libexec_PROGRAMS += fesimple.so
+prosperotrace_so_SOURCES = tracetool/sstmemtrace.cc
+
 endif

--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -54,51 +54,49 @@ sst_prospero_trace_SOURCES = runprosperotrace.cc
 if SST_COMPILE_OSX
 
 install-exec-hook: tracetool/sstmemtrace.cc
-        $(CXX) -O3 -shared \
-	-O3 \
-        $(CPPFLAGS) \
-        $(BOOST_CPPFLAGS) \
-        -DBIGARRAY_MULTIPLIER=1 \
-        -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_MAC \
-        -I$(PINTOOL_DIR)/source/include/pin \
-        -I$(PINTOOL_DIR)/ \
-        -I$(PINTOOL_DIR)/extras/components/include \
-        -I$(PINTOOL_DIR)/source/include/pin/gen/ \
-        -I$(PINTOOL_DIR)/extras/xed-intel64/include \
-        -fomit-frame-pointer -fno-stack-protector \
-        -Wl,-exported_symbols_list \
-        -Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
-        -stdlib=libstdc++ \
-        -L$(PINTOOL_DIR)/intel64/lib \
-        -L$(PINTOOL_DIR)/intel64/lib-ext \
-        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
-        -o prosperotrace.dylib tracetool/sstmemtrace.cc \
-        -stdlib=libstdc++ \
-        -lpin -lxed -lpindwarf -lpthread && \
-	cp prosperotrace.dylib 4(libexecdir)/libexec/prosperotrace.dylib
+	$(CXX) -O3 -shared \
+	$(CPPFLAGS) \
+	$(BOOST_CPPFLAGS) \
+	-DBIGARRAY_MULTIPLIER=1 \
+	-DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_MAC \
+	-I$(PINTOOL_DIR)/source/include/pin \
+	-I$(PINTOOL_DIR)/ \
+	-I$(PINTOOL_DIR)/extras/components/include \
+	-I$(PINTOOL_DIR)/source/include/pin/gen/ \
+	-I$(PINTOOL_DIR)/extras/xed-intel64/include \
+	-fomit-frame-pointer -fno-stack-protector \
+	-Wl,-exported_symbols_list \
+	-Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
+	-L$(PINTOOL_DIR)/intel64/lib \
+	-L$(PINTOOL_DIR)/intel64/lib-ext \
+	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+	-o prosperotrace.dylib tracetool/sstmemtrace.cc \
+	-stdlib=libstdc++ \
+	-lpin -lxed -lpindwarf -lpthread && \
+	cp prosperotrace.dylib 4(libexecdir)/prosperotrace.dylib
 
 else
 
 install-exec-hook: tracetool/sstmemtrace.cc
-        $(CXX) -shared -Wl,--hash-style=sysv -Wl,-Bsymbolic \
+	$(CXX) -shared -Wl,--hash-style=sysv -Wl,-Bsymbolic \
 	-fPIC -O3 \
-        -fomit-frame-pointer \
-        $(CPPFLAGS) \
-        $(BOOST_CPPFLAGS) \
-        -DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX \
-        -I$(PINTOOL_DIR)/source/include/pin \
-        -I$(PINTOOL_DIR)/ \
-        -I$(PINTOOL_DIR)/extras/components/include \
-        -I$(PINTOOL_DIR)/source/include/pin/gen/ \
-        -I$(PINTOOL_DIR)/extras/xed-intel64/include \
-        -Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
-        -L$(PINTOOL_DIR)/intel64/lib \
-        -L$(PINTOOL_DIR)/intel64/lib-ext \
-        -L$(PINTOOL_DIR)/intel64/runtime/glibc \
-        -L$(PINTOOL_DIR)/extras/xed-intel64/lib \
-        -o prosperotrace.so tracetool/sstmemtrace.cc \
-        -ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt && \
-	cp prosperotrace.so $(libexecdir)/libexec/prosperotrace.so
+	-fomit-frame-pointer \
+	$(CPPFLAGS) \
+	$(BOOST_CPPFLAGS) \
+	-DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_LINUX \
+	-I$(PINTOOL_DIR)/source/include/pin \
+	-I$(PINTOOL_DIR)/ \
+	-I$(PINTOOL_DIR)/extras/components/include \
+	-I$(PINTOOL_DIR)/source/include/pin/gen/ \
+	-I$(PINTOOL_DIR)/extras/xed-intel64/include \
+	-Wl,--version-script=$(PINTOOL_DIR)/source/include/pin/pintool.ver \
+	-L$(PINTOOL_DIR)/intel64/lib \
+	-L$(PINTOOL_DIR)/intel64/lib-ext \
+	-L$(PINTOOL_DIR)/intel64/runtime/glibc \
+	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
+	-o prosperotrace.so tracetool/sstmemtrace.cc \
+	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt && \
+	cp prosperotrace.so $(libexecdir)/prosperotrace.so
 
 endif
 endif

--- a/prospero/configure.m4
+++ b/prospero/configure.m4
@@ -2,11 +2,10 @@ dnl -*- Autoconf -*-
 
 AC_DEFUN([SST_prospero_CONFIG], [
 
-  happy="yes"
+  prospero_happy="yes"
 
-  happy_SAVED="$happy"
   SST_CHECK_LIBZ()
-  happy="$happy_SAVED"
+  SST_CHECK_PINTOOL([have_pin=1],[have_pin=0],[])
 
-  AS_IF([test "$happy" = "yes"], [$1], [$2])
+  AS_IF([test "$prospero_happy" = "yes"], [$1], [$2])
 ])

--- a/prospero/runprosperotrace.cc
+++ b/prospero/runprosperotrace.cc
@@ -1,0 +1,127 @@
+
+#include <sst_config.h>
+
+#include <signal.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/wait.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include <vector>
+#include <string>
+
+int main(int argc, char* argv[]) {
+
+	char* pinToolMarker = "-t";
+	char* doubleDash = "--";
+
+	bool foundMarker = false;
+	std::vector<char*> prosParams;
+	std::vector<char*> appParams;
+	char* appPath;
+
+	char* toolPath = (char*) malloc(sizeof(char) * PATH_MAX);
+
+#ifdef SST_COMPILE_MACOSX
+	sprintf(toolPath, "%s/libexec/prospero.dylib", SST_INSTALL_PREFIX);
+#else
+	sprintf(toolPath, "%s/libexec/prospero.so", SST_INSTALL_PREFIX);
+#endif
+
+	appParams.push_back(PINTOOL_EXECUTABLE);
+	appParams.push_back(pinToolMarker);
+	appParams.push_back(toolPath);
+
+	for(int i = 1; i < argc; i++) {
+		if(foundMarker) {
+			appParams.push_back(argv[i]);
+		} else {
+			if(std::strcmp(argv[i], doubleDash) == 0) {
+				foundMarker = true;
+
+				if(i == ( argc - 1 )) {
+					fprintf(stderr, "Found -- marker, but no application path in options\n");
+					exit(-1);
+				} else {
+					appParams.push_back(argv[i]);
+					appParams.push_back(argv[i+1]);
+					appPath = argv[i+1];
+
+					i++;
+				}
+			} else {
+				prosParams.push_back(argv[i]);
+			}
+		}
+	}
+
+	if(! foundMarker) {
+		fprintf(stderr, "Error: did not find the -- marker which separates out the application and profiling options\n");
+		exit(-1);
+	}
+
+	printf("===============================================================\n");
+	printf("Prospero Memory Tracing Tool\n");
+	printf("Part of the Structural Simulation Toolkit (SST)\n");
+	printf("===============================================================\n");
+	printf("\n");
+
+	for(auto nextStr = prosParams.begin(); nextStr != prosParams.end(); nextStr++) {
+		printf("P: %s\n", *nextStr);
+	}
+
+	printf("Prospero will run the following for tracing:\n");
+	for(auto nextStr = appParams.begin(); nextStr != appParams.end(); nextStr++) {
+		printf("%s ", *nextStr);
+	}
+
+	printf("\n");
+
+	pid_t childProcess;
+	childProcess = fork();
+
+	if(childProcess < 0) {
+		perror("fork");
+		fprintf(stderr, "Error: Failed to launch the child process.\n");
+		exit(-1);
+	}
+
+	if(childProcess != 0) {
+		// The process has been launched and we need to wait for it
+		int processStat = 0;
+		pid_t childRC = waitpid(childProcess, &processStat, 0);
+
+		printf("\n");
+		printf("===============================================================\n");
+
+		if( childRC > 0 ) {
+			fprintf(stderr, "Error: launch of PIN failed! Exit with: %d\n",
+				WEXITSTATUS(processStat));
+			exit(-1);
+		} else if( childRC < 0 ) {
+			fprintf(stderr, "Error: Unable to start PIN.\n");
+			perror("waitpid");
+			exit(-1);
+		} else {
+			printf("Child process has completed.\n");
+		}
+
+	} else {
+		appParams.push_back(NULL);
+
+		char** paramsArray = (char**) malloc(sizeof(char*) * appParams.size());
+		for(auto i = 0; i < appParams.size(); i++) {
+			paramsArray[i] = appParams[i];
+		}
+
+		int executeRC = execvp(PINTOOL_EXECUTABLE, paramsArray);
+		printf("Executing application returns %d.\n", executeRC);
+	}
+
+	return 0;
+}
+

--- a/prospero/runprosperotrace.cc
+++ b/prospero/runprosperotrace.cc
@@ -16,8 +16,8 @@
 
 int main(int argc, char* argv[]) {
 
-	char* pinToolMarker = "-t";
-	char* doubleDash = "--";
+	char* pinToolMarker = const_cast<char*>("-t");
+	char* doubleDash = const_cast<char*>("--");
 
 	bool foundMarker = false;
 	std::vector<char*> prosParams;
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
 	sprintf(toolPath, "%s/libexec/prospero.so", SST_INSTALL_PREFIX);
 #endif
 
-	appParams.push_back(PINTOOL_EXECUTABLE);
+	appParams.push_back(const_cast<char*>(PINTOOL_EXECUTABLE));
 	appParams.push_back(pinToolMarker);
 	appParams.push_back(toolPath);
 

--- a/prospero/runprosperotrace.cc
+++ b/prospero/runprosperotrace.cc
@@ -27,9 +27,9 @@ int main(int argc, char* argv[]) {
 	char* toolPath = (char*) malloc(sizeof(char) * PATH_MAX);
 
 #ifdef SST_COMPILE_MACOSX
-	sprintf(toolPath, "%s/libexec/prospero.dylib", SST_INSTALL_PREFIX);
+	sprintf(toolPath, "%s/libexec/prosperotrace.dylib", SST_INSTALL_PREFIX);
 #else
-	sprintf(toolPath, "%s/libexec/prospero.so", SST_INSTALL_PREFIX);
+	sprintf(toolPath, "%s/libexec/prosperotrace.so", SST_INSTALL_PREFIX);
 #endif
 
 	appParams.push_back(const_cast<char*>(PINTOOL_EXECUTABLE));

--- a/prospero/runprosperotrace.cc
+++ b/prospero/runprosperotrace.cc
@@ -99,15 +99,11 @@ int main(int argc, char* argv[]) {
 		printf("===============================================================\n");
 
 		if( childRC > 0 ) {
-			fprintf(stderr, "Error: launch of PIN failed! Exit with: %d\n",
-				WEXITSTATUS(processStat));
-			exit(-1);
-		} else if( childRC < 0 ) {
+			printf("Child process(es) for profiling completed.\n");
+		} else {
 			fprintf(stderr, "Error: Unable to start PIN.\n");
 			perror("waitpid");
 			exit(-1);
-		} else {
-			printf("Child process has completed.\n");
 		}
 
 	} else {

--- a/prospero/tracetool/sstmemtrace.cc
+++ b/prospero/tracetool/sstmemtrace.cc
@@ -12,6 +12,7 @@
 // Uses PIN Tool Memory Trace as a basis for provide SST Memory Tracing output
 // directly to the tracing framework.
 
+#include <sst_config.h>
 #include "pin.H"
 
 #include <stdio.h>
@@ -20,7 +21,7 @@
 #include <iostream>
 #include <inttypes.h>
 
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
 #include <zlib.h>
 #endif
 
@@ -41,7 +42,7 @@ char RECORD_BUFFER[ sizeof(uint64_t) + sizeof(uint64_t) + sizeof(uint32_t) + siz
 // "normal" (binary or text) traces
 FILE** trace;
 
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
 gzFile* traceZ;
 #endif
 
@@ -136,7 +137,7 @@ VOID RecordMemRead(VOID * addr, UINT32 size, THREADID thr)
 			thread_instr_id[thr].readCount++;
 		}
 	} else {
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
 		if(thr < max_thread_count && (traceEnabled > 0)) {
 			gzwrite(traceZ[thr], RECORD_BUFFER, sizeof(uint64_t) + sizeof(uint64_t) + sizeof(uint32_t) + sizeof(char));
 			thread_instr_id[thr].readCount++;
@@ -180,7 +181,7 @@ VOID RecordMemWrite(VOID * addr, UINT32 size, THREADID thr)
 			thread_instr_id[thr].writeCount++;
 		}
 	} else {
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
 		if(thr < max_thread_count && (traceEnabled > 0)) {
 			gzwrite(traceZ[thr], RECORD_BUFFER, sizeof(uint64_t) + sizeof(uint64_t) + sizeof(uint32_t) + sizeof(char));
 			thread_instr_id[thr].writeCount++;
@@ -217,7 +218,7 @@ VOID IncrementInstructionCount(THREADID id) {
                                 trace[id] = fopen(buffer, "wb");
 			}
 		}
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
 		else if(trace_format == 2) {
 			gzclose(traceZ[id]);
 			sprintf(buffer, "%s-%lu-%lu-gz.trace",
@@ -316,7 +317,7 @@ VOID Fini(INT32 code, VOID *v)
 	for(UINT32 i = 0; i < max_thread_count; ++i) {
     		fclose(trace[i]);
 	}
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
     } else if (2 == trace_format) {
 	for(UINT32 i = 0; i < max_thread_count; ++i) {
 		gzclose(traceZ[i]);
@@ -362,7 +363,7 @@ int main(int argc, char *argv[])
     }
 
     trace  = (FILE**) malloc(sizeof(FILE*) * max_thread_count);
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
     traceZ = (gzFile*) malloc(sizeof(gzFile) * max_thread_count);
 #endif
     fileBuffers = (char**) malloc(sizeof(char*) * max_thread_count);
@@ -395,7 +396,7 @@ int main(int argc, char *argv[])
 		fileBuffers[i] = (char*) malloc(sizeof(char) * KnobFileBufferSize.Value());
 		setvbuf(trace[i], fileBuffers[i], _IOFBF, (size_t) KnobFileBufferSize.Value());
 	}
-#ifdef PROSPERO_LIBZ
+#ifdef HAVE_LIBZ
     } else if(KnobTraceFormat.Value() == "compressed") {
 	printf("PROSPERO: Tracing will be recorded in compressed binary format.\n");
 	trace_format = 2;


### PR DESCRIPTION
Provides the `sst-prospero-trace` command to be run from SST `bin` directory. This tool knows/controls which PIN variant to launch and how to locate the default Prospero tracing tools. Has worked successfully in testing on Mac OS X and Linux.