### PR TITLE
Fix alignment in Makefile.am

### DIFF
--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = \
         $(PINTOOL_CPPFLAGS)
 
 if HAVE_SET_PTRACER
-	AM_CPPFLAGS += "-DHAVE_SET_PTRACER=1"
+AM_CPPFLAGS += "-DHAVE_SET_PTRACER=1"
 endif
 
 compdir = $(pkglibdir)


### PR DESCRIPTION
Leading Tab in Makefile.am  causes undesired change in meaning