### PR TITLE
Fix Incorrect string params 

### DIFF
--- a/VaultSimC/tests/sdl1.py
+++ b/VaultSimC/tests/sdl1.py
@@ -27,7 +27,7 @@ comp_ll0.addParams({
       "vaults" : """8""",
       "terminal" : """1""",
       "llID" : """0""",
-      "LL_MASK" : """comp"""
+      "LL_MASK" : """0"""
 })
 comp_ll0.enableStatistics([
         "BW_recv_from_CPU"], {

--- a/memHierarchy/tests/sdl-1.py
+++ b/memHierarchy/tests/sdl-1.py
@@ -30,7 +30,7 @@ comp_l1cache.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "1000 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"

--- a/memHierarchy/tests/sdl-2.py
+++ b/memHierarchy/tests/sdl-2.py
@@ -21,7 +21,7 @@ comp_l1cache.addParams({
       "coherence_protocol" : "MSI",
       "associativity" : "4",
       "cache_line_size" : "32",
-      "debug" : "",
+      "debug" : "0",
       "L1" : "1",
       "LL" : "1",
       "cache_size" : "2 KB"
@@ -29,7 +29,7 @@ comp_l1cache.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "system_ini" : "system.ini",
       "clock" : "1GHz",
       "backend.access_time" : "100 ns",

--- a/memHierarchy/tests/sdl-3.py
+++ b/memHierarchy/tests/sdl-3.py
@@ -21,7 +21,7 @@ comp_l1cache.addParams({
       "coherence_protocol" : "MSI",
       "associativity" : "4",
       "cache_line_size" : "64",
-      "debug" : "",
+      "debug" : "0",
       "L1" : "1",
       "LL" : "1",
       "cache_size" : "4 KB"
@@ -29,7 +29,7 @@ comp_l1cache.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "clock" : "1GHz",
       "backend.access_time" : "100 ns",
       "request_width" : "64",

--- a/memHierarchy/tests/sdl2-1.py
+++ b/memHierarchy/tests/sdl2-1.py
@@ -43,7 +43,7 @@ comp_l2cache.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"

--- a/memHierarchy/tests/sdl3-1.py
+++ b/memHierarchy/tests/sdl3-1.py
@@ -66,7 +66,7 @@ comp_l2cache.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.mem_size" : "512",
       "printStats" : "1",
       "clock" : "1GHz",

--- a/memHierarchy/tests/sdl3-2.py
+++ b/memHierarchy/tests/sdl3-2.py
@@ -23,7 +23,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "6",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "1 KB"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
@@ -43,7 +43,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "6",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "1 KB"
 })
 comp_bus = sst.Component("bus", "memHierarchy.Bus")
@@ -59,14 +59,14 @@ comp_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "debug_level" : "6",
-      "debug" : "",
+      "debug" : "0",
       "LL" : "1",
       "cache_size" : "2 KB"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "clock" : "1GHz",
       "backend.mem_size" : "512",
       "backend.access_time" : "100 ns",

--- a/memHierarchy/tests/sdl3-3.py
+++ b/memHierarchy/tests/sdl3-3.py
@@ -23,7 +23,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "2 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
@@ -42,7 +42,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "2 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_bus = sst.Component("bus", "memHierarchy.Bus")
 comp_bus.addParams({
@@ -58,12 +58,12 @@ comp_l2cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "8 KB",
       "LL" : 1,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.mem_size" : "512",
       "printStats" : "1",
       "clock" : "1GHz",

--- a/memHierarchy/tests/sdl4-1.py
+++ b/memHierarchy/tests/sdl4-1.py
@@ -43,7 +43,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_bus = sst.Component("bus", "memHierarchy.Bus")
 comp_bus.addParams({
@@ -59,12 +59,12 @@ comp_l2cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
       "LL" : 1,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"

--- a/memHierarchy/tests/sdl4-2.py
+++ b/memHierarchy/tests/sdl4-2.py
@@ -23,7 +23,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
@@ -42,7 +42,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_bus = sst.Component("bus", "memHierarchy.Bus")
 comp_bus.addParams({
@@ -58,12 +58,12 @@ comp_l2cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
       "LL" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "clock" : "1GHz",
       "backend.mem_size" : "512",
       "backend.access_time" : "100 ns",

--- a/memHierarchy/tests/sdl5-1.py
+++ b/memHierarchy/tests/sdl5-1.py
@@ -23,7 +23,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "8",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "4 KB"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
@@ -43,7 +43,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "8",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "4 KB"
 })
 comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
@@ -59,7 +59,7 @@ comp_n0_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "debug_level" : "8",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "32 KB"
 })
 comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
@@ -79,7 +79,7 @@ comp_c2_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "8",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "4 KB"
 })
 comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
@@ -99,7 +99,7 @@ comp_c3_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "8",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "4 KB"
 })
 comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
@@ -115,7 +115,7 @@ comp_n1_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "debug_level" : "8",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "32 KB"
 })
 comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
