### PR TITLE
added HBM backend to memHierarchy and associated configurations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,15 +2,6 @@ Copyright 2009-2017 Sandia Corporation. Under the terms
 of Contract DE-NA0003525 with Sandia Corporation, the U.S.
 Government retains certain rights in this software.
 
-Sandia National Laboratories is a multimission laboratory
-managed and operated by National Technology and Engineering
-Solutions of Sandia, LLC., a wholly owned subsidiary of
-Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract
-DE-NA0003525.
-
-Copyright (c) 2009-2017, Sandia Corporation
-
 All rights reserved.
 
 Portions are copyright of other developers:
@@ -44,3 +35,12 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Sandia National Laboratories is a multimission laboratory
+managed and operated by National Technology and Engineering
+Solutions of Sandia, LLC., a wholly owned subsidiary of
+Honeywell International, Inc., for the U.S. Department of
+Energy's National Nuclear Security Administration under contract
+DE-NA0003525.
+
+Copyright (c) 2009-2017, Sandia Corporation

--- a/LICENSE
+++ b/LICENSE
@@ -36,11 +36,3 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Sandia National Laboratories is a multimission laboratory
-managed and operated by National Technology and Engineering
-Solutions of Sandia, LLC., a wholly owned subsidiary of
-Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract
-DE-NA0003525.
-
-Copyright (c) 2009-2017, Sandia Corporation

--- a/config/sst_check_hbmsim.m4
+++ b/config/sst_check_hbmsim.m4
@@ -1,0 +1,44 @@
+
+AC_DEFUN([SST_CHECK_HBMSIM], [
+  AC_ARG_WITH([hbmsim],
+    [AS_HELP_STRING([--with-hbmsim@<:@=DIR@:>@],
+      [Use HBMSim package installed in optionally specified DIR])])
+
+  sst_check_hbmsim_happy="yes"
+  AS_IF([test "$with_hbmsim" = "no"], [sst_check_hbmsim_happy="no"])
+
+  CPPFLAGS_saved="$CPPFLAGS"
+  LDFLAGS_saved="$LDFLAGS"
+  LIBS_saved="$LIBS"
+
+  AS_IF([test ! -z "$with_hbmsim" -a "$with_hbmsim" != "yes"],
+    [HBMSIM_CPPFLAGS="-I$with_hbmsim -DHAVE_HBMSIM"
+     CPPFLAGS="$HBMSIM_CPPFLAGS $CPPFLAGS"
+     HBMSIM_LDFLAGS="-L$with_hbmsim"
+     HBMSIM_LIBDIR="$with_hbmsim"
+     LDFLAGS="$HBMSIM_LDFLAGS $LDFLAGS"],
+    [HBMSIM_CPPFLAGS=
+     HBMSIM_LDFLAGS=
+     HBMSIM_LIBDIR=])
+
+  AC_LANG_PUSH(C++)
+  AC_CHECK_HEADERS([HBMSim.h], [], [sst_check_hbmsim_happy="no"])
+  AC_CHECK_LIB([hbmsim], [libhbmsim_is_present],
+    [HBMSIM_LIB="-lhbmsim"], [sst_check_hbmsim_happy="no"])
+  AC_LANG_POP(C++)
+
+  CPPFLAGS="$CPPFLAGS_saved"
+  LDFLAGS="$LDFLAGS_saved"
+  LIBS="$LIBS_saved"
+
+  AC_SUBST([HBMSIM_CPPFLAGS])
+  AC_SUBST([HBMSIM_LDFLAGS])
+  AC_SUBST([HBMSIM_LIB])
+  AC_SUBST([HBMSIM_LIBDIR])
+  AM_CONDITIONAL([HAVE_HBMSIM], [test "$sst_check_hbmsim_happy" = "yes"])
+  AS_IF([test "$sst_check_hbmsim_happy" = "yes"],
+        [AC_DEFINE([HAVE_HBMSIM], [1], [Set to 1 if HBMSim was found])])
+  AC_DEFINE_UNQUOTED([HBMSIM_LIBDIR], ["$HBMSIM_LIBDIR"], [Path to HBMSim library])
+
+  AS_IF([test "$sst_check_hbmsim_happy" = "yes"], [$1], [$2])
+])

