### PR TITLE
Fix SST-Info renaming in MemHierarchy Stats Messages

### DIFF
--- a/src/sst/elements/memHierarchy/cacheFactory.cc
+++ b/src/sst/elements/memHierarchy/cacheFactory.cc
@@ -236,7 +236,7 @@ Cache::Cache(ComponentId_t id, Params &params, CacheConfig config) : Component(i
   
     if (stats != 0) {
         SST::Output outputStd("",1,0,SST::Output::STDOUT);
-        outputStd.output("%s, **WARNING** The 'statistics' parameter is deprecated: memHierarchy statistics have been moved to the Statistics API. Please see sstinfo for available statistics and update your configuration accordingly.\nNO statistics will be printed otherwise!\n", this->Component::getName().c_str());
+        outputStd.output("%s, **WARNING** The 'statistics' parameter is deprecated: memHierarchy statistics have been moved to the Statistics API. Please see sst-info for available statistics and update your configuration accordingly.\nNO statistics will be printed otherwise!\n", this->Component::getName().c_str());
     }
 
 

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -42,7 +42,7 @@ DirectoryController::DirectoryController(ComponentId_t id, Params &params) :
     Output out("", 1, 0, Output::STDOUT);
     params.find<int>("statistics", 0, found);
     if (found) {
-        out.output("%s, **WARNING** ** Found deprecated parameter: statistics **  memHierarchy statistics have been moved to the Statistics API. Please see sstinfo to view available statistics and update your input deck accordingly.\nNO statistics will be printed otherwise! Remove this parameter from your deck to eliminate this message.\n", getName().c_str());
+        out.output("%s, **WARNING** ** Found deprecated parameter: statistics **  memHierarchy statistics have been moved to the Statistics API. Please see sst-info to view available statistics and update your input deck accordingly.\nNO statistics will be printed otherwise! Remove this parameter from your deck to eliminate this message.\n", getName().c_str());
     }
     params.find<int>("direct_mem_link", 0, found);
     if (found) {

--- a/src/sst/elements/memHierarchy/memoryController.cc
+++ b/src/sst/elements/memHierarchy/memoryController.cc
@@ -60,7 +60,7 @@ MemController::MemController(ComponentId_t id, Params &params) : Component(id) {
     bool found;
     params.find<int>("statistics", 0, found);
     if (found) {
-        out.output("%s, **WARNING** ** Found deprecated parameter: statistics **  memHierarchy statistics have been moved to the Statistics API. Please see sstinfo to view available statistics and update your input deck accordingly.\nNO statistics will be printed otherwise! Remove this parameter from your deck to eliminate this message.\n", getName().c_str());
+        out.output("%s, **WARNING** ** Found deprecated parameter: statistics **  memHierarchy statistics have been moved to the Statistics API. Please see sst-info to view available statistics and update your input deck accordingly.\nNO statistics will be printed otherwise! Remove this parameter from your deck to eliminate this message.\n", getName().c_str());
     }
     params.find<int>("mem_size", 0, found);
     if (found) {


### PR DESCRIPTION
Fixes an issue (#433) which is caused by the renaming of `sstinfo` to `sst-info` for consistency across SST binaries.