### PR TITLE
Afrodri/ramulator

### DIFF
--- a/config/sst_check_ramulator.m4
+++ b/config/sst_check_ramulator.m4
@@ -1,0 +1,44 @@
+
+AC_DEFUN([SST_CHECK_RAMULATOR], [
+  AC_ARG_WITH([ramulator],
+    [AS_HELP_STRING([--with-ramulator@<:@=DIR@:>@],
+      [Use Ramulator library installed in optionally specified DIR])])
+
+  sst_check_ramulator_happy="yes"
+  AS_IF([test "$with_ramulator" = "no"], [sst_check_ramulator_happy="no"])
+
+  CPPFLAGS_saved="$CPPFLAGS"
+  LDFLAGS_saved="$LDFLAGS"
+  LIBS_saved="$LIBS"
+
+  AS_IF([test ! -z "$with_ramulator" -a "$with_ramulator" != "yes"],
+    [RAMULATOR_CPPFLAGS="-I$with_ramulator/src -DRAMULATOR -DHAVE_RAMULATOR"
+     CPPFLAGS="$RAMULATOR_CPPFLAGS $CPPFLAGS"
+     RAMULATOR_LDFLAGS="-L$with_ramulator"
+     RAMULATOR_LIBDIR="$with_ramulator"
+     LDFLAGS="$RAMULATOR_LDFLAGS $LDFLAGS"],
+    [RAMULATOR_CPPFLAGS=
+     RAMULATOR_LDFLAGS=
+     RAMULATOR_LIBDIR=])
+
+  AC_LANG_PUSH(C++)
+  AC_CHECK_HEADERS([Gem5Wrapper.h], [], [sst_check_ramulator_happy="no"])
+  AC_CHECK_LIB([ramulator], [libramulator_is_present],
+    [RAMULATOR_LIB="-lramulator"], [sst_check_ramulator_happy="no"])
+  AC_LANG_POP(C++)
+
+  CPPFLAGS="$CPPFLAGS_saved"
+  LDFLAGS="$LDFLAGS_saved"
+  LIBS="$LIBS_saved"
+
+  AC_SUBST([RAMULATOR_CPPFLAGS])
+  AC_SUBST([RAMULATOR_LDFLAGS])
+  AC_SUBST([RAMULATOR_LIB])
+  AC_SUBST([RAMULATOR_LIBDIR])
+  AM_CONDITIONAL([HAVE_RAMULATOR], [test "$sst_check_ramulator_happy" = "yes"])
+  AS_IF([test "$sst_check_ramulator_happy" = "yes"],
+        [AC_DEFINE([HAVE_RAMULATOR], [1], [Set to 1 if Ramulator was found])])
+  AC_DEFINE_UNQUOTED([RAMULATOR_LIBDIR], ["$RAMULATOR_LIBDIR"], [Path to Ramulator library])
+
+  AS_IF([test "$sst_check_ramulator_happy" = "yes"], [$1], [$2])
+])

--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -121,6 +121,15 @@ nobase_sst_HEADERS = \
 libmemHierarchy_la_LDFLAGS = -module -avoid-version
 libmemHierarchy_la_LIBADD = 
 
+if HAVE_RAMULATOR
+libmemHierarchy_la_LDFLAGS += $(RAMULATOR_LDFLAGS)
+libmemHierarchy_la_LIBADD += $(RAMULATOR_LIB)
+libmemHierarchy_la_SOURCES += membackend/ramulatorBackend.cc \
+	membackend/ramulatorBackend.h
+nobase_sst_HEADERS += membackend/ramulatorBackend.h
+AM_CPPFLAGS += $(RAMULATOR_CPPFLAGS) -DHAVE_LIBRAMULATOR
+endif
+
 if HAVE_DRAMSIM
 libmemHierarchy_la_LDFLAGS += $(DRAMSIM_LDFLAGS)
 libmemHierarchy_la_LIBADD += $(DRAMSIM_LIB)

