### PR TITLE
fixing autoconf caching issue between DRAMSim2 and HBMDRAMSim2

### DIFF
--- a/config/sst_check_hbmdramsim.m4
+++ b/config/sst_check_hbmdramsim.m4
@@ -23,7 +23,7 @@ AC_DEFUN([SST_CHECK_HBMDRAMSIM], [
 
   AC_LANG_PUSH(C++)
   AC_CHECK_HEADERS([HBMDRAMSim.h], [], [sst_check_hbmdramsim_happy="no"])
-  AC_CHECK_LIB([hbmdramsim], [libdramsim_is_present],
+  AC_CHECK_LIB([dramsim], [libhbmdramsim_is_present],
     [HBMDRAMSIM_LIB="-ldramsim"], [sst_check_hbmdramsim_happy="no"])
   AC_LANG_POP(C++)
 


### PR DESCRIPTION
Fixing autoconf issues with DRAMSim2 and HBMDRAMSim2 colliding.  This requires a change in the symbols for DRAMSim2( see https://github.com/tactcomplabs/HBM/commit/6668b3687f5b54dddaa70e97dbf1eb0956c65b0b)

This is a fix for bug #727 

---

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----
