### PR TITLE
Prospero PIN Change to use Child Injection Instrumentation

### DIFF
--- a/src/sst/elements/prospero/runprosperotrace.cc
+++ b/src/sst/elements/prospero/runprosperotrace.cc
@@ -200,7 +200,7 @@ int main(int argc, char* argv[]) {
 
 		execParams.push_back(appParams[0]);
 		execParams.push_back("-injection");
-		execParams.push_back("dynamic");
+		execParams.push_back("child");
 
 		for(auto i = 1; i < appParams.size(); ++i) {
 			// Before we copy in the application parameters, we need to copy in the


### PR DESCRIPTION
Switches over Prospero to use `-injection child` instrumentation.