### PR TITLE
all the Makefile AM changes

### DIFF
--- a/src/sst/elements/ember/Makefile.am
+++ b/src/sst/elements/ember/Makefile.am
@@ -33,6 +33,7 @@ libember_la_SOURCES = \
 	emberdetailedcomputeev.h \
 	embermotiflog.h \
 	embermotiflog.cc \
+	embermemoryev.h \
 	mpi/embermpigen.h \
 	mpi/embermpigen.cc \
 	mpi/emberrecvev.h \

--- a/src/sst/elements/firefly/Makefile.am
+++ b/src/sst/elements/firefly/Makefile.am
@@ -19,6 +19,9 @@ libfirefly_la_SOURCES = \
 	ctrlMsgXXX.h \
 	ctrlMsgFunctors.h \
 	ctrlMsgProcessQueuesState.h \
+	heapAddrs.h \
+	ioapi.h \
+	nicTester.h \
 	mem.h \
 	latencyMod.h \
 	rangeLatMod.h \

--- a/src/sst/elements/thornhill/Makefile.am
+++ b/src/sst/elements/thornhill/Makefile.am
@@ -15,6 +15,9 @@ libthornhill_la_SOURCES = \
 	memoryHeap.cc\
 	memoryHeapLink.h\
 	singleThread.h\
-	singleThread.cc
+	memoryHeapEvent.h\
+	memoryHeapLink.h\
+	singleThread.cc\
+	types.h
 
 libthornhill_la_LDFLAGS = -module -avoid-version


### PR DESCRIPTION
Add the header files to the Makefile.am files.    It's been a while since make-dist has run to look at the unemerated, but required header files.