### PR TITLE
Scheduler - Fix Missing Header Files for Serialization

### DIFF
--- a/src/sst/elements/scheduler/allocators/GranularMBSAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/GranularMBSAllocator.cc
@@ -22,7 +22,8 @@
 #include <vector>
 #include <string>
 #include <set>
-#include <stdio.h>
+#include <cstdio>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/allocators/LinearAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/LinearAllocator.cc
@@ -28,7 +28,8 @@
 #include <set>
 #include <vector>
 #include <string>
-#include <stdio.h>
+#include <algorithm>
+#include <cstdio>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/allocators/MBSAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/MBSAllocator.cc
@@ -19,8 +19,9 @@
 #include "MBSAllocator.h"
 
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/allocators/OctetMBSAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/OctetMBSAllocator.cc
@@ -18,11 +18,12 @@
 #include "sst_config.h"
 #include "OctetMBSAllocator.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <sstream>
-#include <time.h>
-#include <math.h>
+#include <ctime>
+#include <cmath>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/allocators/RoundUpMBSAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/RoundUpMBSAllocator.cc
@@ -18,11 +18,12 @@
 #include "sst_config.h"
 #include "RoundUpMBSAllocator.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
 #include <sstream>
-#include <time.h>
-#include <math.h>
+#include <ctime>
+#include <cmath>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/allocators/SortedFreeListAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/SortedFreeListAllocator.cc
@@ -18,7 +18,8 @@
 
 #include <vector>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/schedulers/EASYScheduler.cc
+++ b/src/sst/elements/scheduler/schedulers/EASYScheduler.cc
@@ -22,7 +22,8 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <stdio.h>
+#include <cstdio>
+#include <cmath>
 
 #include <iostream> //debug
 

--- a/src/sst/elements/scheduler/schedulers/PQScheduler.cc
+++ b/src/sst/elements/scheduler/schedulers/PQScheduler.cc
@@ -20,6 +20,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "Job.h"
 #include "Machine.h"

--- a/src/sst/elements/scheduler/schedulers/StatefulScheduler.cc
+++ b/src/sst/elements/scheduler/schedulers/StatefulScheduler.cc
@@ -19,8 +19,9 @@
 
 #include <functional>
 #include <set>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
+#include <cmath>
 
 #include "Job.h"
 #include "Machine.h"

--- a/src/sst/elements/scheduler/taskMappers/TopoMapper.cc
+++ b/src/sst/elements/scheduler/taskMappers/TopoMapper.cc
@@ -18,10 +18,11 @@
 #endif
 #include "Rcm.h"
 
-#include <assert.h>
+#include <cassert>
 #include <climits>
 #include <numeric>
 #include <vector>
+#include <cmath>
 
 #include "AllocInfo.h"
 #include "Job.h"


### PR DESCRIPTION
Added `#include` for `cmath` and `algorithm`.

Exposed by serialization changes in core.