### PR TITLE
Provide a Tool to Generate Prospero Traces

### DIFF
--- a/prospero/Makefile.am
+++ b/prospero/Makefile.am
@@ -74,7 +74,7 @@ all-local: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.dylib tracetool/sstmemtrace.cc \
 	-stdlib=libstdc++ \
-	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS)
+	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS) $(LIBZ_LIB)
 	
 install-exec-hook: prosperotrace.dylib
 	cp prosperotrace.dylib $(libexecdir)/prosperotrace.dylib
@@ -101,7 +101,7 @@ all-local: tracetool/sstmemtrace.cc
 	-L$(PINTOOL_DIR)/intel64/runtime/glibc \
 	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
 	-o prosperotrace.so tracetool/sstmemtrace.cc \
-	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt $(LIBZ_LDFLAGS)
+	-ldl -lpin -lxed -lpindwarf -ldl -lpthread -lrt $(LIBZ_LDFLAGS) $(LIBZ_LIB)
 	
 install-exec-hook: prosperotrace.so
 	cp prosperotrace.so $(libexecdir)/prosperotrace.so

--- a/prospero/runprosperotrace.cc
+++ b/prospero/runprosperotrace.cc
@@ -1,4 +1,3 @@
-
 #include <sst_config.h>
 
 #include <signal.h>
@@ -14,10 +13,33 @@
 #include <vector>
 #include <string>
 
