### PR TITLE
Ember - Fix Error in Fatal Call where Tool is Named Incorrectly

### DIFF
--- a/ember/mpi/motifs/ember3damr.cc
+++ b/ember/mpi/motifs/ember3damr.cc
@@ -84,7 +84,7 @@ void Ember3DAMRGenerator::loadBlocks() {
 	}
     } else {
 //        amrFile = new EmberAMRTextFile(blockFilePath, out);
-	out->fatal(CALL_INFO, -1, "Binary mesh files are the only type currently supported, use ssh-meshconvert\n");
+	out->fatal(CALL_INFO, -1, "Binary mesh files are the only type currently supported, use sst-meshconvert\n");
     }
 
 	maxLevel   = amrFile->getMaxRefinement();


### PR DESCRIPTION
Fixes a bug in Ember where `ssh-meshconvert` is printed to screen when `sst-meshconvert` is correct name of tool. This caused user confusion because the tool name being printed could not be found. Should address Issue #293.