### PR TITLE
adding logic to initialize the DRAM latency timing information

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -35,6 +35,9 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : Simp
 	hmc_capacity_per_device = params.find<uint32_t>("capacity_per_device", HMC_MIN_CAPACITY);
 	hmc_xbar_depth   =  params.find<uint32_t>("xbar_depth", 4);
 	hmc_max_req_size =  params.find<uint32_t>("max_req_size", 64);
+#if defined( HMC_DEF_DRAM_LATENCY )
+        hmc_dram_latency = params.find<uint32_t>("dram_latency", HMC_DEF_DRAM_LATENCY );
+#endif
 
         link_phy = params.find<float>("link_phy_power", 0.1);
         link_local_route = params.find<float>("link_local_route_power", 0.1);
@@ -114,6 +117,13 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : Simp
         if( rc != 0 ){
 	    output->fatal(CALL_INFO, -1,
                           "Unable to initialize the HMC-Sim power configuration; return code is %d\n", rc);
+        }
+#endif
+#if defined( HMC_DEF_DRAM_LATENCY )
+        rc = hmcsim_init_dram_latency( &the_hmc, hmc_dram_latency );
+        if( rc != 0 ){
+	    output->fatal(CALL_INFO, -1,
+                          "Unable to initialize the HMC-Sim dram latency configuration; return code is %d\n", rc);
         }
 #endif
 

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -80,6 +80,7 @@ private:
 	uint32_t hmc_max_trace_level;
 	uint32_t hmc_tag_count;
 	uint32_t hmc_trace_level;
+        uint32_t hmc_dram_latency;
 
         float link_phy;
         float link_local_route;

--- a/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
@@ -48,7 +48,7 @@ comp_memory.addParams({
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "4",
-      "backend.vault_count" : "16",
+      "backend.vault_count" : "32",
       "backend.queue_depth" : "64",
       "backend.bank_count" : "16",
       "backend.dram_count" : "20",

--- a/src/sst/elements/miranda/tests/goblin_singlestream2.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2.py
@@ -48,7 +48,7 @@ comp_memory.addParams({
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "4",
-      "backend.vault_count" : "16",
+      "backend.vault_count" : "32",
       "backend.queue_depth" : "64",
       "backend.bank_count" : "16",
       "backend.dram_count" : "20",

--- a/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3-trace.py
@@ -48,7 +48,7 @@ comp_memory.addParams({
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "8",
-      "backend.vault_count" : "32",
+      "backend.vault_count" : "64",
       "backend.queue_depth" : "64",
       "backend.bank_count" : "16",
       "backend.dram_count" : "20",

--- a/src/sst/elements/miranda/tests/goblin_singlestream3.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3.py
@@ -48,7 +48,7 @@ comp_memory.addParams({
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "8",
-      "backend.vault_count" : "32",
+      "backend.vault_count" : "64",
       "backend.queue_depth" : "64",
       "backend.bank_count" : "16",
       "backend.dram_count" : "20",


### PR DESCRIPTION
adding logic to initialize the DRAM latency timing information; this requires the use of HMC-Sim 3.0+ as there is a new function interface to initialize the timing info.  All the changes in the goblinHMCBackend are bounded by "HMC_DEF_DRAM_LATENCY" macros in order to protect backward compatibility.  

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----