--- a/src/sst/elements/memHierarchy/configure.m4
+++ b/src/sst/elements/memHierarchy/configure.m4
@@ -5,6 +5,9 @@ dnl
 AC_DEFUN([SST_memHierarchy_CONFIG], [
 	mh_happy="yes"
 
+  # Use global Ramulator check
+  SST_CHECK_RAMULATOR([],[],[AC_MSG_ERROR([Ramulator requested but could not be found])])
+
   # Use global DRAMSim check
   SST_CHECK_DRAMSIM([],[],[AC_MSG_ERROR([DRAMSim requested but could not be found])])
 

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -433,6 +433,7 @@ static const ElementInfoParam cpu_params[] = {
     {"rngseed",                 "Set a seed for the random generation of addresses", "7"},
     {"commFreq",                "How often to do a memory operation."},
     {"memSize",                 "Size of physical memory."},
+    {"maxOutstanding",          "Maximum Number of Outstanding memory requests."},
     {"do_write",                "Enable writes to memory (versus just reads).", "1"},
     {"num_loadstore",           "Stop after this many reads and writes.", "-1"},
     {"noncacheableRangeStart",  "Beginning of range of addresses that are noncacheable.", "0x0"},

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -47,6 +47,10 @@
 #include "membackend/goblinHMCBackend.h"
 #endif
 
+#ifdef HAVE_LIBRAMULATOR
+#include "membackend/ramulatorBackend.h"
+#endif
+
 #ifdef HAVE_LIBDRAMSIM
 #include "membackend/dramSimBackend.h"
 #include "membackend/pagedMultiBackend.h"
@@ -579,6 +583,18 @@ static const ElementInfoParam requestReorderRow_params[] = {
     { NULL, NULL, NULL }
 };
 
+#if defined(HAVE_LIBRAMULATOR)
+static SubComponent* create_Mem_Ramulator(Component* comp, Params& params){
+    return new ramulatorMemory(comp, params);
+}
+
+static const ElementInfoParam ramulatorMem_params[] = {
+    {"verbose",          "Sets the verbosity of the backend output", "0" },
+    {"configFile",      "Name of Ramulator Device config file", NULL},
+    {NULL, NULL, NULL}
+};
+
+#endif
 
 #if defined(HAVE_LIBDRAMSIM)
 static SubComponent* create_Mem_DRAMSim(Component* comp, Params& params){
@@ -862,6 +878,17 @@ static const ElementInfoSubComponent subcomponents[] = {
         NULL,
         "SST::MemHierarchy::MemBackend"
     },
+#if defined(HAVE_LIBRAMULATOR)
+    {
+        "ramulator",
+        "Ramulator-driven memory timings",
+        NULL, /* Advanced help */
+        create_Mem_Ramulator, /* alloc subcomponent */
+        ramulatorMem_params,
+        NULL, /* stats */
+        "SST::MemHierarchy::MemBackend"
+    },
+#endif
 #if defined(HAVE_LIBDRAMSIM)
     {
         "dramsim",

--- a/src/sst/elements/memHierarchy/membackend/ramulatorBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/ramulatorBackend.cc
@@ -1,0 +1,83 @@
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#include <sst_config.h>
+#include "membackend/ramulatorBackend.h"
+
+#include "Config.h"
+#include "Request.h"
+
+using namespace SST;
+using namespace SST::MemHierarchy;
+using namespace ramulator;
+
+ramulatorMemory::ramulatorMemory(Component *comp, Params &params) : 
+    MemBackend(comp, params),
+    callBackFunc(std::bind(&ramulatorMemory::ramulatorDone, this, std::placeholders::_1))
+{
+    std::string ramulatorCfg = params.find<std::string>("configFile",
+                                                        NO_STRING_DEFINED);
+    ramulator::Config configs(ramulatorCfg);
+    
+    configs.set_core_num(1); // ?
+
+    memSystem = new Gem5Wrapper(configs,64); // default cache line to 64 byte
+
+    output->output(CALL_INFO, "Instantiated Ramulator from config file %s\n", ramulatorCfg.c_str());
+}
+
+bool ramulatorMemory::issueRequest(DRAMReq *req){
+    uint64_t addr = req->baseAddr_ + req->amtInProcess_;
+    ramulator::Request::Type type = (req->isWrite_) 
+        ? (ramulator::Request::Type::WRITE) : (ramulator::Request::Type::READ);
+
+    ramulator::Request request(addr, 
+                               type,
+                               callBackFunc, 
+                               0);  /* context or core ID. ? */
+    bool ok = memSystem->send(request);
+    if(!ok) return false;
+
+    // save this DRAM Request
+    dramReqs[addr].push_back(req); 
+
+    return ok;
+}
+
+void ramulatorMemory::clock(){
+    memSystem->tick();
+}
+
+void ramulatorMemory::finish(){
+    memSystem->finish();
+}
+
+
+void ramulatorMemory::ramulatorDone(ramulator::Request& ramReq) {
+    uint64_t addr = ramReq.addr;
+    std::deque<DRAMReq *> &reqs = dramReqs[addr];
+
+#ifdef __SST_DEBUG_OUTPUT__
+    ctrl->dbg.debug(_L10_, "Memory Request for %" PRIx64 " Finished [%zu reqs]\n", (Addr)addr, reqs.size());
+#endif
+    assert(reqs.size());
+    DRAMReq *req = reqs.front();
+    reqs.pop_front();
+    if(0 == reqs.size())
+        dramReqs.erase(addr);
+
+    ctrl->handleMemResponse(req);
+}

--- a/src/sst/elements/memHierarchy/membackend/ramulatorBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/ramulatorBackend.cc
@@ -30,6 +30,9 @@ ramulatorMemory::ramulatorMemory(Component *comp, Params &params) :
 {
     std::string ramulatorCfg = params.find<std::string>("configFile",
                                                         NO_STRING_DEFINED);
+    if (ramulatorCfg == NO_STRING_DEFINED) {
+        ctrl->dbg.fatal(CALL_INFO, -1, "Ramulator Backend must define a 'configFile' file parameter\n");
+    } 
     ramulator::Config configs(ramulatorCfg);
     
     configs.set_core_num(1); // ?

--- a/src/sst/elements/memHierarchy/membackend/ramulatorBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/ramulatorBackend.h
@@ -1,0 +1,49 @@
+// Copyright 2009-2016 Sandia Corporation. Under the terms
+// of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2016, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef _H_SST_MEMH_RAMULATOR_BACKEND
+#define _H_SST_MEMH_RAMULATOR_BACKEND
+
+#include "membackend/memBackend.h"
+
+#include "Gem5Wrapper.h"
+
+#ifdef OLD_DEBUG
+#define DEBUG OLD_DEBUG
+#undef OLD_DEBUG
+#endif
+
+namespace SST {
+namespace MemHierarchy {
+
+class ramulatorMemory : public MemBackend {
+public:
+    ramulatorMemory(Component *comp, Params &params);
+    virtual bool issueRequest(DRAMReq *req);
+    virtual void clock();
+    virtual void finish();
+
+protected:
+    ramulator::Gem5Wrapper *memSystem;
+    std::function<void(ramulator::Request&)> callBackFunc;
+    std::map<uint64_t, std::deque<DRAMReq*> > dramReqs;
+    void ramulatorDone(ramulator::Request& req);
+};
+
+}
+}
+
+#endif

--- a/src/sst/elements/memHierarchy/streamCPU.cc
+++ b/src/sst/elements/memHierarchy/streamCPU.cc
@@ -46,6 +46,8 @@ streamCPU::streamCPU(ComponentId_t id, Params& params) :
         out.fatal(CALL_INFO, -1, "Must set memSize\n");
     }
 
+    maxOutstanding = params.find<uint64_t>("maxOutstanding", 10);
+
     do_write = params.find<bool>("do_write", 1);
 
     numLS = params.find<int>("num_loadstore", -1);
@@ -122,7 +124,7 @@ bool streamCPU::clockTic( Cycle_t )
 {
 	// communicate?
 	if ((numLS != 0) && ((rng.generateNextUInt32() % commFreq) == 0)) {
-		if ( requests.size() > 10 ) {
+		if ( requests.size() > maxOutstanding ) {
 			out.verbose(CALL_INFO, 1, 0, "Not issuing operation, too many outstanding requests are in flight.\n");
 		} else {
 

--- a/src/sst/elements/memHierarchy/streamCPU.h
+++ b/src/sst/elements/memHierarchy/streamCPU.h
@@ -59,6 +59,7 @@ private:
 	int commFreq;
 	bool do_write;
 	uint32_t maxAddr;
+	uint32_t maxOutstanding;
 	uint32_t nextAddr;
 	uint64_t num_reads_issued, num_reads_returned;
 	uint64_t addrOffset;

--- a/src/sst/elements/memHierarchy/tests/sdl4-2-ramulator.py
+++ b/src/sst/elements/memHierarchy/tests/sdl4-2-ramulator.py
@@ -1,0 +1,92 @@
+# Automatically generated SST Python input
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "300000ns")
+
+# Define the simulation components
+comp_cpu0 = sst.Component("cpu0", "memHierarchy.trivialCPU")
+comp_cpu0.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c0_l1cache = sst.Component("c0.l1cache", "memHierarchy.Cache")
+comp_c0_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "cache_size" : "4 KB",
+      "L1" : "1",
+      "debug" : "0"
+})
+comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
+comp_cpu1.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c1_l1cache = sst.Component("c1.l1cache", "memHierarchy.Cache")
+comp_c1_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "cache_size" : "4 KB",
+      "L1" : "1",
+      "debug" : "0"
+})
+comp_bus = sst.Component("bus", "memHierarchy.Bus")
+comp_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_l2cache = sst.Component("l2cache", "memHierarchy.Cache")
+comp_l2cache.addParams({
+      "access_latency_cycles" : "20",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "cache_size" : "32 KB",
+      "debug" : "0"
+})
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MSI",
+      "debug" : "0",
+      "clock" : "1GHz",
+      "backend.mem_size" : "512MiB",
+      "backend.access_time" : "100 ns",
+      "backend.configFile" : "/Users/afrodri/Public/ramulator-afrodri/configs/DDR3-config.cfg",
+      "backend" : "memHierarchy.ramulator"
+})
+
+# Enable statistics
+sst.setStatisticLoadLevel(7)
+sst.setStatisticOutput("sst.statOutputConsole")
+sst.enableAllStatisticsForComponentType("memHierarchy.Cache")
+sst.enableAllStatisticsForComponentType("memHierarchy.MemController")
+
+# Define the simulation links
+link_cpu0_l1cache_link = sst.Link("link_cpu0_l1cache_link")
+link_cpu0_l1cache_link.connect( (comp_cpu0, "mem_link", "1000ps"), (comp_c0_l1cache, "high_network_0", "1000ps") )
+link_c0_l1_l2_link = sst.Link("link_c0_l1_l2_link")
+link_c0_l1_l2_link.connect( (comp_c0_l1cache, "low_network_0", "1000ps"), (comp_bus, "high_network_0", "10000ps") )
+link_cpu1_l1cache_link = sst.Link("link_cpu1_l1cache_link")
+link_cpu1_l1cache_link.connect( (comp_cpu1, "mem_link", "1000ps"), (comp_c1_l1cache, "high_network_0", "1000ps") )
+link_c1_l1_l2_link = sst.Link("link_c1_l1_l2_link")
+link_c1_l1_l2_link.connect( (comp_c1_l1cache, "low_network_0", "1000ps"), (comp_bus, "high_network_1", "10000ps") )
+link_bus_l2cache = sst.Link("link_bus_l2cache")
+link_bus_l2cache.connect( (comp_bus, "low_network_0", "10000ps"), (comp_l2cache, "high_network_0", "1000ps") )
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l2cache, "low_network_0", "10000ps"), (comp_memory, "direct_link", "10000ps") )
+# End of generated output.

