### PR TITLE
Allow Miranda::RandomGen to be seeded from input deck

### DIFF
--- a/miranda/generators/randomgen.cc
+++ b/miranda/generators/randomgen.cc
@@ -28,7 +28,9 @@ RandomGenerator::RandomGenerator( Component* owner, Params& params ) :
 	reqLength  = (uint64_t) params.find_integer("length", 8);
 	maxAddr    = (uint64_t) params.find_integer("max_address", 524288);
 
-	rng = new MarsagliaRNG(11, 31);
+	const uint64_t newSeed = (uint64_t) params.find_integer("seed", 1111);
+	rng = new MarsagliaRNG();
+        rng.seed(newSeed);
 
 	out->verbose(CALL_INFO, 1, 0, "Will issue %" PRIu64 " operations\n", issueCount);
 	out->verbose(CALL_INFO, 1, 0, "Request lengths: %" PRIu64 " bytes\n", reqLength);

--- a/miranda/miranda.cc
+++ b/miranda/miranda.cc
@@ -120,6 +120,7 @@ static const ElementInfoParam randomGen_params[] = {
     { "verbose",          "Sets the verbosity output of the generator", "0" },
     { "count",            "Count for number of items being requested", "1024" },
     { "length",           "Length of requests", "8" },
+    { "seed",             "Set the seed for the random number generator", "1111" },
     { "max_address",      "Maximum address allowed for generation", "16384" },
     { "issue_op_fences",  "Issue operation fences, \"yes\" or \"no\", default is yes", "yes" },
     { NULL, NULL, NULL }


### PR DESCRIPTION
Allow Miranda::RandomGen to be seeded from input deck using the new `seed` parameter and re-seeding capability of `SST::RNG`.