### PR TITLE
Change test input file for compatibility with output config

### DIFF
--- a/src/sst/elements/CramSim/tests/test_txntrace4.py
+++ b/src/sst/elements/CramSim/tests/test_txntrace4.py
@@ -83,7 +83,7 @@ def setup_config_params():
     else:
         l_configFile = open(g_config_file, 'r')
         for l_line in l_configFile:
-            l_tokens = l_line.split(' ')
+            l_tokens = l_line.split()
             #print l_tokens[0], ": ", l_tokens[1]
             l_params[l_tokens[0]] = l_tokens[1]
 


### PR DESCRIPTION
Remove explicit "split on space" and use the implicit "Split on whitespace"  to avoid get extra newline in SST generated Python file.