--- a/src/sst/elements/memHierarchy/tests/sdl4-2-ramulator.py
+++ b/src/sst/elements/memHierarchy/tests/sdl4-2-ramulator.py
@@ -8,9 +8,10 @@ sst.setProgramOption("stopAtCycle", "300000ns")
 # Define the simulation components
 comp_cpu0 = sst.Component("cpu0", "memHierarchy.trivialCPU")
 comp_cpu0.addParams({
-      "memSize" : "0x1000",
+      "memSize" : "0x100000",
       "num_loadstore" : "1000",
-      "commFreq" : "100",
+      "maxOutstanding" : "64",
+      "commFreq" : "1",
       "do_write" : "1"
 })
 comp_c0_l1cache = sst.Component("c0.l1cache", "memHierarchy.Cache")
@@ -27,9 +28,10 @@ comp_c0_l1cache.addParams({
 })
 comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
 comp_cpu1.addParams({
-      "memSize" : "0x1000",
+      "memSize" : "0x100000",
       "num_loadstore" : "1000",
-      "commFreq" : "100",
+      "maxOutstanding" : "64",
+      "commFreq" : "1",
       "do_write" : "1"
 })
 comp_c1_l1cache = sst.Component("c1.l1cache", "memHierarchy.Cache")
@@ -67,7 +69,10 @@ comp_memory.addParams({
       "backend.mem_size" : "512MiB",
       "backend.access_time" : "100 ns",
       "backend.configFile" : "/Users/afrodri/Public/ramulator-afrodri/configs/DDR3-config.cfg",
-      "backend" : "memHierarchy.ramulator"
+      "backend" : "memHierarchy.ramulator",
+      #"backend.system_ini" : "system.ini",
+      #"backend.device_ini" : "DDR3_micron_32M_8B_x4_sg125.ini",
+      #"backend" : "memHierarchy.dramsim"
 })
 
 # Enable statistics

