### PR TITLE
Print helpful messages when ArielCommand decode fails.

### DIFF
--- a/src/sst/elements/ariel/arielcore.cc
+++ b/src/sst/elements/ariel/arielcore.cc
@@ -322,7 +322,7 @@ bool ArielCore::refillQueue() {
 
                 default:
                     // Not sure what this is
-                    assert(0);
+		    output->fatal(CALL_INFO, -1, "Error: Ariel did not understand command (%d) provided during instruction queue refill.\n", (int)(ac.command));
                     break;
                 }
             }
@@ -353,7 +353,7 @@ bool ArielCore::refillQueue() {
             break;
         default:
             // Not sure what this is
-            assert(0);
+	    output->fatal(CALL_INFO, -1, "Error: Ariel did not understand command (%d) provided during instruction queue refill.\n", (int)(ac.command));
             break;
         }
     }


### PR DESCRIPTION
Prints an error message when an `ArielCommand` decode fails rather than asserts. @gvoskuilen has encountered some issues with the very latest Ariel.