### PR TITLE
adding miranda cpu tests for single stream that target the goblin HMC…

### DIFF
--- a/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
@@ -1,0 +1,63 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream1.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1.py
@@ -1,0 +1,58 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
@@ -1,0 +1,72 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "4",
+      "backend.vault_count" : "16",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "4",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream2.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2.py
@@ -1,0 +1,67 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "4",
+      "backend.vault_count" : "16",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "4",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
@@ -1,0 +1,72 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "8",
+      "backend.vault_count" : "32",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "8",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream3.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3.py
@@ -1,0 +1,67 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "8",
+      "backend.vault_count" : "32",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "8",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )


### PR DESCRIPTION
Fix for issue #412 
adds miranda-based cpu tests using Goblin HMC-Sim (2.0+) memBackend (sub-component of memHierarchy).  Includes basic tests using single stream as the source test.  Covers the following test matrix:
- default device config, no tracing
- 4Link device, no tracing
- 8Link device, no tracing
- 4Link device, tracing enabled
- 8Link device, tracing enabled

Does not currently include the power tracing enabled from pull request #472 


---
Instructions for Issuing a Pull Request to sst-elements

`1` Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

`2` Verify that Source branch is up to date with the devel branch of sst-elements

`3` After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
----

… memBackend; Includes tests for 4link and 8link devices and with tracing enabled and disabled; does not currently utilize HMCSim 3.0 power tracing