### PR TITLE
Fix pymerlin nickeys

### DIFF
--- a/src/sst/elements/merlin/pymerlin.py
+++ b/src/sst/elements/merlin/pymerlin.py
@@ -885,6 +885,7 @@ class TrafficGenEndPoint(EndPoint):
     def build(self, nID, extraKeys):
         nic = sst.Component("TrafficGen.%d"%nID, "merlin.trafficgen")
         nic.addParams(_params.subset(self.epKeys, self.epOptKeys))
+        nic.addParams(_params.subset(self.nicKeys))
         nic.addParams(_params.subset(extraKeys, {}))
         #for k in self.optionalKeys:
         #    if k in _params:

--- a/src/sst/elements/merlin/pymerlin.py
+++ b/src/sst/elements/merlin/pymerlin.py
@@ -881,6 +881,13 @@ class TrafficGenEndPoint(EndPoint):
         elif _params["PacketDest:pattern"] == "Binomial":
             self.nicKeys.append("PacketDest:Binomial:Mean")
             self.nicKeys.append("PacketDest:Binomial:Sigma")
+        elif _params["PacketDest:pattern"] == "Exponential":
+            self.nicKeys.append("PacketDest:Exponential:Lambda")
+        elif _params["PacketDest:pattern"] == "Uniform":
+            pass
+        else:
+            print "Unknown pattern" + _params["PacketDest:pattern"]
+            sys.exit(1)
 
     def build(self, nID, extraKeys):
         nic = sst.Component("TrafficGen.%d"%nID, "merlin.trafficgen")


### PR DESCRIPTION
In pymerlin module, the *TrafficGenEndPoint* class has a *nicKeys* variable that is used to hold the keys for traffic generators, it was set based on different patterns but it was never used. As a result, some of the params for certain traffic patterns will be missing, especially for those who doesn't have a default params, such as *HotSpot*.

In commit 0c20626 I added it to the *build* method so that it will ask for user input for missing params of the traffic pattern. 

In commit cb92912 I expanded the pattern check with *Exponential* pattern, which is present in *merlin/trafficgen/traficgen.cc* but was not in the pymerlin module.

