### PR TITLE
Now serializing RtrEvent::injectionTime.

### DIFF
--- a/src/sst/elements/merlin/router.h
+++ b/src/sst/elements/merlin/router.h
@@ -152,6 +152,7 @@ public:
         BaseRtrEvent::serialize_order(ser);
         ser & request;
         ser & size_in_flits;
+        ser & injectionTime;
     }
     
 private:


### PR DESCRIPTION
RtrEvent::injectionTime was not being serialized, resulting in errors for multi-rank runs.