### PR TITLE
Solved a compilation issue in Archlinux

### DIFF
--- a/src/sst/elements/scheduler/DragonflyMachine.cc
+++ b/src/sst/elements/scheduler/DragonflyMachine.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <cmath>
 
 using namespace SST::Scheduler;
 using namespace std;

--- a/src/sst/elements/scheduler/StencilMachine.cc
+++ b/src/sst/elements/scheduler/StencilMachine.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <cmath>
 
 #include "AllocInfo.h"
 #include "Job.h"

--- a/src/sst/elements/scheduler/Torus3DMachine.cc
+++ b/src/sst/elements/scheduler/Torus3DMachine.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <cmath>
 
 using namespace SST::Scheduler;
 


### PR DESCRIPTION
Solution to issue #424.
In archlinux the compiler did not find the math library functions. Added an include in files with issue.