### PR TITLE
Allevin/cleanup cramsim

### DIFF
--- a/src/sst/elements/CramSim/c_Bank.cpp
+++ b/src/sst/elements/CramSim/c_Bank.cpp
@@ -31,181 +31,181 @@ unsigned c_Bank::k_banks = 0;
 c_Bank::c_Bank(SST::Params& x_params) {
 	// read params here
 
-/*	k_nRC = x_params.find_integer("nRC", 55, l_found);
+/*	k_nRC = (uint32_t)x_params.find<uint32_t>("nRC", 55, l_found);
 	if (!l_found) {
 		std::cout << "nRC value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRRD = x_params.find_integer("nRRD", 4, l_found);
+	k_nRRD = (uint32_t)x_params.find<uint32_t>("nRRD", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRRD value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRRD_L = x_params.find_integer("nRRD_L", 6, l_found);
+	k_nRRD_L = (uint32_t)x_params.find<uint32_t>("nRRD_L", 6, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRRD_S = x_params.find_integer("nRRD_S", 4, l_found);
+	k_nRRD_S = (uint32_t)x_params.find<uint32_t>("nRRD_S", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRCD = x_params.find_integer("nRCD", 16, l_found);
+	k_nRCD = (uint32_t)x_params.find<uint32_t>("nRCD", 16, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCCD = x_params.find_integer("nCCD", 4, l_found);
+	k_nCCD = (uint32_t)x_params.find<uint32_t>("nCCD", 4, l_found);
 	if (!l_found) {
 		std::cout << "nCCD value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCCD_L = x_params.find_integer("nCCD_L", 5, l_found);
+	k_nCCD_L = (uint32_t)x_params.find<uint32_t>("nCCD_L", 5, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCCD_L_WR = x_params.find_integer("nCCD_L_WR", 1, l_found);
+	k_nCCD_L_WR = (uint32_t)x_params.find<uint32_t>("nCCD_L_WR", 1, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_L_WR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCCD_S = x_params.find_integer("nCCD_S", 4, l_found);
+	k_nCCD_S = (uint32_t)x_params.find<uint32_t>("nCCD_S", 4, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nAL = x_params.find_integer("nAL", 15, l_found);
+	k_nAL = (uint32_t)x_params.find<uint32_t>("nAL", 15, l_found);
 	if (!l_found) {
 		std::cout << "nAL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCL = x_params.find_integer("nCL", 16, l_found);
+	k_nCL = (uint32_t)x_params.find<uint32_t>("nCL", 16, l_found);
 	if (!l_found) {
 		std::cout << "nCL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nCWL = x_params.find_integer("nCWL", 16, l_found);
+	k_nCWL = (uint32_t)x_params.find<uint32_t>("nCWL", 16, l_found);
 	if (!l_found) {
 		std::cout << "nCWL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nWR = x_params.find_integer("nWR", 16, l_found);
+	k_nWR = (uint32_t)x_params.find<uint32_t>("nWR", 16, l_found);
 	if (!l_found) {
 		std::cout << "nWR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nWTR = x_params.find_integer("nWTR", 3, l_found);
+	k_nWTR = (uint32_t)x_params.find<uint32_t>("nWTR", 3, l_found);
 	if (!l_found) {
 		std::cout << "nWTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nWTR_L = x_params.find_integer("nWTR_L", 9, l_found);
+	k_nWTR_L = (uint32_t)x_params.find<uint32_t>("nWTR_L", 9, l_found);
 	if (!l_found) {
 		std::cout << "nWTR_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nWTR_S = x_params.find_integer("nWTR_S", 3, l_found);
+	k_nWTR_S = (uint32_t)x_params.find<uint32_t>("nWTR_S", 3, l_found);
 	if (!l_found) {
 		std::cout << "nWTR_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRTW = x_params.find_integer("nRTW", 4, l_found);
+	k_nRTW = (uint32_t)x_params.find<uint32_t>("nRTW", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nEWTR = x_params.find_integer("nEWTR", 6, l_found);
+	k_nEWTR = (uint32_t)x_params.find<uint32_t>("nEWTR", 6, l_found);
 	if (!l_found) {
 		std::cout << "nEWTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nERTW = x_params.find_integer("nERTW", 6, l_found);
+	k_nERTW = (uint32_t)x_params.find<uint32_t>("nERTW", 6, l_found);
 	if (!l_found) {
 		std::cout << "nERTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nEWTW = x_params.find_integer("nEWTW", 6, l_found);
+	k_nEWTW = (uint32_t)x_params.find<uint32_t>("nEWTW", 6, l_found);
 	if (!l_found) {
 		std::cout << "nEWTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nERTR = x_params.find_integer("nERTR", 6, l_found);
+	k_nERTR = (uint32_t)x_params.find<uint32_t>("nERTR", 6, l_found);
 	if (!l_found) {
 		std::cout << "nERTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRAS = x_params.find_integer("nRAS", 39, l_found);
+	k_nRAS = (uint32_t)x_params.find<uint32_t>("nRAS", 39, l_found);
 	if (!l_found) {
 		std::cout << "nRAS value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRTP = x_params.find_integer("nRTP", 9, l_found);
+	k_nRTP = (uint32_t)x_params.find<uint32_t>("nRTP", 9, l_found);
 	if (!l_found) {
 		std::cout << "nRTP value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRP = x_params.find_integer("nRP", 16, l_found);
+	k_nRP = (uint32_t)x_params.find<uint32_t>("nRP", 16, l_found);
 	if (!l_found) {
 		std::cout << "nRP value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nRFC = x_params.find_integer("nRFC", 420, l_found);
+	k_nRFC = (uint32_t)x_params.find<uint32_t>("nRFC", 420, l_found);
 	if (!l_found) {
 		std::cout << "nRFC value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nREFI = x_params.find_integer("nREFI", 9360, l_found);
+	k_nREFI = (uint32_t)x_params.find<uint32_t>("nREFI", 9360, l_found);
 	if (!l_found) {
 		std::cout << "nREFI value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nFAW = x_params.find_integer("nFAW", 16, l_found);
+	k_nFAW = (uint32_t)x_params.find<uint32_t>("nFAW", 16, l_found);
 	if (!l_found) {
 		std::cout << "nFAW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_nBL = x_params.find_integer("nBL", 4, l_found);
+	k_nBL = (uint32_t)x_params.find<uint32_t>("nBL", 4, l_found);
 	if (!l_found) {
 		std::cout << "nBL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_numRows = x_params.find_integer("numRows", 16384, l_found);
+	k_numRows = (uint32_t)x_params.find<uint32_t>("numRows", 16384, l_found);
 	if (!l_found) {
 		std::cout << "numRows value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_numCols = x_params.find_integer("numCols", 128, l_found);
+	k_numCols = (uint32_t)x_params.find<uint32_t>("numCols", 128, l_found);
 	if (!l_found) {
 		std::cout << "numCols value is missing ... exiting" << std::endl;
 		exit(-1);
@@ -213,32 +213,32 @@ c_Bank::c_Bank(SST::Params& x_params) {
 	bool l_found = false;
 
 	/* BUFFER ALLOCATION PARAMETERS */
-	k_allocateCmdResQACT = x_params.find_integer("boolAllocateCmdResACT", 1, l_found);
+	k_allocateCmdResQACT = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResACT", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResACT value is missing... exiting" << std::endl;
 	}
 