--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -192,6 +192,15 @@ nobase_sst_HEADERS += membackend/pagedMultiBackend.h
 
 endif
 
+if HAVE_HBMSIM
+libmemHierarchy_la_LDFLAGS += $(HBMSIM_LDFLAGS)
+libmemHierarchy_la_LIBADD += $(HBMSIM_LIB)
+libmemHierarchy_la_SOURCES += membackend/hbmSimBackend.cc \
+	membackend/hbmSimBackend.h
+nobase_sst_HEADERS += membackend/hbmSimBackend.h
+AM_CPPFLAGS += $(HBMSIM_CPPFLAGS) -DHAVE_LIBHBMSIM
+endif
+
 if HAVE_HYBRIDSIM
 libmemHierarchy_la_LDFLAGS += $(HYBRIDSIM_LDFLAGS)
 libmemHierarchy_la_LIBADD += $(HYBRIDSIM_LIB)
@@ -232,6 +241,7 @@ AM_CPPFLAGS += $(HMC_FLAG)
 
 install-exec-hook:
 	$(SST_REGISTER_TOOL) DRAMSIM LIBDIR=$(DRAMSIM_LIBDIR)
+	$(SST_REGISTER_TOOL) HBMSIM LIBDIR=$(HBMSIM_LIBDIR)
 	$(SST_REGISTER_TOOL) HYBRIDSIM LIBDIR=$(HYBRIDSIM_LIBDIR)
 	$(SST_REGISTER_TOOL) NVDIMMSIM LIBDIR=$(NVDIMMSIM_LIBDIR)
 	$(SST_REGISTER_TOOL) FDSIM LIBDIR=$(FDSIM_LIBDIR)

