### PR TITLE
Ariel - Remove Malloc-based Page Allocation

### DIFF
--- a/ariel/arielcore.cc
+++ b/ariel/arielcore.cc
@@ -519,7 +519,8 @@ void ArielCore::handleAllocationEvent(ArielAllocateEvent* aEv) {
 	output->verbose(CALL_INFO, 2, 0, "Handling a memory allocation event, vAddr=%" PRIu64 ", length=%" PRIu64 ", at level=%" PRIu32 " with malloc ID=%" PRIu64 "\n",
                         aEv->getVirtualAddress(), aEv->getAllocationLength(), aEv->getAllocationLevel(), aEv->getInstructionPointer());
 
-	memmgr->allocate(aEv->getAllocationLength(), aEv->getAllocationLevel(), aEv->getVirtualAddress());
+	// Remove because we can rely on on-demand page allocation
+	// memmgr->allocate(aEv->getAllocationLength(), aEv->getAllocationLevel(), aEv->getVirtualAddress());
 
         if (allocLink) {
 	  output->verbose(CALL_INFO, 2, 0, " Sending memory allocation event to allocate monitor\n");


### PR DESCRIPTION
Now utilize on-demand page allocation to reduce memory consumption.