-	k_allocateCmdResQREAD = x_params.find_integer("boolAllocateCmdResREAD", 1, l_found);
+	k_allocateCmdResQREAD = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResREAD", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResREAD value is missing... exiting" << std::endl;
 	}
 
-	k_allocateCmdResQREADA = x_params.find_integer("boolAllocateCmdResREADA", 1, l_found);
+	k_allocateCmdResQREADA = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResREADA", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResREADA value is missing... exiting" << std::endl;
 	}
 
-	k_allocateCmdResQWRITE = x_params.find_integer("boolAllocateCmdResWRITE", 1, l_found);
+	k_allocateCmdResQWRITE = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResWRITE", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResWRITE value is missing... exiting" << std::endl;
 	}
 
-	k_allocateCmdResQWRITEA = x_params.find_integer("boolAllocateCmdResWRITEA", 1, l_found);
+	k_allocateCmdResQWRITEA = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResWRITEA", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResWRITEA value is missing... exiting" << std::endl;
 	}
 
-	k_allocateCmdResQPRE = x_params.find_integer("boolAllocateCmdResPRE", 1, l_found);
+	k_allocateCmdResQPRE = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResPRE", 1, l_found);
 	if (!l_found){
 		std::cout << "boolAllocateCmdResPRE value is missing... exiting" << std::endl;
 	}

--- a/src/sst/elements/CramSim/c_Bank.hpp
+++ b/src/sst/elements/CramSim/c_Bank.hpp
@@ -42,16 +42,16 @@ public:
 
 	void finish() {
 		printf("Bank %u\n", m_bankNum);
-		printf("\tTotal ACT-Cmd received: %lu\n", m_ACTCmdsReceived);
-		printf("\tTotal READ-Cmd received: %lu\n", m_READCmdsReceived);
-		printf("\tTotal WRITE-Cmd received: %lu\n", m_WRITECmdsReceived);
-		printf("\tTotal PRE-Cmd received: %lu\n", m_PRECmdsReceived);
-		printf("\t\tTotal CMDs received: %lu\n", (m_ACTCmdsReceived + m_READCmdsReceived + m_WRITECmdsReceived + m_PRECmdsReceived));
-		// printf("\tTotal ACT-Cmd sent: %lu\n", m_ACTCmdsSent);
-		// printf("\tTotal READ-Cmd sent: %lu\n", m_READCmdsSent);
-		// printf("\tTotal WRITE-Cmd sent: %lu\n", m_WRITECmdsSent);
-		// printf("\tTotal PRE-Cmd sent: %lu\n", m_PRECmdsSent);
-		printf("\t\tTotal CMDs sent: %lu\n", (m_ACTCmdsSent + m_READCmdsSent + m_WRITECmdsSent + m_PRECmdsSent));
+		printf("\tTotal ACT-Cmd received: %" PRIu32 "\n", m_ACTCmdsReceived);
+		printf("\tTotal READ-Cmd received: %" PRIu32 "\n", m_READCmdsReceived);
+		printf("\tTotal WRITE-Cmd received: %" PRIu32 "\n", m_WRITECmdsReceived);
+		printf("\tTotal PRE-Cmd received: %" PRIu32 "\n", m_PRECmdsReceived);
+		printf("\t\tTotal CMDs received: %" PRIu32 "\n", (m_ACTCmdsReceived + m_READCmdsReceived + m_WRITECmdsReceived + m_PRECmdsReceived));
+		// printf("\tTotal ACT-Cmd sent: %" PRIu32 "\n", m_ACTCmdsSent);
+		// printf("\tTotal READ-Cmd sent: %" PRIu32 "\n", m_READCmdsSent);
+		// printf("\tTotal WRITE-Cmd sent: %" PRIu32 "\n", m_WRITECmdsSent);
+		// printf("\tTotal PRE-Cmd sent: %" PRIu32 "\n", m_PRECmdsSent);
+		printf("\t\tTotal CMDs sent: %" PRIu32 "\n", (m_ACTCmdsSent + m_READCmdsSent + m_WRITECmdsSent + m_PRECmdsSent));
 		printf("Component Finished.\n");
 	}
 

