### PR TITLE
Adding entries for smaller page sizes, when bringing a translation + …

### DIFF
--- a/src/sst/elements/Samba/PageTableWalker.h
+++ b/src/sst/elements/Samba/PageTableWalker.h
@@ -89,6 +89,7 @@ class PageTableWalker
 
 	std::vector<SST::Event *> not_serviced; // This holds those accesses not serviced yet
 
+
 	int self_connected; // his parameter indidicates if the PTW is self-connected or actually connected to the memory hierarchy
 
 	int page_walk_latency; // this is really nothing than the page walk latency in case of having no walkers

--- a/src/sst/elements/Samba/TLBUnit.h
+++ b/src/sst/elements/Samba/TLBUnit.h
@@ -32,6 +32,9 @@ using namespace SST::SambaComponent;
 class TLB 
 {
 
+	int level; // This indicates the level of the TLB Unit
+
+	int perfect; // This indidicates if the TLB is perfect or not, perfect is used to measure performance overhead over an ideal TLB hierarchy
 
 	int sizes; // This indicates the number of sizes supported
 
@@ -48,6 +51,9 @@ class TLB
 	PageTableWalker * PTW; // This is a pointer to the PTW in case of being last level
 
 	std::map<long long int, int> SIZE_LOOKUP; // This structure checks if a size is supported inside the structure, and its index structure
+
+	std::map< long long int, std::map< SST::Event *, int>> SAME_MISS; // This tracks the misses for the same location and deduplicates them
+	std::map<long long int, int> PENDING_MISS; // This tracks the addresses of the current master misses (other contained misses are tracked in SAME_MISS)
 
 	int  * sets; //stores the number of sets
 

--- a/src/sst/elements/Samba/libSamba.cc
+++ b/src/sst/elements/Samba/libSamba.cc
@@ -49,6 +49,7 @@ static const ElementInfoParam Samba_params[] = {
 
     {"corecount", "Number of CPU cores to emulate, i.e., number of private Sambas", "1"},
     {"levels", "Number of TLB levels per Samba", "1"},
+    {"perfect", "This is set to 1, when modeling an ideal TLB hierachy with 100\% hit rate", "0"},
     {"os_page_size", "This represents the size of frames the OS allocates in KB", "4"}, // This is a hack, assuming the OS allocated only one page size, this will change later
     {"sizes_L%(levels)", "Number of page sizes supported by Samba", "1"},
     {"page_size%(sizes)_L%(levels)d", "the page size of the supported page size number x in level y","4"},
@@ -61,7 +62,7 @@ static const ElementInfoParam Samba_params[] = {
     {"latency_L%(levels)d", "the access latency in cycles for this level of memory","1"},
     {"parallel_mode_L%(levels)d", "this is for the corner case of having a one cycle overlap with accessing cache","0"},
     {"page_walk_latency", "Each page table walk latency in nanoseconds", "50"},
-    {"self_connected", "Determines if the page walkers are acutally connected to memory hierarcy or just add fixed latency (self-connected)", "1"},
+    {"self_connected", "Determines if the page walkers are acutally connected to memory hierarcy or just add fixed latency (self-connected)", "0"},
     {NULL, NULL, NULL},
 };
 


### PR DESCRIPTION
Adding support for the following cases:
- Handling multiple misses for the same 4KB translation doesn't generate multiple requests to lower levels, but just wait to receive the translation for the first (master) request.
- When a large page translation is brought in, the TLB unit inserts it on all smaller page sizes structures. For example, when we bring a 2MB page translation to an L1 TLB with only 4KB translations support, it adjusts the offset and also add a 4KB translation for that address.

---

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----

…coalesce concurrent misses to the same address