### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
@@ -30,7 +30,7 @@ using namespace SST::MemHierarchy;
 #endif
 
 MemBackendConvertor::MemBackendConvertor(Component *comp, Params& params ) : 
-    SubComponent(comp), m_reqId(0)
+    SubComponent(comp), m_cycleCount(0), m_reqId(0)
 {
     m_dbg.init("--->  ", 
             params.find<uint32_t>("debug_level", 0),


### PR DESCRIPTION
Valgrind was reporting use of uninitialized variable in some statistics.  Tracked down to this variable being uninitialized.   In C++, POD typed member variables are not initialized to zero.