--- a/src/sst/elements/CramSim/c_BankInfo.cpp
+++ b/src/sst/elements/CramSim/c_BankInfo.cpp
@@ -78,6 +78,8 @@ void c_BankInfo::print() {
 	case e_BankState::REF:
 		printf("REF\n");
 		break;
+	default:
+	    break;
 	}
 	std::cout << "m_nextCommandCycleMap: " << std::endl;
 	for (auto l_mapEntry : m_nextCommandCycleMap) {

--- a/src/sst/elements/CramSim/c_BankReceiver.hpp
+++ b/src/sst/elements/CramSim/c_BankReceiver.hpp
@@ -21,7 +21,7 @@
 #include <sst/core/link.h>
 
 // local includes
-#include <sst/elements/CramSim/c_BankCommand.hpp>
+#include "c_BankCommand.hpp"
 
 namespace SST {
 namespace n_BankReceiver {

--- a/src/sst/elements/CramSim/c_BankStateIdle.cpp
+++ b/src/sst/elements/CramSim/c_BankStateIdle.cpp
@@ -54,6 +54,8 @@ void c_BankStateIdle::handleCommand(c_BankInfo* x_bank,
 	case e_BankCommandType::REF:
 		x_bank->setLastCommandCycle(e_BankCommandType::REF, l_time);
 		break;
+	default:
+	    break;
 	}
 	if (nullptr == m_receivedCommandPtr) {
 		m_timer = 1;
@@ -105,6 +107,8 @@ void c_BankStateIdle::clockTic(c_BankInfo* x_bank) {
 					l_p = new c_BankStateRefresh(m_bankParams);
 //					x_bank->setLastCommandCycle(e_BankCommandType::REF, l_time);
 					break;
+				default:
+				break;
 				}
 
 				assert(nullptr != m_receivedCommandPtr);

--- a/src/sst/elements/CramSim/c_CmdDriver.cpp
+++ b/src/sst/elements/CramSim/c_CmdDriver.cpp
@@ -37,7 +37,7 @@ c_CmdDriver::c_CmdDriver(ComponentId_t x_id, Params& x_params) :
 	bool l_found = false;
 
 	//internal queue sizes
-	k_cmdDrvBufferQEntries = x_params.find_integer("numCmdReqQEntries", 100,
+	k_cmdDrvBufferQEntries = (uint32_t)x_params.find<uint32_t>("numCmdReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout

--- a/src/sst/elements/CramSim/c_CmdDriver.hpp
+++ b/src/sst/elements/CramSim/c_CmdDriver.hpp
@@ -20,7 +20,7 @@
 #include <sst/core/link.h>
 
 // local includes
-#include <sst/elements/CramSim/c_Transaction.hpp>
+#include "c_Transaction.hpp"
 
 namespace SST {
 namespace n_CmdDriver {

--- a/src/sst/elements/CramSim/c_CmdUnit.cpp
+++ b/src/sst/elements/CramSim/c_CmdUnit.cpp
@@ -48,14 +48,14 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	// read params here
 	bool l_found = false;
 
-	k_cmdReqQEntries = x_params.find_integer("numCmdReqQEntries", 100, l_found);
+	k_cmdReqQEntries = (uint32_t)x_params.find<uint32_t>("numCmdReqQEntries", 100, l_found);
 	if (!l_found) {
 		std::cout << "numCmdUnitReqQEntries value is missing... exiting"
 				<< std::endl;
 		exit(-1);
 	}
 
-	k_cmdResQEntries = x_params.find_integer("numCmdResQEntries", 100, l_found);
+	k_cmdResQEntries = (uint32_t)x_params.find<uint32_t>("numCmdResQEntries", 100, l_found);
 	if (!l_found) {
 		std::cout << "numCmdUnitResQEntries value is missing... exiting"
 				<< std::endl;
@@ -63,7 +63,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	}
 	m_cmdResQTokens = k_cmdResQEntries;
 
-	k_numBytesPerTransaction = x_params.find_integer("numBytesPerTransaction",
+	k_numBytesPerTransaction = (uint32_t)x_params.find<uint32_t>("numBytesPerTransaction",
 			32, l_found);
 	if (!l_found) {
 		std::cout << "numBytesPerTransaction value is missing... exiting"
@@ -71,7 +71,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numChannelsPerDimm = x_params.find_integer("numChannelsPerDimm", 1,
+	k_numChannelsPerDimm = (uint32_t)x_params.find<uint32_t>("numChannelsPerDimm", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "numChannelsPerDimm value is missing... exiting"
@@ -79,7 +79,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numRanksPerChannel = x_params.find_integer("numRanksPerChannel", 2,
+	k_numRanksPerChannel = (uint32_t)x_params.find<uint32_t>("numRanksPerChannel", 2,
 			l_found);
 	if (!l_found) {
 		std::cout << "numRanksPerChannel value is missing... exiting"
@@ -87,7 +87,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBankGroupsPerRank = x_params.find_integer("numBankGroupsPerRank", 100,
+	k_numBankGroupsPerRank = (uint32_t)x_params.find<uint32_t>("numBankGroupsPerRank", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBankGroupsPerRank value is missing... exiting"
@@ -95,7 +95,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBanksPerBankGroup = x_params.find_integer("numBanksPerBankGroup", 100,
+	k_numBanksPerBankGroup = (uint32_t)x_params.find<uint32_t>("numBanksPerBankGroup", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBanksPerBankGroup value is missing... exiting"
@@ -103,25 +103,25 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numColsPerBank = x_params.find_integer("numColsPerBank", 100, l_found);
+	k_numColsPerBank = (uint32_t)x_params.find<uint32_t>("numColsPerBank", 100, l_found);
 	if (!l_found) {
 		std::cout << "numColsPerBank value is missing... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_numRowsPerBank = x_params.find_integer("numRowsPerBank", 100, l_found);
+	k_numRowsPerBank = (uint32_t)x_params.find<uint32_t>("numRowsPerBank", 100, l_found);
 	if (!l_found) {
 		std::cout << "numRowsPerBank value is missing... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_relCommandWidth = x_params.find_integer("relCommandWidth", 100, l_found);
+	k_relCommandWidth = (uint32_t)x_params.find<uint32_t>("relCommandWidth", 100, l_found);
 	if (!l_found) {
 		std::cout << "relCommandWidth value is missing... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_useRefresh = x_params.find_integer("boolUseRefresh", 1, l_found);
+	k_useRefresh = (uint32_t)x_params.find<uint32_t>("boolUseRefresh", 1, l_found);
 	if (!l_found) {
 		std::cout << "boolUseRefresh param value is missing... exiting"
 				<< std::endl;
@@ -129,7 +129,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	}
 
 	/* BUFFER ALLOCATION PARAMETERS */
-	k_allocateCmdResQACT = x_params.find_integer("boolAllocateCmdResACT", 1,
+	k_allocateCmdResQACT = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResACT", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResACT value is missing... exiting"
@@ -137,7 +137,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_allocateCmdResQREAD = x_params.find_integer("boolAllocateCmdResREAD", 1,
+	k_allocateCmdResQREAD = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResREAD", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResREAD value is missing... exiting"
@@ -145,7 +145,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_allocateCmdResQREADA = x_params.find_integer("boolAllocateCmdResREADA", 1,
+	k_allocateCmdResQREADA = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResREADA", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResREADA value is missing... exiting"
@@ -153,7 +153,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_allocateCmdResQWRITE = x_params.find_integer("boolAllocateCmdResWRITE", 1,
+	k_allocateCmdResQWRITE = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResWRITE", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResWRITE value is missing... exiting"
@@ -161,7 +161,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_allocateCmdResQWRITEA = x_params.find_integer("boolAllocateCmdResWRITEA",
+	k_allocateCmdResQWRITEA = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResWRITEA",
 			1, l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResWRITEA value is missing... exiting"
@@ -169,7 +169,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_allocateCmdResQPRE = x_params.find_integer("boolAllocateCmdResPRE", 1,
+	k_allocateCmdResQPRE = (uint32_t)x_params.find<uint32_t>("boolAllocateCmdResPRE", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "boolAllocateCmdResPRE value is missing... exiting"
@@ -177,7 +177,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_cmdQueueFindAnyIssuable = x_params.find_integer(
+	k_cmdQueueFindAnyIssuable = (uint32_t)x_params.find<uint32_t>(
 			"boolCmdQueueFindAnyIssuable", 1, l_found);
 	if (!l_found) {
 		std::cout << "boolCmdQueueFindAnyIssuable value is missing... exiting"
@@ -185,7 +185,7 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_bankPolicy = x_params.find_integer("bankPolicy", 0, l_found);
+	k_bankPolicy = (uint32_t)x_params.find<uint32_t>("bankPolicy", 0, l_found);
 	if (!l_found) {
 		std::cout << "bankPolicy value is missing... exiting" << std::endl;
 		exit(-1);
@@ -193,169 +193,169 @@ c_CmdUnit::c_CmdUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 
 	/* BANK TRANSITION PARAMETERS */
 	//FIXME: Move this param reading to inside of c_BankInfo
-	m_bankParams["nRC"] = x_params.find_integer("nRC", 55, l_found);
+	m_bankParams["nRC"] = (uint32_t)x_params.find<uint32_t>("nRC", 55, l_found);
 	if (!l_found) {
 		std::cout << "nRC value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRRD"] = x_params.find_integer("nRRD", 4, l_found);
+	m_bankParams["nRRD"] = (uint32_t)x_params.find<uint32_t>("nRRD", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRRD value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRRD_L"] = x_params.find_integer("nRRD_L", 6, l_found);
+	m_bankParams["nRRD_L"] = (uint32_t)x_params.find<uint32_t>("nRRD_L", 6, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRRD_S"] = x_params.find_integer("nRRD_S", 4, l_found);
+	m_bankParams["nRRD_S"] = (uint32_t)x_params.find<uint32_t>("nRRD_S", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRCD"] = x_params.find_integer("nRCD", 16, l_found);
+	m_bankParams["nRCD"] = (uint32_t)x_params.find<uint32_t>("nRCD", 16, l_found);
 	if (!l_found) {
 		std::cout << "nRRD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCCD"] = x_params.find_integer("nCCD", 4, l_found);
+	m_bankParams["nCCD"] = (uint32_t)x_params.find<uint32_t>("nCCD", 4, l_found);
 	if (!l_found) {
 		std::cout << "nCCD value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCCD_L"] = x_params.find_integer("nCCD_L", 5, l_found);
+	m_bankParams["nCCD_L"] = (uint32_t)x_params.find<uint32_t>("nCCD_L", 5, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCCD_L_WR"] = x_params.find_integer("nCCD_L_WR", 1, l_found);
+	m_bankParams["nCCD_L_WR"] = (uint32_t)x_params.find<uint32_t>("nCCD_L_WR", 1, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_L_WR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCCD_S"] = x_params.find_integer("nCCD_S", 4, l_found);
+	m_bankParams["nCCD_S"] = (uint32_t)x_params.find<uint32_t>("nCCD_S", 4, l_found);
 	if (!l_found) {
 		std::cout << "nCCD_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nAL"] = x_params.find_integer("nAL", 15, l_found);
+	m_bankParams["nAL"] = (uint32_t)x_params.find<uint32_t>("nAL", 15, l_found);
 	if (!l_found) {
 		std::cout << "nAL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCL"] = x_params.find_integer("nCL", 16, l_found);
+	m_bankParams["nCL"] = (uint32_t)x_params.find<uint32_t>("nCL", 16, l_found);
 	if (!l_found) {
 		std::cout << "nCL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nCWL"] = x_params.find_integer("nCWL", 16, l_found);
+	m_bankParams["nCWL"] = (uint32_t)x_params.find<uint32_t>("nCWL", 16, l_found);
 	if (!l_found) {
 		std::cout << "nCWL value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nWR"] = x_params.find_integer("nWR", 16, l_found);
+	m_bankParams["nWR"] = (uint32_t)x_params.find<uint32_t>("nWR", 16, l_found);
 	if (!l_found) {
 		std::cout << "nWR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nWTR"] = x_params.find_integer("nWTR", 3, l_found);
+	m_bankParams["nWTR"] = (uint32_t)x_params.find<uint32_t>("nWTR", 3, l_found);
 	if (!l_found) {
 		std::cout << "nWTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nWTR_L"] = x_params.find_integer("nWTR_L", 9, l_found);
+	m_bankParams["nWTR_L"] = (uint32_t)x_params.find<uint32_t>("nWTR_L", 9, l_found);
 	if (!l_found) {
 		std::cout << "nWTR_L value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nWTR_S"] = x_params.find_integer("nWTR_S", 3, l_found);
+	m_bankParams["nWTR_S"] = (uint32_t)x_params.find<uint32_t>("nWTR_S", 3, l_found);
 	if (!l_found) {
 		std::cout << "nWTR_S value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRTW"] = x_params.find_integer("nRTW", 4, l_found);
+	m_bankParams["nRTW"] = (uint32_t)x_params.find<uint32_t>("nRTW", 4, l_found);
 	if (!l_found) {
 		std::cout << "nRTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nEWTR"] = x_params.find_integer("nEWTR", 6, l_found);
+	m_bankParams["nEWTR"] = (uint32_t)x_params.find<uint32_t>("nEWTR", 6, l_found);
 	if (!l_found) {
 		std::cout << "nEWTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nERTW"] = x_params.find_integer("nERTW", 6, l_found);
+	m_bankParams["nERTW"] = (uint32_t)x_params.find<uint32_t>("nERTW", 6, l_found);
 	if (!l_found) {
 		std::cout << "nERTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nEWTW"] = x_params.find_integer("nEWTW", 6, l_found);
+	m_bankParams["nEWTW"] = (uint32_t)x_params.find<uint32_t>("nEWTW", 6, l_found);
 	if (!l_found) {
 		std::cout << "nEWTW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nERTR"] = x_params.find_integer("nERTR", 6, l_found);
+	m_bankParams["nERTR"] = (uint32_t)x_params.find<uint32_t>("nERTR", 6, l_found);
 	if (!l_found) {
 		std::cout << "nERTR value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRAS"] = x_params.find_integer("nRAS", 39, l_found);
+	m_bankParams["nRAS"] = (uint32_t)x_params.find<uint32_t>("nRAS", 39, l_found);
 	if (!l_found) {
 		std::cout << "nRAS value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRTP"] = x_params.find_integer("nRTP", 9, l_found);
+	m_bankParams["nRTP"] = (uint32_t)x_params.find<uint32_t>("nRTP", 9, l_found);
 	if (!l_found) {
 		std::cout << "nRTP value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRP"] = x_params.find_integer("nRP", 16, l_found);
+	m_bankParams["nRP"] = (uint32_t)x_params.find<uint32_t>("nRP", 16, l_found);
 	if (!l_found) {
 		std::cout << "nRP value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nRFC"] = x_params.find_integer("nRFC", 420, l_found);
+	m_bankParams["nRFC"] = (uint32_t)x_params.find<uint32_t>("nRFC", 420, l_found);
 	if (!l_found) {
 		std::cout << "nRFC value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nREFI"] = x_params.find_integer("nREFI", 9360, l_found);
+	m_bankParams["nREFI"] = (uint32_t)x_params.find<uint32_t>("nREFI", 9360, l_found);
 	if (!l_found) {
 		std::cout << "nREFI value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nFAW"] = x_params.find_integer("nFAW", 16, l_found);
+	m_bankParams["nFAW"] = (uint32_t)x_params.find<uint32_t>("nFAW", 16, l_found);
 	if (!l_found) {
 		std::cout << "nFAW value is missing ... exiting" << std::endl;
 		exit(-1);
 	}
 
-	m_bankParams["nBL"] = x_params.find_integer("nBL", 4, l_found);
+	m_bankParams["nBL"] = (uint32_t)x_params.find<uint32_t>("nBL", 4, l_found);
 	if (!l_found) {
 		std::cout << "nBL value is missing ... exiting" << std::endl;
 		exit(-1);
@@ -1292,6 +1292,8 @@ bool c_CmdUnit::sendCommand(c_BankCommand* x_bankCommandPtr,
 		case e_BankCommandType::PRE:
 			l_doAllocateSpace = k_allocateCmdResQPRE;
 			break;
+		default:
+		    break;
 		}
 		if (l_doAllocateSpace)
 			m_cmdResQTokens--;

--- a/src/sst/elements/CramSim/c_CmdUnit.hpp
+++ b/src/sst/elements/CramSim/c_CmdUnit.hpp
@@ -46,7 +46,7 @@ public:
 		// printf("\n\t CmdUnit Res Q:\n");
 		// for (unsigned l_i = 0; l_i != k_cmdResQEntries+1; ++l_i)
 		// 	printf("%u\n", m_statsResQ[l_i]);
-		printf("Refresh's sent out: %lu\n", m_refsSent);
+		printf("Refresh's sent out: %" PRIu32 "\n", m_refsSent);
 
 	}
 

--- a/src/sst/elements/CramSim/c_Dimm.cpp
+++ b/src/sst/elements/CramSim/c_Dimm.cpp
@@ -54,7 +54,7 @@ c_Dimm::c_Dimm(SST::ComponentId_t x_id, SST::Params& x_params) :
 	// read params here
 	bool l_found = false;
 
-	k_numRanksPerChannel = x_params.find_integer("numRanksPerChannel", 100,
+	k_numRanksPerChannel = (uint32_t)x_params.find<uint32_t>("numRanksPerChannel", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numRanksPerChannel value is missing... exiting"
@@ -62,7 +62,7 @@ c_Dimm::c_Dimm(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBankGroupsPerRank = x_params.find_integer("numBankGroupsPerRank", 100,
+	k_numBankGroupsPerRank = (uint32_t)x_params.find<uint32_t>("numBankGroupsPerRank", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBankGroupsPerRank value is missing... exiting"
@@ -70,7 +70,7 @@ c_Dimm::c_Dimm(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBanksPerBankGroup = x_params.find_integer("numBanksPerBankGroup", 100,
+	k_numBanksPerBankGroup = (uint32_t)x_params.find<uint32_t>("numBanksPerBankGroup", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBanksPerBankGroup value is missing... exiting"

--- a/src/sst/elements/CramSim/c_DramSimTraceReader.cpp
+++ b/src/sst/elements/CramSim/c_DramSimTraceReader.cpp
@@ -42,7 +42,7 @@ c_DramSimTraceReader::c_DramSimTraceReader(ComponentId_t x_id, Params& x_params)
 	m_resWriteCount = 0;
 
 	//internal queues' sizes
-	k_txnGenReqQEntries = x_params.find_integer("numTxnGenReqQEntries", 100,
+	k_txnGenReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnGenReqQEntries value is missing... exiting"
@@ -50,7 +50,7 @@ c_DramSimTraceReader::c_DramSimTraceReader(ComponentId_t x_id, Params& x_params)
 		exit(-1);
 	}
 
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnGenResQEntries value is missing... exiting"
@@ -59,7 +59,7 @@ c_DramSimTraceReader::c_DramSimTraceReader(ComponentId_t x_id, Params& x_params)
 	}
 
 	//transaction unit queue entries
-	k_txnUnitReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -70,7 +70,7 @@ c_DramSimTraceReader::c_DramSimTraceReader(ComponentId_t x_id, Params& x_params)
 	m_txnUnitReqQTokens = k_txnUnitReqQEntries;
 
 	// trace file param
-	m_traceFileName = x_params.find_string("traceFile", "nil", l_found);
+	m_traceFileName = x_params.find<std::string>("traceFile", "nil", l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: traceFile name is missing... exiting"
 				<< std::endl;

--- a/src/sst/elements/CramSim/c_TracefileReader.cpp
+++ b/src/sst/elements/CramSim/c_TracefileReader.cpp
@@ -43,7 +43,7 @@ c_TracefileReader::c_TracefileReader(ComponentId_t x_id, Params& x_params) :
 	m_resWriteCount = 0;
 
 	//internal queues' sizes
-	k_txnGenReqQEntries = x_params.find_integer("numTxnGenReqQEntries", 100,
+	k_txnGenReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -52,7 +52,7 @@ c_TracefileReader::c_TracefileReader(ComponentId_t x_id, Params& x_params) :
 		exit(-1);
 	}
 
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -62,7 +62,7 @@ c_TracefileReader::c_TracefileReader(ComponentId_t x_id, Params& x_params) :
 	}
 
 	//transaction unit queue entries
-	k_txnUnitReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnUnitReqQEntries value is missing... exiting"
@@ -72,7 +72,7 @@ c_TracefileReader::c_TracefileReader(ComponentId_t x_id, Params& x_params) :
 	m_txnUnitReqQTokens = k_txnUnitReqQEntries;
 
   // trace file param
-  m_traceFileName = x_params.find_string("traceFile", "nil", l_found);
+  m_traceFileName = x_params.find<std::string>("traceFile", "nil", l_found);
   if (!l_found) {
     std::cout << "TxnGen:: traceFile name is missing... exiting" << std::endl;
     exit(-1);

--- a/src/sst/elements/CramSim/c_TxnDriver.cpp
+++ b/src/sst/elements/CramSim/c_TxnDriver.cpp
@@ -36,7 +36,7 @@ c_TxnDriver::c_TxnDriver(ComponentId_t x_id, Params& x_params) :
 	bool l_found = false;
 
 	//internal queue sizes
-	k_txnDrvBufferQEntries = x_params.find_integer("numTxnDrvBufferQEntries",
+	k_txnDrvBufferQEntries = (uint32_t)x_params.find<uint32_t>("numTxnDrvBufferQEntries",
 			100, l_found);
 	if (!l_found) {
 		std::cout
@@ -46,7 +46,7 @@ c_TxnDriver::c_TxnDriver(ComponentId_t x_id, Params& x_params) :
 	}
 
 	//transaction gen queue entries
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout

--- a/src/sst/elements/CramSim/c_TxnDriver.hpp
+++ b/src/sst/elements/CramSim/c_TxnDriver.hpp
@@ -20,7 +20,7 @@
 #include <sst/core/link.h>
 
 // local includes
-#include <sst/elements/CramSim/c_Transaction.hpp>
+#include "c_Transaction.hpp"
 
 namespace SST {
 namespace n_TxnDriver {

--- a/src/sst/elements/CramSim/c_TxnGenRand.cpp
+++ b/src/sst/elements/CramSim/c_TxnGenRand.cpp
@@ -40,7 +40,7 @@ c_TxnGenRand::c_TxnGenRand(ComponentId_t x_id, Params& x_params) :
 	m_resWriteCount = 0;
 
 	//internal queues' sizes
-	k_txnGenReqQEntries = x_params.find_integer("numTxnGenReqQEntries", 100,
+	k_txnGenReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -49,7 +49,7 @@ c_TxnGenRand::c_TxnGenRand(ComponentId_t x_id, Params& x_params) :
 		exit(-1);
 	}
 
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -59,7 +59,7 @@ c_TxnGenRand::c_TxnGenRand(ComponentId_t x_id, Params& x_params) :
 	}
 
 	//transaction unit queue entries
-	k_txnUnitReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnUnitReqQEntries value is missing... exiting"
@@ -70,7 +70,7 @@ c_TxnGenRand::c_TxnGenRand(ComponentId_t x_id, Params& x_params) :
 
 	//ratio of read txn's : write txn's to generate
 	k_readWriteTxnRatio
-			= x_params.find_floating("readWriteRatio", 1.0, l_found);
+			= x_params.find<float>("readWriteRatio", 1.0, l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: readWriteRatio value is missing... exiting"
 				<< std::endl;

--- a/src/sst/elements/CramSim/c_TxnGenSeq.cpp
+++ b/src/sst/elements/CramSim/c_TxnGenSeq.cpp
@@ -40,7 +40,7 @@ c_TxnGenSeq::c_TxnGenSeq(ComponentId_t x_id, Params& x_params) :
 	m_resWriteCount = 0;
 
 	//internal queues' sizes
-	k_txnGenReqQEntries = x_params.find_integer("numTxnGenReqQEntries", 100,
+	k_txnGenReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -49,7 +49,7 @@ c_TxnGenSeq::c_TxnGenSeq(ComponentId_t x_id, Params& x_params) :
 		exit(-1);
 	}
 
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -59,7 +59,7 @@ c_TxnGenSeq::c_TxnGenSeq(ComponentId_t x_id, Params& x_params) :
 	}
 
 	//transaction unit queue entries
-	k_txnUnitReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnUnitReqQEntries value is missing... exiting"
@@ -70,7 +70,7 @@ c_TxnGenSeq::c_TxnGenSeq(ComponentId_t x_id, Params& x_params) :
 
 	//ratio of read txn's : write txn's to generate
 	k_readWriteTxnRatio
-			= x_params.find_floating("readWriteRatio", 1.0, l_found);
+			= x_params.find<float>("readWriteRatio", 1.0, l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: readWriteRatio value is missing... exiting"
 				<< std::endl;

--- a/src/sst/elements/CramSim/c_TxnUnit.cpp
+++ b/src/sst/elements/CramSim/c_TxnUnit.cpp
@@ -41,7 +41,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	bool l_found = false;
 
 	// load internal params
-	k_txnReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numTxnUnitReqQEntries param value is missing... exiting"
@@ -49,7 +49,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_txnResQEntries = x_params.find_integer("numTxnUnitResQEntries", 100,
+	k_txnResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numTxnUnitResQEntries param value is missing... exiting"
@@ -57,7 +57,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBytesPerTransaction = x_params.find_integer("numBytesPerTransaction",
+	k_numBytesPerTransaction = (uint32_t)x_params.find<uint32_t>("numBytesPerTransaction",
 			32, l_found);
 	if (!l_found) {
 		std::cout << "numBytesPerTransaction value is missing... exiting"
@@ -65,7 +65,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numChannelsPerDimm = x_params.find_integer("numChannelsPerDimm", 1,
+	k_numChannelsPerDimm = (uint32_t)x_params.find<uint32_t>("numChannelsPerDimm", 1,
 			l_found);
 	if (!l_found) {
 		std::cout << "numChannelsPerDimm value is missing... exiting"
@@ -73,7 +73,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numRanksPerChannel = x_params.find_integer("numRanksPerChannel", 2,
+	k_numRanksPerChannel = (uint32_t)x_params.find<uint32_t>("numRanksPerChannel", 2,
 			l_found);
 	if (!l_found) {
 		std::cout << "numRanksPerChannel value is missing... exiting"
@@ -81,7 +81,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBankGroupsPerRank = x_params.find_integer("numBankGroupsPerRank", 100,
+	k_numBankGroupsPerRank = (uint32_t)x_params.find<uint32_t>("numBankGroupsPerRank", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBankGroupsPerRank value is missing... exiting"
@@ -89,7 +89,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numBanksPerBankGroup = x_params.find_integer("numBanksPerBankGroup", 100,
+	k_numBanksPerBankGroup = (uint32_t)x_params.find<uint32_t>("numBanksPerBankGroup", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numBanksPerBankGroup value is missing... exiting"
@@ -97,26 +97,26 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_numColsPerBank = x_params.find_integer("numColsPerBank", 100, l_found);
+	k_numColsPerBank = (uint32_t)x_params.find<uint32_t>("numColsPerBank", 100, l_found);
 	if (!l_found) {
 		std::cout << "numColsPerBank value is missing... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_numRowsPerBank = x_params.find_integer("numRowsPerBank", 100, l_found);
+	k_numRowsPerBank = (uint32_t)x_params.find<uint32_t>("numRowsPerBank", 100, l_found);
 	if (!l_found) {
 		std::cout << "numRowsPerBank value is missing... exiting" << std::endl;
 		exit(-1);
 	}
 
-	k_relCommandWidth = x_params.find_integer("relCommandWidth", 1, l_found);
+	k_relCommandWidth = (uint32_t)x_params.find<uint32_t>("relCommandWidth", 1, l_found);
 	if (!l_found) {
 		std::cout << "relCommandWidth value is missing ... exiting"
 				<< std::endl;
 		exit(-1);
 	}
 
-	k_REFI = x_params.find_integer("nREFI", 1, l_found);
+	k_REFI = (uint32_t)x_params.find<uint32_t>("nREFI", 1, l_found);
 	if (!l_found) {
 		std::cout << "nREFI value is missing ... exiting" << std::endl;
 		exit(-1);
@@ -125,7 +125,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 
 	// calculate total number of banks
 
-	int l_numRanksPerChannel = x_params.find_integer("numRanksPerChannel", 100,
+	int l_numRanksPerChannel = (uint32_t)x_params.find<uint32_t>("numRanksPerChannel", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numRanksPerChannel value is missing... exiting"
@@ -133,7 +133,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	int l_numBankGroupsPerRank = x_params.find_integer("numBankGroupsPerRank",
+	int l_numBankGroupsPerRank = (uint32_t)x_params.find<uint32_t>("numBankGroupsPerRank",
 			100, l_found);
 	if (!l_found) {
 		std::cout << "numBankGroupsPerRank value is missing... exiting"
@@ -141,7 +141,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	int l_numBanksPerBankGroup = x_params.find_integer("numBanksPerBankGroup",
+	int l_numBanksPerBankGroup = (uint32_t)x_params.find<uint32_t>("numBanksPerBankGroup",
 			100, l_found);
 	if (!l_found) {
 		std::cout << "numBanksPerBankGroup value is missing... exiting"
@@ -153,7 +153,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 			* l_numBanksPerBankGroup;
 
 	//load neighboring component's params
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numTxnGenResQEntries param value is missing... exiting"
@@ -162,7 +162,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	}
 	m_txnGenResQTokens = k_txnGenResQEntries;
 
-	k_cmdUnitReqQEntries = x_params.find_integer("numCmdReqQEntries", 100,
+	k_cmdUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numCmdReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "numCmdReqQEntries param value is missing... exiting"
@@ -171,21 +171,21 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 	}
 	m_cmdUnitReqQTokens = k_cmdUnitReqQEntries;
 
-	k_useReadA = x_params.find_integer("boolUseReadA", 1, l_found);
+	k_useReadA = (uint32_t)x_params.find<uint32_t>("boolUseReadA", 1, l_found);
 	if (!l_found) {
 		std::cout << "boolUseWriteA param value is missing... exiting"
 				<< std::endl;
 		exit(-1);
 	}
 
-	k_useWriteA = x_params.find_integer("boolUseWriteA", 1, l_found);
+	k_useWriteA = (uint32_t)x_params.find<uint32_t>("boolUseWriteA", 1, l_found);
 	if (!l_found) {
 		std::cout << "boolUseWriteA param value is missing... exiting"
 				<< std::endl;
 		exit(-1);
 	}
 
-	k_bankPolicy = x_params.find_integer("bankPolicy", 0, l_found);
+	k_bankPolicy = (uint32_t)x_params.find<uint32_t>("bankPolicy", 0, l_found);
 	if (!l_found) {
 		std::cout << "bankPolicy value is missing... exiting" << std::endl;
 		exit(-1);
@@ -197,7 +197,7 @@ c_TxnUnit::c_TxnUnit(SST::ComponentId_t x_id, SST::Params& x_params) :
 		exit(-1);
 	}
 
-	k_useRefresh = x_params.find_integer("boolUseRefresh", 1, l_found);
+	k_useRefresh = (uint32_t)x_params.find<uint32_t>("boolUseRefresh", 1, l_found);
 	if (!l_found) {
 		std::cout << "boolUseRefresh param value is missing... exiting"
 				<< std::endl;

--- a/src/sst/elements/CramSim/c_USimmTraceReader.cpp
+++ b/src/sst/elements/CramSim/c_USimmTraceReader.cpp
@@ -44,7 +44,7 @@ c_USimmTraceReader::c_USimmTraceReader(ComponentId_t x_id, Params& x_params) :
 	m_resWriteCount = 0;
 
 	//internal queues' sizes
-	k_txnGenReqQEntries = x_params.find_integer("numTxnGenReqQEntries", 100,
+	k_txnGenReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -53,7 +53,7 @@ c_USimmTraceReader::c_USimmTraceReader(ComponentId_t x_id, Params& x_params) :
 		exit(-1);
 	}
 
-	k_txnGenResQEntries = x_params.find_integer("numTxnGenResQEntries", 100,
+	k_txnGenResQEntries = (uint32_t)x_params.find<uint32_t>("numTxnGenResQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout
@@ -63,7 +63,7 @@ c_USimmTraceReader::c_USimmTraceReader(ComponentId_t x_id, Params& x_params) :
 	}
 
 	//transaction unit queue entries
-	k_txnUnitReqQEntries = x_params.find_integer("numTxnUnitReqQEntries", 100,
+	k_txnUnitReqQEntries = (uint32_t)x_params.find<uint32_t>("numTxnUnitReqQEntries", 100,
 			l_found);
 	if (!l_found) {
 		std::cout << "TxnGen:: numTxnUnitReqQEntries value is missing... exiting"
@@ -73,7 +73,7 @@ c_USimmTraceReader::c_USimmTraceReader(ComponentId_t x_id, Params& x_params) :
 	m_txnUnitReqQTokens = k_txnUnitReqQEntries;
 
   // trace file param
-  m_traceFileName = x_params.find_string("traceFile", "nil", l_found);
+  m_traceFileName = x_params.find<std::string>("traceFile", "nil", l_found);
   if (!l_found) {
     std::cout << "TxnGen:: traceFile name is missing... exiting" << std::endl;
     exit(-1);

--- a/src/sst/elements/CramSim/c_USimmTraceReader.hpp
+++ b/src/sst/elements/CramSim/c_USimmTraceReader.hpp
@@ -53,7 +53,7 @@ public:
 		printf("Total Write-Txns Requests send: %lu\n", m_reqWriteCount);
 		printf("Total Read-Txns Responses received: %lu\n", m_resReadCount);
 		printf("Total Write-Txns Responses received: %lu\n", m_resWriteCount);
-		printf("Total Cycles: %lu\n", Simulation::getSimulation()->getCurrentSimCycle());
+		printf("Total Cycles: %" PRIu64 "\n", Simulation::getSimulation()->getCurrentSimCycle());
 		printf("Component Finished.\n");
 	}
 


### PR DESCRIPTION
Clean up compile warnings and warnings about deprecated param.find_xxx calls.  Also fixed include file paths that were breaking  out of source build.