### PR TITLE
Added relative global route mode.

### DIFF
--- a/merlin/merlin.cc
+++ b/merlin/merlin.cc
@@ -387,6 +387,7 @@ static const ElementInfoParam dragonfly2_params[] = {
     {"dragonfly:algorithm","Routing algorithm to use [minmal (default) | valiant].", "minimal"},
     {"dragonfly:adaptive_threshold","Threshold to use when make adaptive routing decisions.", "2.0"},
     {"dragonfly:global_link_map","Array specifying connectivity of global links in each dragonfly group."},
+    {"dragonfly:global_route_mode","Mode for intepreting global link map [absolute (default) | relative].","absolute"},
     {NULL,NULL,NULL}
 };
 

--- a/merlin/topology/dragonfly2.h
+++ b/merlin/topology/dragonfly2.h
@@ -49,7 +49,7 @@ private:
     SharedRegion* region;
     size_t groups;
     size_t routes;
-
+    
     
 public:
     RouteToGroup() {}
@@ -96,6 +96,9 @@ class topo_dragonfly2: public Topology {
     int const* output_credits;
     int num_vcs;
     
+    enum global_route_mode_t { ABSOLUTE, RELATIVE };
+    global_route_mode_t global_route_mode;
+
 public:
     struct dgnfly2Addr {
         uint32_t group;


### PR DESCRIPTION
The new relative global route mode interprets the global
link map differently.  Numbers in the link map are taken
as relative offsets from the current group, instead of as
an absolute number with the current group removed.  The
translation from global link map entry to raw group number
and global slice is the same for both modes.  However, the
raw group numbers are converted to actual group number
differently.