### PR TITLE
adding power tracing option to goblinHMCSim membackend; only applies …

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -57,6 +57,10 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 		hmc_trace_level = hmc_trace_level | HMC_TRACE_STALL;
 	}
 
+	if(params.find<bool>("trace-power", false)) {
+		hmc_trace_level = hmc_trace_level | HMC_TRACE_POWER;
+	}
+
 	hmc_tag_count    = params.find<uint32_t>("tag_count", 64);
 
 	hmc_trace_file   = params.find<std::string>("trace_file", "hmc-trace.out");


### PR DESCRIPTION
Adds the ability to enable/disable device power tracing in Goblin HMC-Sim version 3.0+ (upstream).  This patch adds "trace-power" to the goblinHMCSim component parameters to enable/disable HMC_TRACE_POWER.  The current tracing output is written to the hmc-trace.out trace file.  

Power tracing values include: 
— Link Phy
— Link Local Route (route of packet to local quadrant)
— Link Remote Route (route of packet to distant quadrant)
— Crossbar Request Slot (active SRAM/register state)
— Crossbar Response Slot (active SRAM/register state)
— Crossbar External Route (Cube-to-Cube route minus link phy)
— Vault Request Slot
— Vault Response Slot
— Vault Controller
— Row Access (inclues pre-charge+activate+fetch+sense) 

---
Instructions for Issuing a Pull Request to sst-elements

`1` Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

`2` Verify that Source branch is up to date with the devel branch of sst-elements

`3` After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
----

…to Goblin HMC-Sim version 3.0+