--- a/src/sst/elements/memHierarchy/configure.m4
+++ b/src/sst/elements/memHierarchy/configure.m4
@@ -11,6 +11,9 @@ AC_DEFUN([SST_memHierarchy_CONFIG], [
   # Use global DRAMSim check
   SST_CHECK_DRAMSIM([],[],[AC_MSG_ERROR([DRAMSim requested but could not be found])])
 
+  # Use global HBMSim check
+  SST_CHECK_HBMSIM([],[],[AC_MSG_ERROR([HBMSim requested but could not be found])])
+
   # Use global HybridSim check
   SST_CHECK_HYBRIDSIM([],[],[AC_MSG_ERROR([HybridSim requested but could not be found])])
 

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -74,6 +74,10 @@
 #include "membackend/pagedMultiBackend.h"
 #endif
 
+#ifdef HAVE_LIBHBMSIM
+#include "membackend/hbmSimBackend.h"
+#endif
+
 #ifdef HAVE_LIBHYBRIDSIM
 #include "membackend/hybridSimBackend.h"
 #endif
@@ -1145,6 +1149,24 @@ static const ElementInfoStatistic pagedMultiMem_statistics[] = {
 
 #endif
 
+/*****************************************************************************************
+ *  SubComponent: hbmSimMemory
+ *  Purpose: Memory backend, interface to HBMSim
+ *****************************************************************************************/
+#if defined(HAVE_LIBHBMSIM)
+static SubComponent* create_Mem_HBMSim(Component* comp, Params& params){
+    return new HBMSimMemory(comp, params);
+}
+
+
+static const ElementInfoParam hbmsimMem_params[] = {
+    {"verbose",          "Sets the verbosity of the backend output", "0" },
+    {"device_ini",      "Name of HBMSim Device config file", NULL},
+    {"system_ini",      "Name of HBMSim Device system file", NULL},
+    {NULL, NULL, NULL}
+};
+#endif
+
 
 /*****************************************************************************************
  *  SubComponent: hybridSimMemory
@@ -1593,6 +1615,17 @@ static const ElementInfoSubComponent subcomponents[] = {
         create_Mem_pagedMulti, /* Module Alloc w/ params */
         pagedMultiMem_params,
         pagedMultiMem_statistics, /* statistics */
+        "SST::MemHierarchy::MemBackend"
+    },
+#endif
+#if defined(HAVE_LIBHBMSIM)
+    {
+        "hbmsim",
+        "HBMSim-driven memory timings",
+        NULL, /* Advanced help */
+        create_Mem_HBMSim, /* Module Alloc w/ params */
+        hbmsimMem_params,
+        NULL, /* statistics */
         "SST::MemHierarchy::MemBackend"
     },
 #endif

--- a/src/sst/elements/memHierarchy/membackend/hbmSimBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/hbmSimBackend.cc
@@ -1,0 +1,94 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include <sst_config.h>
+#include "sst/elements/memHierarchy/util.h"
+#include "membackend/hbmSimBackend.h"
+
+using namespace SST;
+using namespace SST::MemHierarchy;
+
+HBMSimMemory::HBMSimMemory(Component *comp, Params &params)
+    : SimpleMemBackend(comp, params) {
+  std::string deviceIniFilename =
+      params.find<std::string>("device_ini", NO_STRING_DEFINED);
+  if (NO_STRING_DEFINED == deviceIniFilename)
+    output->fatal(CALL_INFO, -1,
+                  "Model must define a 'device_ini' file parameter\n");
+  std::string systemIniFilename =
+      params.find<std::string>("system_ini", NO_STRING_DEFINED);
+  if (NO_STRING_DEFINED == systemIniFilename)
+    output->fatal(CALL_INFO, -1,
+                  "Model must define a 'system_ini' file parameter\n");
+
+  UnitAlgebra ramSize = UnitAlgebra(params.find<std::string>("mem_size", "0B"));
+  if (ramSize.getRoundedValue() % (1024 * 1024) != 0) {
+    output->fatal(CALL_INFO, -1,
+                  "For HBMSim, backend.mem_size must be a multiple of 1MiB. "
+                  "Note: for units in base-10 use 'MB', for base-2 use 'MiB'. "
+                  "You specified '%s'\n",
+                  ramSize.toString().c_str());
+  }
+  unsigned int ramSizeMiB = ramSize.getRoundedValue() / (1024 * 1024);
+
+  memSystem = HBMSim::getMemorySystemInstance(
+      deviceIniFilename, systemIniFilename, "", ramSizeMiB);
+
+  HBMSim::Callback<HBMSimMemory, void, unsigned int, uint64_t, uint64_t>
+      *readDataCB, *writeDataCB;
+
+  readDataCB =
+      new HBMSim::Callback<HBMSimMemory, void, unsigned int, uint64_t,
+                            uint64_t>(this, &HBMSimMemory::dramSimDone);
+  writeDataCB =
+      new HBMSim::Callback<HBMSimMemory, void, unsigned int, uint64_t,
+                            uint64_t>(this, &HBMSimMemory::dramSimDone);
+
+  memSystem->RegisterCallbacks(readDataCB, writeDataCB);
+}
+
+bool HBMSimMemory::issueRequest(ReqId id, Addr addr, bool isWrite, unsigned) {
+  bool ok = memSystem->willAcceptTransaction(addr);
+  if (!ok) return false;
+  ok = memSystem->addTransaction(isWrite, addr);
+  if (!ok) return false;  // This *SHOULD* always be ok
+#ifdef __SST_DEBUG_OUTPUT__
+  output->debug(_L10_, "Issued transaction for address %" PRIx64 "\n",
+                (Addr)addr);
+#endif
+  dramReqs[addr].push_back(id);
+  return true;
+}
+
+void HBMSimMemory::clock() { memSystem->update(); }
+
+void HBMSimMemory::finish() { memSystem->printStats(true); }
+
+void HBMSimMemory::dramSimDone(unsigned int id, uint64_t addr,
+                               uint64_t clockcycle) {
+  std::deque<ReqId> &reqs = dramReqs[addr];
+#ifdef __SST_DEBUG_OUTPUT__
+  output->debug(_L10_, "Memory Request for %" PRIx64 " Finished [%zu reqs]\n",
+                (Addr)addr, reqs.size());
+#endif
+  if (reqs.size() == 0)
+    output->fatal(CALL_INFO, -1,
+                  "Error: reqs.size() is 0 at HBMSimMemory done\n");
+  ReqId reqId = reqs.front();
+  reqs.pop_front();
+  if (0 == reqs.size()) dramReqs.erase(addr);
+
+  handleMemResponse(reqId);
+}

--- a/src/sst/elements/memHierarchy/membackend/hbmSimBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/hbmSimBackend.h
@@ -1,0 +1,53 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef _H_SST_MEMH_HBMSIM_BACKEND
+#define _H_SST_MEMH_HBMSIM_BACKEND
+
+#include "membackend/memBackend.h"
+
+#ifdef DEBUG
+#define OLD_DEBUG DEBUG
+#undef DEBUG
+#endif
+
+#include <HBMSim.h>
+
+#ifdef OLD_DEBUG
+#define DEBUG OLD_DEBUG
+#undef OLD_DEBUG
+#endif
+
+namespace SST {
+namespace MemHierarchy {
+
+class HBMSimMemory : public SimpleMemBackend {
+  public:
+  HBMSimMemory(Component *comp, Params &params);
+  virtual bool issueRequest(ReqId, Addr, bool, unsigned);
+  virtual void clock();
+  virtual void finish();
+
+  protected:
+  void dramSimDone(unsigned int id, uint64_t addr, uint64_t clockcycle);
+
+  HBMSim::MultiChannelMemorySystem *memSystem;
+  std::map<uint64_t, std::deque<ReqId>> dramReqs;
+};
+}
+}
+
+#endif

--- a/src/sst/elements/memHierarchy/tests/hbm.py
+++ b/src/sst/elements/memHierarchy/tests/hbm.py
@@ -1,0 +1,180 @@
+# Automatically generated SST Python input
+import sst
+
+# Define the simulation components
+comp_cpu0 = sst.Component("cpu0", "memHierarchy.trivialCPU")
+comp_cpu0.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c0_l1cache = sst.Component("c0.l1cache", "memHierarchy.Cache")
+comp_c0_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_cpu1 = sst.Component("cpu1", "memHierarchy.trivialCPU")
+comp_cpu1.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c1_l1cache = sst.Component("c1.l1cache", "memHierarchy.Cache")
+comp_c1_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_n0_bus = sst.Component("n0.bus", "memHierarchy.Bus")
+comp_n0_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_n0_l2cache = sst.Component("n0.l2cache", "memHierarchy.Cache")
+comp_n0_l2cache.addParams({
+      "access_latency_cycles" : "20",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "32 KB"
+})
+comp_cpu2 = sst.Component("cpu2", "memHierarchy.trivialCPU")
+comp_cpu2.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c2_l1cache = sst.Component("c2.l1cache", "memHierarchy.Cache")
+comp_c2_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_cpu3 = sst.Component("cpu3", "memHierarchy.trivialCPU")
+comp_cpu3.addParams({
+      "memSize" : "0x1000",
+      "num_loadstore" : "1000",
+      "commFreq" : "100",
+      "do_write" : "1"
+})
+comp_c3_l1cache = sst.Component("c3.l1cache", "memHierarchy.Cache")
+comp_c3_l1cache.addParams({
+      "access_latency_cycles" : "5",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "L1" : "1",
+      "debug" : "0",
+      "cache_size" : "4 KB"
+})
+comp_n1_bus = sst.Component("n1.bus", "memHierarchy.Bus")
+comp_n1_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_n1_l2cache = sst.Component("n1.l2cache", "memHierarchy.Cache")
+comp_n1_l2cache.addParams({
+      "access_latency_cycles" : "20",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "32 KB"
+})
+comp_n2_bus = sst.Component("n2.bus", "memHierarchy.Bus")
+comp_n2_bus.addParams({
+      "bus_frequency" : "2 Ghz"
+})
+comp_l3cache = sst.Component("l3cache", "memHierarchy.Cache")
+comp_l3cache.addParams({
+      "access_latency_cycles" : "100",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MSI",
+      "associativity" : "8",
+      "cache_line_size" : "64",
+      "debug_level" : "8",
+      "debug" : "0",
+      "cache_size" : "64 KB"
+})
+comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MSI",
+      "debug" : "0",
+      "clock" : "1GHz",
+      "backend.mem_size" : "4GiB",
+      "backend.access_time" : "1000 ns",
+      "backend.system_ini" : "/root/local/packages/HBM/ini/HBMSystemLegacy.ini",
+      "backend.device_ini" : "/root/local/packages/HBM/ini/HBMDevice4GbLegacy.ini",
+      "backend" : "memHierarchy.hbmsim"
+})
+
+# Enable statistics
+sst.setStatisticLoadLevel(7)
+sst.setStatisticOutput("sst.statOutputConsole")
+sst.enableAllStatisticsForComponentType("memHierarchy.Cache")
+sst.enableAllStatisticsForComponentType("memHierarchy.MemController")
+
+# Define the simulation links
+link_cpu0_l1cache_link = sst.Link("link_cpu0_l1cache_link")
+link_cpu0_l1cache_link.connect( (comp_cpu0, "mem_link", "1000ps"), (comp_c0_l1cache, "high_network_0", "1000ps") )
+link_c0_l1cache_l2cache_link = sst.Link("link_c0_l1cache_l2cache_link")
+link_c0_l1cache_l2cache_link.connect( (comp_c0_l1cache, "low_network_0", "10000ps"), (comp_n0_bus, "high_network_0", "10000ps") )
+link_cpu1_l1cache_link = sst.Link("link_cpu1_l1cache_link")
+link_cpu1_l1cache_link.connect( (comp_cpu1, "mem_link", "1000ps"), (comp_c1_l1cache, "high_network_0", "1000ps") )
+link_c1_l1cache_l2cache_link = sst.Link("link_c1_l1cache_l2cache_link")
+link_c1_l1cache_l2cache_link.connect( (comp_c1_l1cache, "low_network_0", "10000ps"), (comp_n0_bus, "high_network_1", "10000ps") )
+link_n0_bus_l2cache = sst.Link("link_n0_bus_l2cache")
+link_n0_bus_l2cache.connect( (comp_n0_bus, "low_network_0", "10000ps"), (comp_n0_l2cache, "high_network_0", "1000ps") )
+link_n0_l2cache_l3cache = sst.Link("link_n0_l2cache_l3cache")
+link_n0_l2cache_l3cache.connect( (comp_n0_l2cache, "low_network_0", "10000ps"), (comp_n2_bus, "high_network_0", "10000ps") )
+link_cpu2_l1cache_link = sst.Link("link_cpu2_l1cache_link")
+link_cpu2_l1cache_link.connect( (comp_cpu2, "mem_link", "1000ps"), (comp_c2_l1cache, "high_network_0", "1000ps") )
+link_c2_l1cache_l2cache_link = sst.Link("link_c2_l1cache_l2cache_link")
+link_c2_l1cache_l2cache_link.connect( (comp_c2_l1cache, "low_network_0", "10000ps"), (comp_n1_bus, "high_network_0", "10000ps") )
+link_cpu3_l1cache_link = sst.Link("link_cpu3_l1cache_link")
+link_cpu3_l1cache_link.connect( (comp_cpu3, "mem_link", "1000ps"), (comp_c3_l1cache, "high_network_0", "1000ps") )
+link_c3_l1cache_l2cache_link = sst.Link("link_c3_l1cache_l2cache_link")
+link_c3_l1cache_l2cache_link.connect( (comp_c3_l1cache, "low_network_0", "10000ps"), (comp_n1_bus, "high_network_1", "10000ps") )
+link_n1_bus_l2cache = sst.Link("link_n1_bus_l2cache")
+link_n1_bus_l2cache.connect( (comp_n1_bus, "low_network_0", "10000ps"), (comp_n1_l2cache, "high_network_0", "1000ps") )
+link_n1_l2cache_l3cache = sst.Link("link_n1_l2cache_l3cache")
+link_n1_l2cache_l3cache.connect( (comp_n1_l2cache, "low_network_0", "10000ps"), (comp_n2_bus, "high_network_1", "10000ps") )
+link_bus_l3cache = sst.Link("link_bus_l3cache")
+link_bus_l3cache.connect( (comp_n2_bus, "low_network_0", "10000ps"), (comp_l3cache, "high_network_0", "10000ps") )
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l3cache, "low_network_0", "10000ps"), (comp_memory, "direct_link", "10000ps") )
+# End of generated output.


### PR DESCRIPTION
1. added HBM backend to memHierarchy and made some changes so that HBM memory can be used with memHierarchy.
2. added config/sst_check_hbmsim.m4 file.
3. added memHierarchy/test/hbm.py for sanity check.