### PR TITLE
Power Metric Parameters and CMC-Lib Parameters for HMC-Sim 3.0+

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -119,11 +119,7 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
             // attempt to add the cmc lib
             output->verbose(CALL_INFO, 1, 0,
                             "Initializing HMC-Sim CMC Library...\n" );
-            std::vector<char> libchars(cmclibs[i].c_str(),
-                                       cmclibs[i].c_str() +
-                                        cmclibs[i].size() +
-                                        1u);
-            //if( hmcsim_load_cmc(&the_hmc, cmclibs[i].c_str() ) != 0 ){
+            std::vector<char> libchars( cmclibs[i].begin(), cmclibs[i].end() );
             rc = hmcsim_load_cmc(&the_hmc, &libchars[0] );
             if( rc != 0 ){
 	      output->fatal(CALL_INFO, -1,

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -65,6 +65,8 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 
 	hmc_trace_file   = params.find<std::string>("trace_file", "hmc-trace.out");
 
+        params.find_array<std::string>("cmc-lib", cmclibs);
+
 	output->verbose(CALL_INFO, 1, 0, "Initializing HMC...\n");
 	int rc = hmcsim_init(&the_hmc,
 		hmc_dev_count,
@@ -81,6 +83,24 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 	} else {
 		output->verbose(CALL_INFO, 1, 0, "Initialized successfully.\n");
 	}
+
+        // load the cmc libs
+        for( unsigned i=0; i< cmclibs.size(); i++ ){
+          if( cmclibs[i].length() > 0 ){
+            // attempt to add the cmc lib
+            output->verbose(CALL_INFO, 1, 0,
+                            "Initializing HMC-Sim CMC Library...\n" );
+            std::vector<char> libchars(cmclibs[i].c_str(),
+                                       cmclibs[i].c_str() +
+                                        cmclibs[i].size() +
+                                        1u);
+            //if( hmcsim_load_cmc(&the_hmc, cmclibs[i].c_str() ) != 0 ){
+            if( hmcsim_load_cmc(&the_hmc, &libchars[0] ) != 0 ){
+	      output->fatal(CALL_INFO, -1,
+                            "Unable to HMC-Sim CMC Library and the return code is %d\n", rc);
+            }
+          }
+        }
 
 	for(uint32_t i = 0; i < hmc_link_count; ++i) {
 		output->verbose(CALL_INFO, 1, 0, "Configuring link: %" PRIu32 "...\n", i);

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -35,6 +35,18 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 	hmc_capacity_per_device = params.find<uint32_t>("capacity_per_device", HMC_MIN_CAPACITY);
 	hmc_xbar_depth   =  params.find<uint32_t>("xbar_depth", 4);
 	hmc_max_req_size =  params.find<uint32_t>("max_req_size", 64);
+
+        link_phy = params.find<float>("link_phy_power", 0.1);
+        link_local_route = params.find<float>("link_local_route_power", 0.1);
+        link_remote_route = params.find<float>("link_remote_route_power", 0.1);
+        xbar_rqst_slot = params.find<float>("xbar_rqst_slot_power", 0.1);
+        xbar_rsp_slot = params.find<float>("xbar_rsp_slot_power", 0.1);
+        xbar_route_extern = params.find<float>("xbar_route_extern_power", 0.1);
+        vault_rqst_slot = params.find<float>("vault_rqst_slot_power", 0.1);
+        vault_rsp_slot = params.find<float>("vault_rsp_slot_power", 0.1);
+        vault_ctrl = params.find<float>("vault_ctrl_power", 0.1);
+        row_access = params.find<float>("row_access_power", 0.1);
+
 	hmc_trace_level  = 0;
 
 	if (params.find<bool>("trace-banks", false)) {
@@ -84,6 +96,23 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
 		output->verbose(CALL_INFO, 1, 0, "Initialized successfully.\n");
 	}
 
+        // load the power config
+        rc = hmcsim_power_config( &the_hmc,
+                                 link_phy,
+                                 link_local_route,
+                                 link_remote_route,
+                                 xbar_rqst_slot,
+                                 xbar_rsp_slot,
+                                 xbar_route_extern,
+                                 vault_rqst_slot,
+                                 vault_rsp_slot,
+                                 vault_ctrl,
+                                 row_access );
+        if( rc != 0 ){
+	    output->fatal(CALL_INFO, -1,
+                          "Unable to initialize the HMC-Sim power configuration; return code is %d\n", rc);
+        }
+
         // load the cmc libs
         for( unsigned i=0; i< cmclibs.size(); i++ ){
           if( cmclibs[i].length() > 0 ){
@@ -95,7 +124,8 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : MemB
                                         cmclibs[i].size() +
                                         1u);
             //if( hmcsim_load_cmc(&the_hmc, cmclibs[i].c_str() ) != 0 ){
-            if( hmcsim_load_cmc(&the_hmc, &libchars[0] ) != 0 ){
+            rc = hmcsim_load_cmc(&the_hmc, &libchars[0] );
+            if( rc != 0 ){
 	      output->fatal(CALL_INFO, -1,
                             "Unable to HMC-Sim CMC Library and the return code is %d\n", rc);
             }

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -78,6 +78,8 @@ private:
 
 	uint32_t nextLink;
 
+        std::vector<std::string> cmclibs;
+
 	std::string hmc_trace_file;
 	FILE* hmc_trace_file_handle;
 

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -76,6 +76,17 @@ private:
 	uint32_t hmc_tag_count;
 	uint32_t hmc_trace_level;
 
+        float link_phy;
+        float link_local_route;
+        float link_remote_route;
+        float xbar_rqst_slot;
+        float xbar_rsp_slot;
+        float xbar_route_extern;
+        float vault_rqst_slot;
+        float vault_rsp_slot;
+        float vault_ctrl;
+        float row_access;
+
 	uint32_t nextLink;
 
         std::vector<std::string> cmclibs;


### PR DESCRIPTION
Adding parameter parsing for power measurement feature strings.  Each device component power metric can be individually tuned in an SST python script.  Adding CMC (custom memory cube) support.  CMC libraries can now be loaded directly from the SST python script.

This pull request adds the following parameters for goblinHMCBackend: 
- link_phy_power : float
- link_local_route_power : float
- link_remote_route_power : float
- xbar_rqst_slot_power : float
- xbar_rsp_slot_power : float
- xbar_route_extern_power : float
- vault_rqst_slot_power : float
- vault_rsp_slot_power : float
- vault_ctrl_power : float
- row_access_power : float
- cmc-lib : std::string

The cmc-lib value is interpreted using 'find_array'.  As such, the arguments must be in the form: 
"[/path/to/lib1.so,/path/to/lib2.so]"
---
## Instructions for Issuing a Pull Request to sst-elements

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
- Automatic Testing will commence in a short while 
  - Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
    - These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
  - If testing passes, the source branch will be automatically merged (if possible)
    - Pull Requests from forks will not be automatically tested until the code is inspected.
    - Pull Requests from forks will not be automatically merged into the devel branch.
  - If testing fails, You will be notified of the test results.  
    - The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
## 4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
