### PR TITLE
Eliminates use of *_MAX in favor of std::numeric_limits<type>::max()

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/pagedMultiBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/pagedMultiBackend.cc
@@ -11,6 +11,9 @@
 
 
 #include <sst_config.h>
+
+#include <limits>
+
 #include "membackend/pagedMultiBackend.h"
 #include "sst/core/rng/mersenne.h"
 #include "sst/core/timeLord.h" // is this allowed?
@@ -313,7 +316,7 @@ void pagedMultiMemory::do_LFU(DRAMReq *req, pageInfo &page, bool &inFast, bool &
             if (maxFastPages > 0) {
 	      if(page.touched > lastMin) {
                 // we're full, search for someone to bump
-	        lastMin = UINT_MAX;
+	        lastMin = std::numeric_limits<uint>::max(); // UINT_MAX;
 	        const auto endP = pageMap.end();
                 bool found = 0;
                 for (auto p = pageMap.begin(); p != endP; ++p) {

--- a/src/sst/elements/scheduler/allocators/BestFitAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/BestFitAllocator.cc
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include <string>
+#include <limits>
 #include <stdio.h>
 
 #include "AllocInfo.h"
@@ -66,7 +67,7 @@ AllocInfo* BestFitAllocator::allocate(Job* job)
 
     int bestInterval = -1;  //index of best interval found so far
     //(-1 = none)
-    int bestSize = INT_MAX;  //its size
+    int bestSize = std::numeric_limits<int>::max(); //its size
 
     //look for smallest sufficiently-large interval
     for (int i = 0; i < (int)intervals -> size(); i++) {


### PR DESCRIPTION
Eliminate use of TYPENAME_MAX macros from C in favor of using std::numeric_limits<type>::max() calls which ensure better compliance with C++11.