### PR TITLE
Scheduler Fix for Missing Algorithm Includes

### DIFF
--- a/src/sst/elements/scheduler/taskMappers/TopoMapper.cc
+++ b/src/sst/elements/scheduler/taskMappers/TopoMapper.cc
@@ -23,6 +23,7 @@
 #include <numeric>
 #include <vector>
 #include <cmath>
+#include <algorithm>
 
 #include "AllocInfo.h"
 #include "Job.h"


### PR DESCRIPTION
Fix to Scheduler to address missing algorithm `#include`.