@@ -131,14 +131,14 @@ comp_l3cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "debug_level" : "8",
-      "debug" : "",
+      "debug" : "0",
       "LL" : "1",
       "cache_size" : "64 KB"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "clock" : "1GHz",
       "backend.mem_size" : "512",
       "backend.access_time" : "1000 ns",

--- a/memHierarchy/tests/sdl8-1.py
+++ b/memHierarchy/tests/sdl8-1.py
@@ -23,7 +23,7 @@ comp_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_l2cache = sst.Component("l2cache", "memHierarchy.Cache")
 comp_l2cache.addParams({
@@ -34,7 +34,7 @@ comp_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_l3cache = sst.Component("l3cache", "memHierarchy.Cache")
 comp_l3cache.addParams({
@@ -45,7 +45,7 @@ comp_l3cache.addParams({
       "associativity" : "16",
       "cache_line_size" : "64",
       "cache_size" : "64 KB",
-      "debug" : "",
+      "debug" : "0",
       "network_address" : "1",
       "network_bw" : "25GB/s",
       "directory_at_next_level" : "1"
@@ -75,7 +75,7 @@ comp_dirctrl.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"

--- a/memHierarchy/tests/sdl8-3.py
+++ b/memHierarchy/tests/sdl8-3.py
@@ -24,7 +24,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
@@ -44,7 +44,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
 comp_n0_bus.addParams({
@@ -59,7 +59,7 @@ comp_n0_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
 comp_cpu2.addParams({
@@ -79,7 +79,7 @@ comp_c2_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
 comp_cpu3.addParams({
@@ -99,7 +99,7 @@ comp_c3_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
 comp_n1_bus.addParams({
@@ -114,7 +114,7 @@ comp_n1_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
 comp_n2_bus.addParams({
@@ -129,7 +129,7 @@ comp_l3cache.addParams({
       "associativity" : "16",
       "cache_line_size" : "64",
       "cache_size" : "64 KB",
-      "debug" : "",
+      "debug" : "0",
       "network_address" : "1",
       "network_bw" : "25GB/s",
       "directory_at_next_level" : "1"
@@ -148,7 +148,7 @@ comp_chiprtr.addParams({
 comp_dirctrl = sst.Component("dirctrl", "memHierarchy.DirectoryController")
 comp_dirctrl.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "network_address" : "0",
       "entry_cache_size" : "32768",
       "network_bw" : "25GB/s",
@@ -158,7 +158,7 @@ comp_dirctrl.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "backend.mem_size" : "512",
       "clock" : "1GHz",

--- a/memHierarchy/tests/sdl8-4.py
+++ b/memHierarchy/tests/sdl8-4.py
@@ -24,7 +24,7 @@ comp_c0_l1cache.addParams({
       "cache_size" : "4 KB",
       "L1" : "1",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
@@ -44,7 +44,7 @@ comp_c1_l1cache.addParams({
       "cache_size" : "4 KB",
       "L1" : "1",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
 comp_n0_bus.addParams({
@@ -60,7 +60,7 @@ comp_n0_l2cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
 comp_cpu2.addParams({
@@ -80,7 +80,7 @@ comp_c2_l1cache.addParams({
       "cache_size" : "4 KB",
       "L1" : "1",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
 comp_cpu3.addParams({
@@ -100,7 +100,7 @@ comp_c3_l1cache.addParams({
       "cache_size" : "4 KB",
       "L1" : "1",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
 comp_n1_bus.addParams({
@@ -116,7 +116,7 @@ comp_n1_l2cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
       "debug_level" : 10,
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
 comp_n2_bus.addParams({
@@ -132,7 +132,7 @@ comp_l3cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "64 KB",
       "debug_level" : 10,
-      "debug" : "",
+      "debug" : "0",
       "network_address" : "1",
       "network_bw" : "25GB/s",
       "directory_at_next_level" : "1"
@@ -151,7 +151,7 @@ comp_chiprtr.addParams({
 comp_dirctrl = sst.Component("dirctrl", "memHierarchy.DirectoryController")
 comp_dirctrl.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "debug_level" : 10,
       "network_address" : "0",
       "entry_cache_size" : "1024",
@@ -163,7 +163,7 @@ comp_dirctrl.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512",

--- a/memHierarchy/tests/sdl9-1.py
+++ b/memHierarchy/tests/sdl9-1.py
@@ -25,7 +25,7 @@ comp_l1cache.addParams({
       "cache_line_size" : "64",
       "debug_level" : "8",
       "L1" : "1",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "4 KB"
 })
 comp_l2cache = sst.Component("l2cache", "memHierarchy.Cache")
@@ -37,7 +37,7 @@ comp_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "debug_level" : "8",
-      "debug" : "",
+      "debug" : "0",
       "cache_size" : "32 KB"
 })
 comp_l3cache = sst.Component("l3cache", "memHierarchy.Cache")
@@ -49,14 +49,14 @@ comp_l3cache.addParams({
       "associativity" : "16",
       "cache_line_size" : "64",
       "debug_level" : "8",
-      "debug" : "",
+      "debug" : "0",
       "LL" : 1,
       "cache_size" : "64 KB"
 })
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"

--- a/memHierarchy/tests/sdl9-2.py
+++ b/memHierarchy/tests/sdl9-2.py
@@ -25,7 +25,7 @@ comp_c0_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
@@ -46,7 +46,7 @@ comp_c1_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
 comp_cpu2.addParams({
@@ -67,7 +67,7 @@ comp_c2_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
 comp_cpu3.addParams({
@@ -88,7 +88,7 @@ comp_c3_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
 comp_n0_bus.addParams({
@@ -103,7 +103,7 @@ comp_n0_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu4 = sst.Component("cpu4", "memHierarchy.trivialCPU")
 comp_cpu4.addParams({
@@ -124,7 +124,7 @@ comp_c4_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu5 = sst.Component("cpu5", "memHierarchy.trivialCPU")
 comp_cpu5.addParams({
@@ -145,7 +145,7 @@ comp_c5_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu6 = sst.Component("cpu6", "memHierarchy.trivialCPU")
 comp_cpu6.addParams({
@@ -166,7 +166,7 @@ comp_c6_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_cpu7 = sst.Component("cpu7", "memHierarchy.trivialCPU")
 comp_cpu7.addParams({
@@ -187,7 +187,7 @@ comp_c7_l1cache.addParams({
       "cache_line_size" : "64",
       "cache_size" : "4 KB",
       "L1" : "1",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
 comp_n1_bus.addParams({
@@ -202,7 +202,7 @@ comp_n1_l2cache.addParams({
       "associativity" : "8",
       "cache_line_size" : "64",
       "cache_size" : "32 KB",
-      "debug" : ""
+      "debug" : "0"
 })
 comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
 comp_n2_bus.addParams({
@@ -236,7 +236,7 @@ comp_chiprtr.addParams({
 comp_dirctrl = sst.Component("dirctrl", "memHierarchy.DirectoryController")
 comp_dirctrl.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "network_address" : "0",
       "entry_cache_size" : "8192",
       "network_bw" : "25GB/s",
@@ -247,7 +247,7 @@ comp_dirctrl.addParams({
 comp_memory = sst.Component("memory", "memHierarchy.MemController")
 comp_memory.addParams({
       "coherence_protocol" : "MSI",
-      "debug" : "",
+      "debug" : "0",
       "backend.access_time" : "100 ns",
       "clock" : "1GHz",
       "backend.mem_size" : "512"


### PR DESCRIPTION
Fixing params that are strings going into integers that is being used by new core params code.  Any empty string or invalid value will now throw an exception.  Old code would just return 0.