### PR TITLE
Memh remove boost

### DIFF
--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -3,7 +3,7 @@
 #
 
 AM_CPPFLAGS = \
-	$(BOOST_CPPFLAGS) $(MPI_CPPFLAGS) \
+	$(MPI_CPPFLAGS) \
 	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)

--- a/src/sst/elements/memHierarchy/cacheEventProcessing.cc
+++ b/src/sst/elements/memHierarchy/cacheEventProcessing.cc
@@ -357,7 +357,7 @@ void Cache::processNoncacheable(MemEvent* event, Command cmd, Addr baseAddr) {
             // Flushes can be returned out of order since they don't neccessarily require a memory access so we need to actually search the MSHRs
             vector<mshrType> * entries = mshrNoncacheable_->getAll(baseAddr);
             for (vector<mshrType>::iterator it = entries->begin(); it != entries->end(); it++) {
-                MemEvent * candidate = boost::get<MemEvent*>(it->elem);
+                MemEvent * candidate = (it->elem).getEvent();
                 if (candidate->getCmd() == FlushLine || candidate->getCmd() == FlushLineInv) { // All entries are events so no checking for pointer vs event needed
                     if (candidate->getID().first == event->getResponseToID().first && candidate->getID().second == event->getResponseToID().second) {
                         origRequest = candidate;

--- a/src/sst/elements/memHierarchy/configure.m4
+++ b/src/sst/elements/memHierarchy/configure.m4
@@ -23,8 +23,5 @@ AC_DEFUN([SST_memHierarchy_CONFIG], [
   # Use FlashDIMMSim
   SST_CHECK_FDSIM([],[],[AC_MSG_ERROR([FlashDIMMSim requested but could not be found])])
 
-  # Check for BOOST
-  SST_CHECK_BOOST([],[mh_happy="no"])
-
   AS_IF([test "$mh_happy" = "yes"], [$1], [$2])
 ])

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -1681,7 +1681,7 @@ void DirectoryController::replayWaitingEvents(Addr addr) {
     if (mshr->isHit(addr)) {
         vector<mshrType> replayEntries = mshr->removeAll(addr);
         for (vector<mshrType>::reverse_iterator it = replayEntries.rbegin(); it != replayEntries.rend(); it++) {
-            MemEvent *ev = boost::get<MemEvent*>((*it).elem);
+            MemEvent *ev = ((*it).elem).getEvent();
 #ifdef __SST_DEBUG_OUTPUT__
             if (DEBUG_ALL || DEBUG_ADDR == addr) {
                 dbg.debug(_L5_, "Reactivating event. Cmd = %s, BaseAddr = 0x%" PRIx64 ", Addr = 0x%" PRIx64 "\n", CommandString[ev->getCmd()], ev->getBaseAddr(), ev->getAddr());

--- a/src/sst/elements/memHierarchy/mshr.cc
+++ b/src/sst/elements/memHierarchy/mshr.cc
@@ -16,6 +16,8 @@
 #include <sst_config.h>
 #include "mshr.h"
 
+#include <algorithm>
+
 using namespace SST;
 using namespace SST::MemHierarchy;
 

--- a/src/sst/elements/memHierarchy/mshr.cc
+++ b/src/sst/elements/memHierarchy/mshr.cc
@@ -22,16 +22,16 @@ using namespace SST::MemHierarchy;
 struct MSHREntryCompare {
     enum Type {Event, Pointer};
     MSHREntryCompare( mshrType* _m ) : m_(_m) {
-        if (m_->elem.type() == typeid(MemEvent*)) type_ = Event;
+        if (m_->elem.isEvent()) type_ = Event;
         else type_ = Pointer;
     }
     bool operator() (mshrType& _n) {
         if (type_ == Event) {
-            if (_n.elem.type() == typeid(MemEvent*)) return boost::get<MemEvent*>(m_->elem) == boost::get<MemEvent*>(_n.elem);
+            if (_n.elem.isEvent()) return (m_->elem).getEvent() == (_n.elem).getEvent();
             return false;
         }
         else{
-            if (_n.elem.type() == typeid(Addr)) return boost::get<Addr>(m_->elem) == boost::get<Addr>(_n.elem);
+            if (_n.elem.isAddr()) return (m_->elem).getAddr() == (_n.elem).getAddr();
             return false;
         }
     }
@@ -142,7 +142,7 @@ bool MSHR::exists(Addr baseAddr) {
     vector<mshrType> * queue = &((it->second).mshrQueue);
     vector<mshrType>::iterator frontEntry = queue->begin();
     if (frontEntry == queue->end()) return false;
-    return (frontEntry->elem.type() == typeid(MemEvent*));
+    return (frontEntry->elem.isEvent());
 }
 
 bool MSHR::isHit(Addr baseAddr) { return (map_.find(baseAddr) != map_.end()) && (map_.find(baseAddr)->second.mshrQueue.size() > 0); }
@@ -173,10 +173,10 @@ MemEvent* MSHR::lookupFront(Addr baseAddr) {
         d2_->fatal(CALL_INFO,-1, "%s (MSHR), Error: mshr did not find entry with address 0x%" PRIx64 "\n", ownerName_.c_str(), baseAddr);
     }
     vector<mshrType> queue = (it->second).mshrQueue;
-    if (queue.front().elem.type() != typeid(MemEvent*)) {
+    if (queue.front().elem.isAddr()) {
         d2_->fatal(CALL_INFO,-1, "%s (MSHR), Error: front entry in mshr is not of type MemEvent. Addr = 0x%" PRIx64 "\n", ownerName_.c_str(), baseAddr);
     }
-    return boost::get<MemEvent*>(queue.front().elem);
+    return (queue.front().elem).getEvent();
 }
 
 /* Public insertion methods
@@ -267,9 +267,9 @@ bool MSHR::insertAll(Addr baseAddr, vector<mshrType>& events) {
     int trueSize = 0;
     int prefetches = 0;
     for (vector<mshrType>::iterator it = events.begin(); it != events.end(); it++) {
-        if ((*it).elem.type() == typeid(MemEvent*)) {
+        if ((*it).elem.isEvent()) {
             trueSize++;
-            if ((boost::get<MemEvent*>(it->elem))->isPrefetch()) 
+            if (((it->elem)).getEvent()->isPrefetch()) 
                 prefetches++;
         }
     }
@@ -303,8 +303,8 @@ bool MSHR::insertInv(Addr baseAddr, mshrType entry, bool inProgress) {
     /*int i = 0;
     for (it = map_[baseAddr].mshrQueue.begin(); it != map_[baseAddr].mshrQueue.end(); it++) {
         if (inProgress && it == map_[baseAddr].mshrQueue.begin()) continue;
-        if (it->elem.type() == typeid(MemEvent*)) {
-            MemEvent * ev = boost::get<MemEvent*>(it->elem);
+        if (it->elem.isEvent()) {
+            MemEvent * ev = getEvent(it->elem);
             if (ev->getCmd() == GetS || ev->getCmd() == GetSEx || ev->getCmd() == GetX) {
                 break;
             }
@@ -313,7 +313,7 @@ bool MSHR::insertInv(Addr baseAddr, mshrType entry, bool inProgress) {
     }*/
     if (inProgress && map_[baseAddr].mshrQueue.size() > 0) it++;
     map_[baseAddr].mshrQueue.insert(it, entry);
-    if (entry.elem.type() == typeid(MemEvent*)) size_++;
+    if (entry.elem.isEvent()) size_++;
     //printTable();
     return true;
 }
@@ -328,8 +328,8 @@ MemEvent* MSHR::getOldestRequest() const {
     MemEvent *ev = NULL;
     for ( mshrTable::const_iterator it = map_.begin() ; it != map_.end() ; ++it ) {
         for ( vector<mshrType>::const_iterator jt = (it->second).mshrQueue.begin() ; jt != (it->second).mshrQueue.end() ; jt++ ) {
-            if ( jt->elem.type() == typeid(MemEvent*) ) {
-                MemEvent *me = boost::get<MemEvent*>(jt->elem);
+            if ( jt->elem.isEvent() ) {
+                MemEvent *me = (jt->elem).getEvent();
                 if ( !ev || ( me->getInitializationTime() < ev->getInitializationTime() ) ) {
                     ev = me;
                 }
@@ -366,9 +366,9 @@ vector<mshrType> MSHR::removeAll(Addr baseAddr) {
     int trueSize = 0;
     int prefetches = 0;
     for (vector<mshrType>::iterator it = res.begin(); it != res.end(); it++) {
-        if ((*it).elem.type() == typeid(MemEvent*)) {
+        if ((*it).elem.isEvent()) {
             trueSize++;
-            MemEvent * ev = boost::get<MemEvent*>(it->elem);
+            MemEvent * ev = (it->elem).getEvent();
             if (ev->isPrefetch()) prefetches++;
         }
     }
@@ -390,11 +390,11 @@ MemEvent* MSHR::removeFront(Addr baseAddr) {
     //  d2_->fatal(CALL_INFO,-1, "%s (MSHR), Error: no front entry to remove in mshr for addr = 0x%" PRIx64 "\n", ownerName_.c_str(), baseAddr);
     //}
     //
-    // if (it->second.front().elem.type() != typeid(MemEvent*)) {
+    // if (it->second.front().elem.isAddr()) {
     //     d2_->fatal(CALL_INFO,-1, "%s (MSHR), Error: front entry in mshr is not of type MemEvent. Addr = 0x%" PRIx64 "\n", ownerName_.c_str(), baseAddr);
     // }
     
-    MemEvent* ret = boost::get<MemEvent*>((it->second).mshrQueue.front().elem);
+    MemEvent* ret = ((it->second).mshrQueue.front().elem).getEvent();
     
     if (ret->isPrefetch()) prefetchCount_--;
     
@@ -487,12 +487,12 @@ void MSHR::printTable() {
         vector<mshrType> entries = (it->second).mshrQueue;
         d_->debug(_L9_, "MSHR: Addr = 0x%" PRIx64 "\n", (it->first));
         for (vector<mshrType>::iterator it2 = entries.begin(); it2 != entries.end(); it2++) {
-            if (it2->elem.type() != typeid(MemEvent*)) {
-                Addr ptr = boost::get<Addr>(it2->elem);
+            if (it2->elem.isAddr()) {
+                Addr ptr = (it2->elem).getAddr();
                 d_->debug(_L9_, "\t0x%" PRIx64 "\n", ptr);
 
             } else {
-                MemEvent * ev = boost::get<MemEvent*>(it2->elem);
+                MemEvent * ev = (it2->elem).getEvent();
                 d_->debug(_L9_, "\t%s, %s\n", ev->getSrc().c_str(), CommandString[ev->getCmd()]);
             }
         }

--- a/src/sst/elements/memHierarchy/mshr.h
+++ b/src/sst/elements/memHierarchy/mshr.h
@@ -27,15 +27,36 @@
 #include <util.h>
 #include <string>
 #include <sstream>
-#include <boost/variant.hpp>
 
 namespace SST { namespace MemHierarchy {
 
 using namespace std;
 
+// Specific version of variant class to replace boost::variant
+
+class variant_lite {
+    union {
+        Addr addr;
+        MemEvent* event;
+    } data;
+    bool _isAddr;
+    
+public:
+    variant_lite(Addr a) {data.addr = a; _isAddr = true; }
+    variant_lite(MemEvent* ev) {data.event = ev; _isAddr = false; }
+
+    Addr getAddr() const { return data.addr; }
+    MemEvent* getEvent() const { return data.event; }
+
+    bool isAddr() const { return _isAddr; }
+    bool isEvent() const { return !_isAddr; }
+    
+};
+
 /* MSHRs hold both events and pointers to events (e.g., the address of an event to replay when the current event resolves) */
 struct mshrType {
-    boost::variant<Addr, MemEvent*> elem;
+    variant_lite elem;
+    // boost::variant<Addr, MemEvent*> elem;
     MemEvent * event;
     mshrType(MemEvent* ev) : elem(ev), event(ev) {}
     mshrType(Addr addr) : elem(addr) {}

--- a/src/sst/elements/memHierarchy/mshr.h
+++ b/src/sst/elements/memHierarchy/mshr.h
@@ -34,7 +34,7 @@ using namespace std;
 
 // Specific version of variant class to replace boost::variant
 
-class variant_lite {
+class AddrEventVariant {
     union {
         Addr addr;
         MemEvent* event;
@@ -42,8 +42,8 @@ class variant_lite {
     bool _isAddr;
     
 public:
-    variant_lite(Addr a) {data.addr = a; _isAddr = true; }
-    variant_lite(MemEvent* ev) {data.event = ev; _isAddr = false; }
+    AddrEventVariant(Addr a) {data.addr = a; _isAddr = true; }
+    AddrEventVariant(MemEvent* ev) {data.event = ev; _isAddr = false; }
 
     Addr getAddr() const { return data.addr; }
     MemEvent* getEvent() const { return data.event; }
@@ -55,7 +55,7 @@ public:
 
 /* MSHRs hold both events and pointers to events (e.g., the address of an event to replay when the current event resolves) */
 struct mshrType {
-    variant_lite elem;
+    AddrEventVariant elem;
     // boost::variant<Addr, MemEvent*> elem;
     MemEvent * event;
     mshrType(MemEvent* ev) : elem(ev), event(ev) {}


### PR DESCRIPTION
Removed the use of boost::variant in mshr.h.  Replace it with AddrEventVariant, which is a variant-like implementation for the specific case of types Addr and MemEvent*.