--- a/src/sst/elements/memHierarchy/tests/sdl5-1-ramulator.py
+++ b/src/sst/elements/memHierarchy/tests/sdl5-1-ramulator.py
@@ -1,0 +1,182 @@
+# Automatically generated SST Python input
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "300000ns")
+
+# Define the simulation components
+comp_cpu0 = sst.Component("cpu0", "memHierarchy.trivialCPU")
+comp_cpu0.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c0_l1cache = sst.Component("c0.l1cache", "memHierarchy.Cache")
+comp_c0_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
+comp_cpu1.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c1_l1cache = sst.Component("c1.l1cache", "memHierarchy.Cache")
+comp_c1_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
+comp_n0_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_n0_l2cache = sst.Component("n0.l2cache", "memHierarchy.Cache")
+comp_n0_l2cache.addParams({
+      "access_latency_cycles" : "20",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "32 KB"
+})
+comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
+comp_cpu2.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c2_l1cache = sst.Component("c2.l1cache", "memHierarchy.Cache")
+comp_c2_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
+comp_cpu3.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c3_l1cache = sst.Component("c3.l1cache", "memHierarchy.Cache")
+comp_c3_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
+comp_n1_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_n1_l2cache = sst.Component("n1.l2cache", "memHierarchy.Cache")
+comp_n1_l2cache.addParams({
+      "access_latency_cycles" : "20",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "32 KB"
+})
+comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
+comp_n2_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_l3cache = sst.Component("l3cache", "memHierarchy.Cache")
+comp_l3cache.addParams({
+      "access_latency_cycles" : "100",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "64 KB"
+})
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MSI",
+      "debug" : "0",
+      "clock" : "1GHz",
+      "backend.mem_size" : "512MiB",
+      "backend.configFile" : "/Users/afrodri/Public/ramulator/configs/DDR3-config.cfg",
+      "backend" : "memHierarchy.ramulator"
+})
+
+# Enable statistics
+sst.setStatisticLoadLevel(7)
+sst.setStatisticOutput("sst.statOutputConsole")
+sst.enableAllStatisticsForComponentType("memHierarchy.Cache")
+sst.enableAllStatisticsForComponentType("memHierarchy.MemController")
+
+# Define the simulation links
+link_cpu0_l1cache_link = sst.Link("link_cpu0_l1cache_link")
+link_cpu0_l1cache_link.connect( (comp_cpu0, "mem_link", "1000ps"), (comp_c0_l1cache, "high_network_0", "1000ps") )
+link_c0_l1cache_l2cache_link = sst.Link("link_c0_l1cache_l2cache_link")
+link_c0_l1cache_l2cache_link.connect( (comp_c0_l1cache, "low_network_0", "10000ps"), (comp_n0_bus, "high_network_0", "10000ps") )
+link_cpu1_l1cache_link = sst.Link("link_cpu1_l1cache_link")
+link_cpu1_l1cache_link.connect( (comp_cpu1, "mem_link", "1000ps"), (comp_c1_l1cache, "high_network_0", "1000ps") )
+link_c1_l1cache_l2cache_link = sst.Link("link_c1_l1cache_l2cache_link")
+link_c1_l1cache_l2cache_link.connect( (comp_c1_l1cache, "low_network_0", "10000ps"), (comp_n0_bus, "high_network_1", "10000ps") )
+link_n0_bus_l2cache = sst.Link("link_n0_bus_l2cache")
+link_n0_bus_l2cache.connect( (comp_n0_bus, "low_network_0", "10000ps"), (comp_n0_l2cache, "high_network_0", "1000ps") )
+link_n0_l2cache_l3cache = sst.Link("link_n0_l2cache_l3cache")
+link_n0_l2cache_l3cache.connect( (comp_n0_l2cache, "low_network_0", "10000ps"), (comp_n2_bus, "high_network_0", "10000ps") )
+link_cpu2_l1cache_link = sst.Link("link_cpu2_l1cache_link")
+link_cpu2_l1cache_link.connect( (comp_cpu2, "mem_link", "1000ps"), (comp_c2_l1cache, "high_network_0", "1000ps") )
+link_c2_l1cache_l2cache_link = sst.Link("link_c2_l1cache_l2cache_link")
+link_c2_l1cache_l2cache_link.connect( (comp_c2_l1cache, "low_network_0", "10000ps"), (comp_n1_bus, "high_network_0", "10000ps") )
+link_cpu3_l1cache_link = sst.Link("link_cpu3_l1cache_link")
+link_cpu3_l1cache_link.connect( (comp_cpu3, "mem_link", "1000ps"), (comp_c3_l1cache, "high_network_0", "1000ps") )
+link_c3_l1cache_l2cache_link = sst.Link("link_c3_l1cache_l2cache_link")
+link_c3_l1cache_l2cache_link.connect( (comp_c3_l1cache, "low_network_0", "10000ps"), (comp_n1_bus, "high_network_1", "10000ps") )
+link_n1_bus_l2cache = sst.Link("link_n1_bus_l2cache")
+link_n1_bus_l2cache.connect( (comp_n1_bus, "low_network_0", "10000ps"), (comp_n1_l2cache, "high_network_0", "1000ps") )
+link_n1_l2cache_l3cache = sst.Link("link_n1_l2cache_l3cache")
+link_n1_l2cache_l3cache.connect( (comp_n1_l2cache, "low_network_0", "10000ps"), (comp_n2_bus, "high_network_1", "10000ps") )
+link_bus_l3cache = sst.Link("link_bus_l3cache")
+link_bus_l3cache.connect( (comp_n2_bus, "low_network_0", "10000ps"), (comp_l3cache, "high_network_0", "10000ps") )
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l3cache, "low_network_0", "10000ps"), (comp_memory, "direct_link", "10000ps") )
+# End of generated output.

