### PR TITLE
converting goblinHMCBackend to utilize ExtMemBackend infrastructure

### DIFF
--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -1317,11 +1317,17 @@ static const ElementInfoParam goblin_hmcsim_Mem_params[] = {
   	{ "dram_count",         "Sets the number of DRAM blocks per cube", "20" },
 	{ "xbar_depth",         "Sets the queue depth for the HMC X-bar", "8" },
         { "max_req_size",       "Sets the maximum requests which can be inflight from the controller side at any time", "32" },
+#ifdef HMC_DEV_DRAM_LATENCY
+        { "dram_latency",       "Sets the internal DRAM fetch latency in clock cycles", "2" },
+#endif
 	{ "trace-banks", 	"Decides where tracing for memory banks is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
 	{ "trace-queue", 	"Decides where tracing for queues is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
 	{ "trace-cmds", 	"Decides where tracing for commands is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
 	{ "trace-latency", 	"Decides where tracing for latency is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
 	{ "trace-stalls", 	"Decides where tracing for memory stalls is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
+#ifdef HMC_TRACE_POWER
+        { "trace-power",        "Decides where tracing for memory power is enabled, \"yes\" or \"no\", default=\"no\"", "no" },
+#endif
 	{ "tag_count",		"Sets the number of inflight tags that can be pending at any point in time", "16" },
 	{ "capacity_per_device", "Sets the capacity of the device being simulated in GiB, min=2, max=8, default is 4", "4" },
 	{ NULL, NULL, NULL }

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -18,6 +18,7 @@
 #define _H_SST_MEMH_GOBLIN_HMC_BACKEND
 
 #include <queue>
+#include <vector>
 
 #include <sst/core/component.h>
 #include <sst/core/elementinfo.h>
@@ -54,13 +55,14 @@ class HMCSimBackEndReq {
 		uint64_t startTime;
 };
 
-class GOBLINHMCSimBackend : public SimpleMemBackend {
+class GOBLINHMCSimBackend : public ExtMemBackend {
 
 public:
-	GOBLINHMCSimBackend() : SimpleMemBackend() {};
 	GOBLINHMCSimBackend(Component* comp, Params& params);
 	~GOBLINHMCSimBackend();
-	bool issueRequest(ReqId, Addr, bool, unsigned);
+	bool issueRequest(ReqId, Addr, bool,
+                          std::vector<uint64_t>,
+                          uint32_t, unsigned);
 	void setup();
 	void finish();
 	virtual bool clock(Cycle_t cycle);

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -35,8 +35,8 @@ namespace MemHierarchy {
 
 class HMCSimBackEndReq {
 	public:
-		HMCSimBackEndReq(MemBackend::ReqId r, Addr a, uint64_t sTime) :
-			req(r), addr(a), startTime(sTime) {}
+		HMCSimBackEndReq(MemBackend::ReqId r, Addr a, uint64_t sTime, bool hr) :
+			req(r), addr(a), startTime(sTime), hasResp(hr) {}
 		~HMCSimBackEndReq() {}
 
 		uint64_t getStartTime() const {
@@ -49,10 +49,14 @@ class HMCSimBackEndReq {
         Addr getAddr() const {
 			return addr;
 		}
+        bool hasResponse() const {
+                        return hasResp;
+                }
 	private:
         MemBackend::ReqId req;
         Addr addr;
-		uint64_t startTime;
+	uint64_t startTime;
+        bool hasResp;
 };
 
 class GOBLINHMCSimBackend : public ExtMemBackend {


### PR DESCRIPTION
Converting the goblinHMCBackend to utilize the recently merged ExtMemBackend infrastructure.  The goblin backend has been updated to utilize the incoming flag field such that it will now support posted write requests (similar to the posted request support in the scratchpad memHierarchy component).  This pull request has been tested to pass against all the goblinHMCBackend tests.

---

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----
