### PR TITLE
Remove references to SimpleNetwork::Mapping.

### DIFF
--- a/src/sst/elements/merlin/test/nic.cc
+++ b/src/sst/elements/merlin/test/nic.cc
@@ -108,8 +108,6 @@ void nic::setup()
     if ( !initialized ) {
         output.output("Nic %d: Broadcast failed!\n", id);
     }
-
-    net_map.bind("global");
 }
 
 void

--- a/src/sst/elements/merlin/test/nic.h
+++ b/src/sst/elements/merlin/test/nic.h
@@ -53,7 +53,6 @@ private:
     int *next_seq;
 
     int remap;
-    SST::Interfaces::SimpleNetwork::Mapping net_map;
 
     Output& output;
     

--- a/src/sst/elements/merlin/test/simple_patterns/shift.h
+++ b/src/sst/elements/merlin/test/simple_patterns/shift.h
@@ -53,7 +53,6 @@ private:
     SST::Interfaces::SimpleNetwork* link_control;
 
     int remap;
-    SST::Interfaces::SimpleNetwork::Mapping net_map;
 
     Output& output;
     


### PR DESCRIPTION
This functionality has been replace by ShareRegion.