### PR TITLE
Remove Boost Serialization references

### DIFF
--- a/src/sst/elements/pyproto/pyarchive.cc
+++ b/src/sst/elements/pyproto/pyarchive.cc
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include <sst/core/event.h>
+#include <sst/core/serialization/serialize.h>
 
 #include "pymodule.h"
 #include "pyproto.h"
@@ -30,12 +31,14 @@ PyEvent_t *convertEventToPython(SST::Event *event)
     if ( pe ) {
         return pe->getPyObj();
     } else {
+#if 0
         PyEvent_t *out = NULL;
         polymorphic_PyEvent_oarchive oa(std::cout, boost::archive::no_header|boost::archive::no_codecvt);
 
         oa << event;
 
         return oa.getEvent();
+#endif
     }
     return NULL;
 }

--- a/src/sst/elements/pyproto/pyarchive.h
+++ b/src/sst/elements/pyproto/pyarchive.h
@@ -16,9 +16,15 @@
 #include <numeric>
 
 #include <cstddef>
+
+#include <sst/core/serialization/serializer.h>
+
+
+#if 0
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/detail/common_oarchive.hpp>
 #include <boost/archive/detail/polymorphic_oarchive_route.hpp>
+#endif
 
 #include "pymodule.h"
 #include "pyproto.h"
@@ -26,6 +32,7 @@
 namespace SST {
 namespace PyProtoNS {
 
+#if 0
 class PyEvent_oarchive : public boost::archive::detail::common_oarchive<PyEvent_oarchive>
 {
     // permit serialization system privileged access to permit
@@ -174,9 +181,13 @@ public:
 
 typedef boost::archive::detail::polymorphic_oarchive_route<PyEvent_oarchive> polymorphic_PyEvent_oarchive;
 
+#endif
 }
 }
 
+#if 0
 BOOST_SERIALIZATION_REGISTER_ARCHIVE(
     SST::PyProtoNS::polymorphic_PyEvent_oarchive
 )
+
+#endif

--- a/src/sst/elements/pyproto/pyproto.h
+++ b/src/sst/elements/pyproto/pyproto.h
@@ -37,12 +37,13 @@ private:
     PyEvent_t *pyE;
 	PyEvent() {} // For serialization only
 
-public:	
+public:
     void serialize_order(SST::Core::Serialization::serializer &ser) {
         Event::serialize_order(ser);
+        // TODO:  Serialize pyE
     }
-    
-    ImplementSerializable(SST::PyProtoNS::PyEvent);     
+
+    ImplementSerializable(SST::PyProtoNS::PyEvent);
 };
 
 


### PR DESCRIPTION

PyProto no longer supports translating SST Events into Python objects.
Hopefully this will return at some point with a new serialization
mechanism.