+void printUsage() {
+	printf("sst-prospero-trace [trace options] -- [app] [app options]\n");
+	printf("\n");
+	printf("Trace-Options:\n");
+	printf("  -o <file>     Name of trace output files.\n");
+	printf("  -f <format>   Output <format> = {text, binary, compressed}\n");
+	printf("  -t <maxthr>   Maximum number of threads to trace, if not set will search for OMP_NUM_THREADS or set to 1\n");
+	printf("\n");
+}
+
 int main(int argc, char* argv[]) {
+
+	for(int i = 1; i < argc; i++) {
+		if(std::strcmp(argv[i], "--") == 0) {
+			break;
+		} else if(std::strcmp(argv[i], "--help") == 0 ||
+			std::strcmp(argv[i], "-help") == 0 ||
+			std::strcmp(argv[i], "-h") == 0) {
+
+			printUsage();
+			exit(0);
+		}
+	}
 
 	char* pinToolMarker = const_cast<char*>("-t");
 	char* doubleDash = const_cast<char*>("--");
+	char* numberOne = const_cast<char*>("1");
 
 	bool foundMarker = false;
 	std::vector<char*> prosParams;
@@ -61,24 +83,74 @@ int main(int argc, char* argv[]) {
 
 	if(! foundMarker) {
 		fprintf(stderr, "Error: did not find the -- marker which separates out the application and profiling options\n");
+		printUsage();
 		exit(-1);
+	}
+
+	int threadCount = 0;
+	char* outputFile = const_cast<char*>("prospero-trace");
+	char* outputFormat = const_cast<char*>("text");
+
+	for(int i = 0; i < prosParams.size(); i++) {
+		if( std::strcmp(prosParams[i], "-t") == 0 ) {
+			if(i == (prosParams.size() - 1) ) {
+				fprintf(stderr, "-t needs a number of threads to be specified\n");
+				exit(-1);
+			} else {
+				threadCount = std::atoi(prosParams[i+1]);
+				i++;
+			}
+		} else if( std::strcmp(prosParams[i], "-o") == 0 ) {
+			if(i == (prosParams.size() - 1) ) {
+				fprintf(stderr, "-o needs a file to be specified\n");
+				exit(-1);
+			} else {
+				outputFile = prosParams[i+1];
+				i++;
+			}
+		} else if( std::strcmp(prosParams[i], "-f") == 0) {
+			if(i == (prosParams.size() - 1) ) {
+				fprintf(stderr, "-f needs a format to be specified\n");
+				exit(-1);
+			} else {
+				if(std::strcmp(prosParams[i+1], "text") == 0 ||
+					std::strcmp(prosParams[i+1], "binary") == 0 ||
+					std::strcmp(prosParams[i+1], "compressed") == 0) {
+
+					outputFormat = prosParams[i+1];
+					i++;
+				} else {
+					fprintf(stderr, "Error: output format %s is not valid\n",
+						prosParams[i+1]);
+					printUsage();
+					exit(-1);
+				}
+			}
+		} else {
+			fprintf(stderr, "Error: program option: %s\n",
+				prosParams[i]);
+			printUsage();
+			exit(-1);
+		}
+	}
+
+	if(0 == threadCount) {
+		// User did not set this
+		if(NULL == getenv("OMP_NUM_THREADS")) {
+			prosParams.push_back(pinToolMarker);
+			prosParams.push_back(numberOne);
+		} else {
+			prosParams.push_back(pinToolMarker);
+			char* ompThreadCount = (char*) malloc(sizeof(char) * 8);
+			sprintf(ompThreadCount, "%d", getenv("OMP_NUM_THREADS"));
+			prosParams.push_back(ompThreadCount);
+		}
 	}
 
 	printf("===============================================================\n");
 	printf("Prospero Memory Tracing Tool\n");
 	printf("Part of the Structural Simulation Toolkit (SST)\n");
 	printf("===============================================================\n");
-	printf("\n");
-
-	for(auto nextStr = prosParams.begin(); nextStr != prosParams.end(); nextStr++) {
-		printf("P: %s\n", *nextStr);
-	}
-
-	printf("Prospero will run the following for tracing:\n");
-	for(auto nextStr = appParams.begin(); nextStr != appParams.end(); nextStr++) {
-		printf("%s ", *nextStr);
-	}
-
 	printf("\n");
 
 	pid_t childProcess;
@@ -100,6 +172,7 @@ int main(int argc, char* argv[]) {
 
 		if( childRC > 0 ) {
 			printf("Child process(es) for profiling completed.\n");
+			printf("===============================================================\n");
 		} else {
 			fprintf(stderr, "Error: Unable to start PIN.\n");
 			perror("waitpid");
@@ -107,15 +180,45 @@ int main(int argc, char* argv[]) {
 		}
 
 	} else {
+		printf("IN THE ZERO CASE!\n");
+
 		appParams.push_back(NULL);
 
-		char** paramsArray = (char**) malloc(sizeof(char*) * appParams.size());
-		for(auto i = 0; i < appParams.size(); i++) {
-			paramsArray[i] = appParams[i];
+		char** paramsArray = (char**) malloc(sizeof(char*) * (appParams.size() + prosParams.size()));
+		int nextParamsArray = 0;
+
+		for(auto i = 0; i < appParams.size(); ++i) {
+			printf("Iteration: %d [%s]\n", i, appParams[i]);
+
+			// Before we copy in the application parameters, we need to copy in the
+			// the options for the tool itself
+			if( (NULL != appParams[i]) && (std::strcmp(appParams[i], "--") == 0) ) {
+				for(auto j = 0; j < prosParams.size(); j++) {
+					paramsArray[nextParamsArray] = prosParams[j];
+					nextParamsArray++;
+				}
+			}
+
+			paramsArray[nextParamsArray] = appParams[i];
+			nextParamsArray++;
 		}
+
+		printf("Prospero will run the tracing command:\n");
+
+		for(auto i = 0; i < (appParams.size() + prosParams.size()); ++i) {
+			if(NULL != paramsArray[i]) {
+				printf("%s ", paramsArray[i]);
+			} else {
+				printf("(NULL) ");
+			}
+		}
+
+		printf("\n");
 
 		int executeRC = execvp(PINTOOL_EXECUTABLE, paramsArray);
 		printf("Executing application returns %d.\n", executeRC);
+
+		free(paramsArray);
 	}
 
 	return 0;


### PR DESCRIPTION
Provides a tool to correctly load PIN and perform a multi-threaded memory trace for Prospero. Appears that PIN detection and execution in testing for Prospero is not consistent with how Ariel is used even though both tools use PIN. This means Prospero will fail but Ariel will not. This tool provides the same launch mechanism as Ariel but for Prospero traces. Support is provided for `text`, `binary` and `compressed` traces.