### PR TITLE
Ariel fix ptracing

### DIFF
--- a/config/sst_check_ptrace_set_tracer.m4
+++ b/config/sst_check_ptrace_set_tracer.m4
@@ -1,0 +1,32 @@
+AC_DEFUN([SST_CHECK_PTRACE_SET_TRACER],
+[
+  sst_check_ptrace_set_tracer_happy="yes"
+
+  CPPFLAGS_saved="$CPPFLAGS"
+  LDFLAGS_saved="$LDFLAGS"
+
+  AC_LANG_PUSH([C++])
+  AC_COMPILE_IFELSE(
+  	[AC_LANG_PROGRAM([[#include <sys/prctl.h>
+  	#include <sys/types.h>
+  	#include <unistd.h>]],
+        [[
+        	prctl(PR_SET_PTRACER, getppid(), 0, 0, 0);
+        ]])],
+        [],
+        [sst_check_ptrace_set_tracer_happy="no"])
+  
+  AC_LANG_POP([C++])
+
+  CPPFLAGS="$CPPFLAGS_saved"
+  LDFLAGS="$LDFLAGS_saved"
+
+  AS_IF([test "x$sst_check_ptrace_set_tracer_happy" = "xyes"],
+  	[HAVE_SET_PTRACER=1], [HAVE_SET_PTRACER=0])
+
+  AC_SUBST([HAVE_SET_PTRACER])
+  AM_CONDITIONAL([HAVE_SET_PTRACER], [test "x$sst_check_ptrace_set_tracer_happy" = "xyes"])
+
+  AC_MSG_CHECKING([for for PR_SET_PTRACER])
+  AC_MSG_RESULT([$sst_check_ptrace_set_tracer_happy])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,8 @@ AC_SUBST(CC_VERSION)
 MPICC_VERSION=`$MPICC --version | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/%/g' | awk -F'%' '{print $1}'`
 AC_SUBST(MPICC_VERSION)
 
+SST_CHECK_PTRACE_SET_TRACER()
+
 AC_CONFIG_FILES([
   Makefile
   src/Makefile

--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -4,6 +4,10 @@ AM_CPPFLAGS = \
         $(MPI_CPPFLAGS) \
         $(PINTOOL_CPPFLAGS)
 
+if HAVE_SET_PTRACER
+	AM_CPPFLAGS += "-DHAVE_SET_PTRACER=1"
+endif
+
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libariel.la
 libariel_la_SOURCES = \

--- a/src/sst/elements/ariel/arielcpu.cc
+++ b/src/sst/elements/ariel/arielcpu.cc
@@ -456,10 +456,11 @@ int ArielCPU::forkPINChild(const char* app, char** args, std::map<std::string, s
 	            		setenv("PIN_DYLD_RESTORE_REQUIRED", "t", 1);
 	            		unsetenv("DYLD_LIBRARY_PATH");
 	       	 	}
-#endif
-#if !defined(SST_COMPILE_MACOSX)
+#else
+#if defined(HAVE_SET_PTRACER)
                         prctl(PR_SET_PTRACER, getppid(), 0, 0 ,0);
-#endif
+#endif // End of HAVE_SET_PTRACER
+#endif // End SST_COMPILE_MACOSX (else branch)
 			int ret_code = execvp(app, args);
 			perror("execve");
 

--- a/src/sst/elements/ariel/configure.m4
+++ b/src/sst/elements/ariel/configure.m4
@@ -4,6 +4,7 @@ AC_DEFUN([SST_ariel_CONFIG], [
   sst_check_ariel="yes"
 
   SST_CHECK_PINTOOL([have_pin=1],[have_pin=0],[AC_MSG_ERROR([PIN was requested but not found])])
+  SST_CHECK_PTRACE_SET_TRACER()
 
   AS_IF( [test "$have_pin" = 1], [sst_check_ariel="yes"], [sst_check_ariel="no"] )
   AS_IF([test "$sst_check_ariel" = "yes"], [$1], [$2])


### PR DESCRIPTION
Adds configure time detection of whether `PR_SET_PTRACER` is defined since this is not available on kernels older than Linux 3.X. If not detected then Ariel will ignore this code.