### PR TITLE
fixing namespace issues with pageInfo structure and links to HBM-targ…

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/HBMdramSimBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/HBMdramSimBackend.cc
@@ -15,8 +15,8 @@
 
 // Originally derived from the DRAMSim membackend
 // Modified to provide HBM-specific functionality
-// using the GATech DRAMSim port from:
-// https://github.com/gthparch/HBM
+// using the DRAMSim port from:
+// https://github.com/tactcomplabs/HBM
 
 #include <sst_config.h>
 #include "sst/elements/memHierarchy/util.h"

--- a/src/sst/elements/memHierarchy/membackend/HBMdramSimBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/HBMdramSimBackend.h
@@ -16,8 +16,8 @@
 // -------------------------------------------------
 // Originally derived from the DRAMSim membackend
 // Modified to provide HBM-specific functionality
-// using the GATech DRAMSim port from:
-// https://github.com/gthparch/HBM
+// using the DRAMSim port from:
+// https://github.com/tactcomplabs/HBM
 // -------------------------------------------------
 
 
@@ -31,7 +31,7 @@
 #undef DEBUG
 #endif
 
-#include <DRAMSim.h>
+#include <HBMDRAMSim.h>
 
 #ifdef OLD_DEBUG
 #define DEBUG OLD_DEBUG

--- a/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.cc
@@ -137,7 +137,7 @@ HBMpagedMultiMemory::HBMpagedMultiMemory(Component *comp, Params &params)
 }
 
 // should we add it?
