### PR TITLE
Fix Makefile.am files Needed for Out-of-Source Builds to Work Correctly

### DIFF
--- a/src/sst/elements/VaultSimC/Makefile.am
+++ b/src/sst/elements/VaultSimC/Makefile.am
@@ -27,7 +27,7 @@ libVaultSimC_la_SOURCES = \
 	vaultGlobals.h
 
 libVaultSimC_la_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
-	$(LIBPHX_CPPFLAGS)
+	$(LIBPHX_CPPFLAGS) -I$(top_srcdir)/src
 libVaultSimC_la_LDFLAGS = -module -avoid-version \
 	$(LIBPHX_LDFLAGS) $(LIBPHX_LIBDIR) 
 libVaultSimC_la_LIBADD = $(LIBPHX_LIB)

--- a/src/sst/elements/cassini/Makefile.am
+++ b/src/sst/elements/cassini/Makefile.am
@@ -4,7 +4,8 @@
 
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
-	$(MPI_CPPFLAGS) 
+	$(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libcassini.la

--- a/src/sst/elements/ember/Makefile.am
+++ b/src/sst/elements/ember/Makefile.am
@@ -2,7 +2,8 @@
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
 	$(MPI_CPPFLAGS) \
-	-I$(top_srcdir)/src/sst/elements/ember/sirius/include
+	-I$(top_srcdir)/src/sst/elements/ember/sirius/include \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libember.la

--- a/src/sst/elements/firefly/Makefile.am
+++ b/src/sst/elements/firefly/Makefile.am
@@ -2,7 +2,8 @@
 #
 #
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS)
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libfirefly.la

--- a/src/sst/elements/hermes/Makefile.am
+++ b/src/sst/elements/hermes/Makefile.am
@@ -4,7 +4,8 @@
 
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
-	$(MPI_CPPFLAGS) 
+	$(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libhermes.la

--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -4,8 +4,7 @@
 
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
-	-g
-
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libmemHierarchy.la

--- a/src/sst/elements/merlin/Makefile.am
+++ b/src/sst/elements/merlin/Makefile.am
@@ -2,7 +2,9 @@
 #
 #
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) $(PYTHON_CPPFLAGS) $(CPPFLAGS)
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
+	$(PYTHON_CPPFLAGS) $(CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libmerlin.la

--- a/src/sst/elements/miranda/Makefile.am
+++ b/src/sst/elements/miranda/Makefile.am
@@ -1,7 +1,8 @@
 
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
-	$(MPI_CPPFLAGS) 
+	$(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libmiranda.la

--- a/src/sst/elements/savannah/Makefile.am
+++ b/src/sst/elements/savannah/Makefile.am
@@ -1,7 +1,8 @@
 
 AM_CPPFLAGS = \
         $(BOOST_CPPFLAGS) \
-        $(MPI_CPPFLAGS)
+        $(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libsavannah.la

--- a/src/sst/elements/thornhill/Makefile.am
+++ b/src/sst/elements/thornhill/Makefile.am
@@ -2,7 +2,8 @@
 #
 #
 
-AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS)
+AM_CPPFLAGS = $(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libthornhill.la

--- a/src/sst/elements/zodiac/Makefile.am
+++ b/src/sst/elements/zodiac/Makefile.am
@@ -4,12 +4,14 @@
 
 AM_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
-	$(MPI_CPPFLAGS)
+	$(MPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 libzodiac_la_CPPFLAGS = \
 	$(BOOST_CPPFLAGS) \
 	$(MPI_CPPFLAGS) \
-	$(DUMPI_CPPFLAGS)
+	$(DUMPI_CPPFLAGS) \
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libzodiac.la


### PR DESCRIPTION
Modifies several `Makefile.am` files so that the elements build can be performed "out-of-source".