### PR TITLE
Fix MemHierarchy Compiler Warnings with Printf and Minor Code Errors

### DIFF
--- a/src/sst/elements/memHierarchy/cacheFactory.cc
+++ b/src/sst/elements/memHierarchy/cacheFactory.cc
@@ -599,7 +599,7 @@ void Cache::intrapolateMSHRLatency() {
     }
     mshrLatency_ = y[accessLatency_];
 
-    d2_->verbose(CALL_INFO, 1, 0, "%s: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to %u cycles.\n", getName().c_str(), mshrLatency_);
+    d2_->verbose(CALL_INFO, 1, 0, "%s: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to %" PRIu64 " cycles.\n", getName().c_str(), mshrLatency_);
 }
 
 }}

--- a/src/sst/elements/memHierarchy/membackend/delayBuffer.cc
+++ b/src/sst/elements/memHierarchy/membackend/delayBuffer.cc
@@ -37,7 +37,7 @@ DelayBuffer::DelayBuffer(Component *comp, Params &params) : MemBackend(comp, par
     if (delay.getRoundedValue() == 0) {
         delay_self_link = ctrl->configureSelfLink("DelaySelfLink", delay.toString(), new Event::Handler<DelayBuffer>(this, &DelayBuffer::handleNextRequest));
     } else {
-        delay_self_link == NULL;
+        delay_self_link = NULL;
     }
 }
 

--- a/src/sst/elements/memHierarchy/memoryController.cc
+++ b/src/sst/elements/memHierarchy/memoryController.cc
@@ -144,7 +144,7 @@ MemController::MemController(ComponentId_t id, Params &params) : Component(id) {
     // Convert into MBs
     memSize_ = backendRamSize.getRoundedValue();
     if (memSize_ % cacheLineSize_ != 0) {
-        dbg.fatal(CALL_INFO, -1, "Invalid param(%s): backend.mem_size - must be a multiple of request_size. Note: use 'MB' for base-10 and 'MiB' for base-2. Please change one of these parameters. You specified backend.mem_size='%s' and request_size='%d' B\n", getName().c_str(), backendRamSize.toString().c_str(), cacheLineSize_);
+        dbg.fatal(CALL_INFO, -1, "Invalid param(%s): backend.mem_size - must be a multiple of request_size. Note: use 'MB' for base-10 and 'MiB' for base-2. Please change one of these parameters. You specified backend.mem_size='%s' and request_size='%" PRIu64 "' B\n", getName().c_str(), backendRamSize.toString().c_str(), cacheLineSize_);
     }
 
     // Check interleave parameters


### PR DESCRIPTION
Fixes a series of compiler warnings and minor code errors in MemHierarchy. These appear on Mac when using clang.