-bool HBMpagedMultiMemory::checkAdd(pageInfo &page) {
+bool HBMpagedMultiMemory::checkAdd(HBMpageInfo &page) {
     // only add if the dram isn't too busy
     if (dramBackpressure && dramQ.size() >= 4) return false;
 
@@ -224,7 +224,7 @@ bool HBMpagedMultiMemory::checkAdd(pageInfo &page) {
     }
 }
 
-void HBMpagedMultiMemory::do_FIFO_LRU( pageInfo &page, bool &inFast, bool &swapping) {  
+void HBMpagedMultiMemory::do_FIFO_LRU( HBMpageInfo &page, bool &inFast, bool &swapping) {  
     swapping = 0;
     if (0 == page.inFast) {
         // not in fast
@@ -239,13 +239,13 @@ void HBMpagedMultiMemory::do_FIFO_LRU( pageInfo &page, bool &inFast, bool &swapp
                 if (modelSwaps) {moveToFast(page);}
             } else {
                 // kick someone out
-                pageInfo *victimPage = pageList.back();
-                pageInfo::pageListIter e = pageList.end();
+                HBMpageInfo *victimPage = pageList.back();
+                HBMpageInfo::pageListIter e = pageList.end();
                 bool found = 0;
                 while (e != pageList.begin()) {
                     e--;
                     victimPage = *e;
-                    if (victimPage->swapDir == pageInfo::NONE) {
+                    if (victimPage->swapDir == HBMpageInfo::NONE) {
                         found = 1;
                         break;
                     }
@@ -273,12 +273,12 @@ void HBMpagedMultiMemory::do_FIFO_LRU( pageInfo &page, bool &inFast, bool &swapp
                 if (modelSwaps) {moveToFast(page);}
                 if ((replaceStrat == BiLRU) && ((rng->generateNextUInt32() & 0x7f) == 0)) { // roughly 1:128 chance
                     pageList.push_back(&page); // put in back of list
-                    pageInfo::pageListIter le = pageList.end(); le--;
+                    HBMpageInfo::pageListIter le = pageList.end(); le--;
                     page.listEntry = le;
                 } else if ((replaceStrat == SCLRU) && (page.scanLeng > scanThreshold)) {
                     // put "scan-y" pages at the back
                     pageList.push_back(&page); // put in back of list
-                    pageInfo::pageListIter le = pageList.end(); le--;
+                    HBMpageInfo::pageListIter le = pageList.end(); le--;
                     page.listEntry = le;
                 } else {
                     pageList.push_front(&page); // put in front of FIFO/list
@@ -310,7 +310,7 @@ void HBMpagedMultiMemory::do_FIFO_LRU( pageInfo &page, bool &inFast, bool &swapp
     page.lastTouch = getCurrentSimTimeNano(); // for mrpu       
 }
 
-void HBMpagedMultiMemory::do_LFU( Addr addr, pageInfo &page, bool &inFast, bool &swapping) {
+void HBMpagedMultiMemory::do_LFU( Addr addr, HBMpageInfo &page, bool &inFast, bool &swapping) {
     const uint64_t pageAddr = addr >> pageShift;
     inFast = 0;
     swapping = 0;
@@ -334,7 +334,7 @@ void HBMpagedMultiMemory::do_LFU( Addr addr, pageInfo &page, bool &inFast, bool 
 		  if ((p->second.inFast == 1) && (p->first != pageAddr)) {
 		    lastMin = min(lastMin, p->second.touched);
 		    if((p->second.touched < page.touched) &&
-                       (p->second.swapDir == pageInfo::NONE)) { // make sure we don't bump someone in motion
+                       (p->second.swapDir == HBMpageInfo::NONE)) { // make sure we don't bump someone in motion
                         found = 1;
                         p->second.inFast = 0; // rm old
                         if (modelSwaps) {moveToSlow(&(p->second));}
@@ -500,7 +500,7 @@ void HBMpagedMultiMemory::handleSelfEvent(SST::Event *event){
         delete ev;
     } else if (modelSwaps && si_w != swapToFast_Writes.end()) {
         // this is from fast mem, indicating a transfer from slow.
-        pageInfo *page = si_w->second;
+        HBMpageInfo *page = si_w->second;
         page->swapsOut -= 1;
 	//printf(" got moveToFast write addr:%p ev:%p p:%p sO:%d\n", (void*)(req->baseAddr_ + req->amtInProcess_) ,ev, page, page->swapsOut);
         if (page->swapsOut == 0) {
@@ -529,14 +529,14 @@ bool HBMpagedMultiMemory::quantaClock(SST::Cycle_t _cycle) {
     return false;
 }
 
-void HBMpagedMultiMemory::moveToFast(pageInfo &page) {
-    assert(page.swapDir == pageInfo::NONE);
+void HBMpagedMultiMemory::moveToFast(HBMpageInfo &page) {
+    assert(page.swapDir == HBMpageInfo::NONE);
 
     uint64_t addr = page.pageAddr << pageShift;
     const uint numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
 
     // mark page as swapping
-    page.swapDir = pageInfo::StoF;
+    page.swapDir = HBMpageInfo::StoF;
     page.swapsOut = numTransfers;   
 
     dbg.debug(_L10_, "moveToFast(%p addr:%p) sO:%d\n", &page, (void*)(addr), 
@@ -553,8 +553,8 @@ void HBMpagedMultiMemory::moveToFast(pageInfo &page) {
     }
 }
 
-void HBMpagedMultiMemory::moveToSlow(pageInfo *page) {
-    assert(page->swapDir == pageInfo::NONE);
+void HBMpagedMultiMemory::moveToSlow(HBMpageInfo *page) {
+    assert(page->swapDir == HBMpageInfo::NONE);
 
     uint64_t addr = page->pageAddr << pageShift;
     const uint numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
@@ -562,7 +562,7 @@ void HBMpagedMultiMemory::moveToSlow(pageInfo *page) {
     dbg.debug(_L10_, "moveToSlow(%p addr:%p)\n", page, (void*)(addr));
 
     // mark page as swapping
-    page->swapDir = pageInfo::FtoS;
+    page->swapDir = HBMpageInfo::FtoS;
     page->swapsOut = numTransfers;
 
     // issue reads to fast mem
@@ -592,7 +592,7 @@ void HBMpagedMultiMemory::dramSimDone(unsigned int id, uint64_t addr, uint64_t c
     if (modelSwaps && si != swapToSlow_Writes.end()) {
         // this is a returning write from the DRAM
         // mark the page as having less outstanding
-        pageInfo *page = si->second;
+        HBMpageInfo *page = si->second;
         page->swapsOut -= 1;
         if (page->swapsOut == 0) {
             swapDone(page, addr);
@@ -617,12 +617,12 @@ void HBMpagedMultiMemory::dramSimDone(unsigned int id, uint64_t addr, uint64_t c
     }
 }
 
-void HBMpagedMultiMemory::swapDone(pageInfo *page, const uint64_t addr) {
+void HBMpagedMultiMemory::swapDone(HBMpageInfo *page, const uint64_t addr) {
     const uint64_t pageAddr = addr >> pageShift;
     dbg.debug(_L10_, "swapDone(%p addr:%p) %d\n", page, (void*)pageAddr, page->swapDir);
 
     assert(page->swapsOut == 0);
-    assert(page->swapDir != pageInfo::NONE);
+    assert(page->swapDir != HBMpageInfo::NONE);
     assert(&pageMap[pageAddr] == page);
 
 
@@ -631,7 +631,7 @@ void HBMpagedMultiMemory::swapDone(pageInfo *page, const uint64_t addr) {
     //printf(" - swapDone releasing %d\n", (int)waitList.size());
     for (auto it = waitList.begin(); it != waitList.end(); ++it) {
         Req *req = *it;
-        if (page->swapDir == pageInfo::FtoS) {
+        if (page->swapDir == HBMpageInfo::FtoS) {
             // just finished moving page from fast to slow mem, so issue to DRAM
             //assert(DRAMSimMemory::issueRequest(req));
             queueRequest(req);
@@ -644,11 +644,11 @@ void HBMpagedMultiMemory::swapDone(pageInfo *page, const uint64_t addr) {
     waitingReqs.erase(pageAddr);
 
     // mark page as ready
-    page->swapDir = pageInfo::NONE;
+    page->swapDir = HBMpageInfo::NONE;
 }
 
 
-bool HBMpagedMultiMemory::pageIsSwapping(const pageInfo &page) {
-    return (page.swapDir != pageInfo::NONE);
+bool HBMpagedMultiMemory::pageIsSwapping(const HBMpageInfo &page) {
+    return (page.swapDir != HBMpageInfo::NONE);
 }
 

--- a/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.h
@@ -28,7 +28,7 @@
 #undef DEBUG
 #endif
 
-#include <DRAMSim.h>
+#include <HBMDRAMSim.h>
 
 #ifdef OLD_DEBUG
 #define DEBUG OLD_DEBUG
@@ -38,8 +38,8 @@
 namespace SST {
 namespace MemHierarchy {
 
-struct pageInfo {
-    typedef list<pageInfo*> pageList_t;
+struct HBMpageInfo {
+    typedef list<HBMpageInfo*> pageList_t;
     typedef pageList_t::iterator pageListIter;
 
     uint64_t pageAddr;
@@ -139,7 +139,7 @@ struct pageInfo {
 	rqstrs.clear();
     }
 
-    pageInfo() : pageAddr(0), touched(0), inFast(0), lastTouch(0), lastRef(0), scanLeng(0),
+    HBMpageInfo() : pageAddr(0), touched(0), inFast(0), lastTouch(0), lastRef(0), scanLeng(0),
                  pageDelay(0), swapDir(NONE), swapsOut(0) {
         for (int i = 0; i < LAST_CASE; ++i) {
             accPat[i] = 0;
@@ -176,7 +176,7 @@ private:
         Req() {}
 		ImplementSerializable(SST::MemHierarchy::HBMpagedMultiMemory::Req)
     };
-    pageInfo::pageList_t pageList; // used in FIFO
+    HBMpageInfo::pageList_t pageList; // used in FIFO
 
     // addition strategy
     typedef enum {addMFU, // Most Frequent
@@ -200,9 +200,9 @@ private:
 
     bool dramBackpressure;
 
-    bool checkAdd(pageInfo &page);
-    void do_FIFO_LRU( pageInfo &page, bool &inFast, bool &swapping);
-    void do_LFU( Addr, pageInfo &page, bool &inFast, bool &swapping);
+    bool checkAdd(HBMpageInfo &page);
+    void do_FIFO_LRU( HBMpageInfo &page, bool &inFast, bool &swapping);
+    void do_LFU( Addr, HBMpageInfo &page, bool &inFast, bool &swapping);
     
     void printAccStats();
     queue<Req *> dramQ;
@@ -219,18 +219,18 @@ private:
 public:
     class MemCtrlEvent;
 private:
-    typedef map<MemCtrlEvent *, pageInfo*> evToPage_t;
-    typedef map<Req *, pageInfo*> reqToPage_t;
+    typedef map<MemCtrlEvent *, HBMpageInfo*> evToPage_t;
+    typedef map<Req *, HBMpageInfo*> reqToPage_t;
     evToPage_t swapToSlow_Reads;
     evToPage_t swapToFast_Writes;
     reqToPage_t swapToSlow_Writes;
     reqToPage_t swapToFast_Reads;
 
     void dramSimDone(unsigned int id, uint64_t addr, uint64_t clockcycle);
-    void swapDone(pageInfo *, uint64_t);
-    void moveToFast(pageInfo &);
-    void moveToSlow(pageInfo *);
-    bool pageIsSwapping(const pageInfo &page);
+    void swapDone(HBMpageInfo *, uint64_t);
+    void moveToFast(HBMpageInfo &);
+    void moveToSlow(HBMpageInfo *);
+    bool pageIsSwapping(const HBMpageInfo &page);
 
 public:
     class MemCtrlEvent : public SST::Event {
@@ -252,7 +252,7 @@ public:
         ImplementSerializable(SST::MemHierarchy::HBMpagedMultiMemory::MemCtrlEvent);     
     };
 
-    typedef map<uint64_t, pageInfo> pageMap_t;
+    typedef map<uint64_t, HBMpageInfo> pageMap_t;
     pageMap_t pageMap;
     uint maxFastPages;
     uint pageShift;


### PR DESCRIPTION
fixing namespace issues with pageInfo structure and links to HBM-target DRAMSim2.  Tested to build and execute successfully when HBMDRAMSim2 and DRAMSim2 are enabled in sst-elements configuration

This is a fix for issue 717.  
https://github.com/sstsimulator/sst-elements/issues/717
 
---

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----
