### PR TITLE
Fix miranda gups generator seeds not set problem

### DIFF
--- a/miranda/generators/gupsgen.cc
+++ b/miranda/generators/gupsgen.cc
@@ -28,8 +28,9 @@ GUPSGenerator::GUPSGenerator( Component* owner, Params& params ) :
 	issueCount = ((uint64_t) params.find_integer("count", 1000)) * iterations;
 	reqLength  = (uint64_t) params.find_integer("length", 8);
 	maxAddr    = (uint64_t) params.find_integer("max_address", 524288);
-
-	rng = new MarsagliaRNG(11, 31);
+    seed_a     = (uint64_t) params.find_integer("seed_a", 11);
+	seed_b     = (uint64_t) params.find_integer("seed_b", 31);
+	rng = new MarsagliaRNG(seed_a, seed_b);
 
 	out->verbose(CALL_INFO, 1, 0, "Will issue %" PRIu64 " operations\n", issueCount);
 	out->verbose(CALL_INFO, 1, 0, "Request lengths: %" PRIu64 " bytes\n", reqLength);

--- a/miranda/generators/gupsgen.cc
+++ b/miranda/generators/gupsgen.cc
@@ -28,7 +28,7 @@ GUPSGenerator::GUPSGenerator( Component* owner, Params& params ) :
 	issueCount = ((uint64_t) params.find_integer("count", 1000)) * iterations;
 	reqLength  = (uint64_t) params.find_integer("length", 8);
 	maxAddr    = (uint64_t) params.find_integer("max_address", 524288);
-    seed_a     = (uint64_t) params.find_integer("seed_a", 11);
+	seed_a     = (uint64_t) params.find_integer("seed_a", 11);
 	seed_b     = (uint64_t) params.find_integer("seed_b", 31);
 	rng = new MarsagliaRNG(seed_a, seed_b);
 

--- a/miranda/generators/gupsgen.h
+++ b/miranda/generators/gupsgen.h
@@ -38,7 +38,7 @@ private:
 	uint64_t maxAddr;
 	uint64_t issueCount;
 	uint64_t iterations;
-    uint64_t seed_a;
+	uint64_t seed_a;
 	uint64_t seed_b;
 	SSTRandom* rng;
 	Output*  out;

--- a/miranda/generators/gupsgen.h
+++ b/miranda/generators/gupsgen.h
@@ -38,6 +38,8 @@ private:
 	uint64_t maxAddr;
 	uint64_t issueCount;
 	uint64_t iterations;
+    uint64_t seed_a;
+	uint64_t seed_b;
 	SSTRandom* rng;
 	Output*  out;
 	bool issueOpFences;


### PR DESCRIPTION
there're *seed_a* and *seed_b* in the params, but they're never set, so it's not actually random...