### PR TITLE
New feature

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -57,6 +57,10 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 		hmc_trace_level = hmc_trace_level | HMC_TRACE_STALL;
 	}
 
+        if(params.find<bool>("trace-power", false)) {
+          hmc_trace_level = hmc_trace_level | HMC_TRACE_POWER;
+        }
+
 	hmc_tag_count    = params.find<uint32_t>("tag_count", 64);
 
 	hmc_trace_file   = params.find<std::string>("trace_file", "hmc-trace.out");

--- a/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
@@ -1,0 +1,63 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream1.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1.py
@@ -1,0 +1,58 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
@@ -1,0 +1,72 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "4",
+      "backend.vault_count" : "16",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "4",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream2.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2.py
@@ -1,0 +1,67 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "4",
+      "backend.vault_count" : "16",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "4",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
@@ -1,0 +1,72 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "8",
+      "backend.vault_count" : "32",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "8",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/tests/goblin_singlestream3.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3.py
@@ -1,0 +1,67 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.SingleStreamGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.device_count" : "1",
+      "backend.link_count" : "8",
+      "backend.vault_count" : "32",
+      "backend.queue_depth" : "64",
+      "backend.bank_count" : "16",
+      "backend.dram_count" : "20",
+      "backend.capacity_per_device" : "8",
+      "backend.xbar_depth" : "128",
+      "backend.max_req_size" : "128"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )


### PR DESCRIPTION
Adds the ability to enable/disable device power tracing in Goblin HMC-Sim version 3.0+ (upstream). This patch adds "trace-power" to the goblinHMCSim component parameters to enable/disable HMC_TRACE_POWER. The current tracing output is written to the hmc-trace.out trace file.  Reworking pull request following github fail.  

Power tracing values include: 
— Link Phy
— Link Local Route (route of packet to local quadrant)
— Link Remote Route (route of packet to distant quadrant)
— Crossbar Request Slot (active SRAM/register state)
— Crossbar Response Slot (active SRAM/register state)
— Crossbar External Route (Cube-to-Cube route minus link phy)
— Vault Request Slot
— Vault Response Slot
— Vault Controller
— Row Access (inclues pre-charge+activate+fetch+sense)