--- a/src/sst/elements/memHierarchy/trivialCPU.cc
+++ b/src/sst/elements/memHierarchy/trivialCPU.cc
@@ -45,6 +45,8 @@ trivialCPU::trivialCPU(ComponentId_t id, Params& params) :
     }
     
     maxAddr = params.find<uint64_t>("memSize", -1) -1;
+
+    maxOutstanding = params.find<uint64_t>("maxOutstanding", 10);
     
     if ( !maxAddr ) {
         out.fatal(CALL_INFO, -1, "Must set memSize\n");
@@ -121,7 +123,7 @@ bool trivialCPU::clockTic( Cycle_t )
 
 	// communicate?
 	if ((0 != numLS) && (0 == (rng.generateNextUInt32() % commFreq))) {
-		if ( requests.size() > 10 ) {
+		if ( requests.size() > maxOutstanding ) {
 			out.output("%s: Not issuing read.  Too many outstanding requests.\n",
 					getName().c_str());
 		} else {

--- a/src/sst/elements/memHierarchy/trivialCPU.h
+++ b/src/sst/elements/memHierarchy/trivialCPU.h
@@ -70,6 +70,7 @@ private:
     int commFreq;
     bool do_write;
     uint64_t maxAddr;
+    uint64_t maxOutstanding;
     uint64_t num_reads_issued, num_reads_returned;
     uint64_t noncacheableRangeStart, noncacheableRangeEnd;
     uint64_t clock_ticks;


### PR DESCRIPTION
Modifications to integrate with Ramulator memory simulator. 
Primarily, this adds a new memory backend. It is very similar to the DRAMSim backend.
Also, there are some modifications to trivialCPU and streamCPU to make testing a bit easier (bumped up the number of requests in flight) and a couple of test files, based on existing DRAMSim tests. 

The Modified Ramulator code is:
https://github.com/afrodri/ramulator
(Very minor changes, I have submitted a pull request to the Ramulator team)