### PR TITLE
Remove boost references in merlin

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/backing.h
+++ b/src/sst/elements/memHierarchy/membackend/backing.h
@@ -17,6 +17,7 @@
 #define __SST_MEMH_BACKEND_BACKING
 
 #include <fcntl.h>
+#include <unistd.h>
 #include "sst/elements/memHierarchy/util.h"
 
 namespace SST {

--- a/src/sst/elements/merlin/merlin.h
+++ b/src/sst/elements/merlin/merlin.h
@@ -35,62 +35,6 @@ namespace Merlin {
     static Output merlin_abort("Merlin: ", 5, -1, Output::STDERR);
     static Output merlin_abort_full("Merlin: @f, line @l: ", 5, -1, Output::STDOUT);
     
-// Whole class definition needs to be in the header file so that other
-// libraries can use the class to talk with the merlin routers.
-
-    // static TimeConverter* getTimeConverterFromGbps(const std::string gbps) {
-    //     // Check to make sure this is a valid floating point number.
-    //     // Just need to check each character to see if it is a number
-    //     // or a period.  Plus, can have only one period.
-    //     bool decimal = false;
-    //     bool start_num = false;
-    //     bool end_num = false;
-    //     for ( int i = 0; i < gbps.length(); i++ ) {
-    //         if ( !start_num ) {
-    //             // Only valid characters are white space, which we
-    //             // ignore, or a digit, which starts the number.
-    //             if ( isspace(gbps[i]) ) continue;
-    //             else if ( isdigit(gbps[i]) ) {
-    //                 start_num = true;
-    //                 // Decrement index so that it will look at it next
-    //                 // loop, but now with start_num set to true.
-    //                 i--;
-    //             }
-    //             else {
-    //                 return NULL;
-    //             }
-    //         }
-    //         else if ( !end_num ) {
-    //             // Valid characters are digits, decimal point (if a
-    //             // decimal point hasn't already occurred) and white
-    //             // space (which ends the number).
-    //             if ( gbps[i] == '.' ) {
-    //                 if ( decimal ) return NULL; // Second decimal point, ERROR
-    //                 else {
-    //                     decimal = true;
-    //                     continue;
-    //                 }
-    //             }
-    //             else if ( isspace(gbps[i]) ) {
-    //                 end_num == true;
-    //                 continue;
-    //             }
-    //             else {
-    //                 if ( !isdigit(gbps[i] ) ) return NULL;
-    //             }
-    //         }
-    //         else {
-    //             // Number is done, only whitespace allowed
-    //             if ( !isspace(gbps[i]) ) return NULL;
-    //         }
-    //     }
-
-    //     // Add "GHz" to end of string and send to getTimeConverter
-    //     std::string temp = gbps;
-    //     temp.append("GHz");
-    //     return Simulation::getSimulation()->getTimeLord()->getTimeConverter(temp);
-    // }
-
 }
 }
 

--- a/src/sst/elements/merlin/trafficgen/trafficgen.h
+++ b/src/sst/elements/merlin/trafficgen/trafficgen.h
@@ -19,8 +19,7 @@
 #ifndef COMPONENTS_MERLIN_GENERATORS_TRAFFICEGEN_H
 #define COMPONENTS_MERLIN_GENERATORS_TRAFFICEGEN_H
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/binomial_distribution.hpp>
+#include <cstdlib>
 
 #include <sst/core/rng/mersenne.h>
 #include <sst/core/rng/gaussian.h>
@@ -35,6 +34,7 @@
 #include <sst/core/timeConverter.h>
 #include <sst/core/output.h>
 
+#include "sst/elements/merlin/merlin.h"
 #include "sst/elements/merlin/linkControl.h"
 
 #define ENABLE_FINISH_HACK 0
@@ -61,7 +61,7 @@ private:
         virtual int getNextValue(void) = 0;
         virtual void seed(uint32_t val) = 0;
     };
-
+    
     class NearestNeighbor : public Generator {
         Generator *dist;
         int *neighbors;
@@ -89,8 +89,8 @@ private:
                     "Unsure how to deal with %d neighbors\n", numNeighbors);
             }
         }
-
-	int getNextValue(void)
+        
+        int getNextValue(void)
         {
             int neighbor = dist->getNextValue();
             return neighbors[neighbor];
@@ -197,7 +197,7 @@ private:
 
         void seed(uint32_t val)
         {
-	    gen = new MersenneRNG((unsigned int) val);
+            gen = new MersenneRNG((unsigned int) val);
         }
     };
 
@@ -210,8 +210,8 @@ private:
     public:
         NormalDist(int min, int max, double mean, double stddev) : minValue(min), maxValue(max)
         {
-	    gen = new MersenneRNG();
-	    dist = new SSTGaussianDistribution(mean, stddev);
+            gen = new MersenneRNG();
+            dist = new SSTGaussianDistribution(mean, stddev);
         }
 
 	~NormalDist() {
@@ -229,26 +229,25 @@ private:
 
         void seed(uint32_t val)
         {
-	    gen = new MersenneRNG((unsigned int) val);
+            gen = new MersenneRNG((unsigned int) val);
         }
     };
 
     class BinomialDist : public Generator {
-        boost::random::mt19937 gen;
-        boost::random::binomial_distribution<> dist;
         int minValue;
     public:
         BinomialDist(int min, int max, int trials, float probability) : minValue(min)
         {
-            dist = boost::random::binomial_distribution<>(trials, probability);
+            merlin_abort.fatal(CALL_INFO, -1, "BinomialDist is not currently supported\n");
         }
         virtual int getNextValue(void)
         {
-            return dist(gen) + minValue;
+            // return dist(gen) + minValue;
+            return 0;
         }
         virtual void seed(uint32_t val)
         {
-            gen.seed(val);
+            // gen.seed(val);
         }
     };
 


### PR DESCRIPTION
Removes boost from merlin library.  Also adds a necessary header in memHierarchy that was being included through the boost includes in core.  This is in preparation for removing boost from the core.