### PR TITLE
Remove boost from CramSim

### DIFF
--- a/src/sst/elements/CramSim/Makefile.am
+++ b/src/sst/elements/CramSim/Makefile.am
@@ -3,7 +3,6 @@
 #
 
 AM_CPPFLAGS = \
-	$(BOOST_CPPFLAGS) \
 	$(MPI_CPPFLAGS)
 
 compdir = $(pkglibdir)

--- a/src/sst/elements/CramSim/c_TracefileReader.hpp
+++ b/src/sst/elements/CramSim/c_TracefileReader.hpp
@@ -19,7 +19,6 @@
 #include <stdint.h>
 #include <queue>
 #include<iostream>
-#include<boost/tokenizer.hpp>
 #include<string>
 #include<fstream>
 

--- a/src/sst/elements/CramSim/configure.m4
+++ b/src/sst/elements/CramSim/configure.m4
@@ -5,8 +5,5 @@ dnl
 AC_DEFUN([SST_CramSim_CONFIG], [
 	cs_happy="yes"
 
-  # Check for BOOST
-  SST_CHECK_BOOST([],[cs_happy="no"])
-
   AS_IF([test "$cs_happy" = "yes"], [$1], [$2])
 ])


### PR DESCRIPTION
Cramsim was only requiring boost due to an include file.  Removed the include and changed the configure.m4 and makefile.am files.