### PR TITLE
backend logic for mapping existing memory requests to any other request type in goblinHMCbackend

### DIFF
--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -33,6 +33,8 @@ libmemHierarchy_la_SOURCES = \
 	membackend/simpleMemBackendConvertor.cc \
 	membackend/hmcMemBackendConvertor.h \
 	membackend/hmcMemBackendConvertor.cc \
+	membackend/extMemBackendConvertor.h \
+	membackend/extMemBackendConvertor.cc \
 	membackend/delayBuffer.h \
 	membackend/delayBuffer.cc \
 	membackend/simpleMemBackend.h \

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -1331,6 +1331,8 @@ static const ElementInfoParam goblin_hmcsim_Mem_params[] = {
 #endif
 	{ "tag_count",		"Sets the number of inflight tags that can be pending at any point in time", "16" },
 	{ "capacity_per_device", "Sets the capacity of the device being simulated in GiB, min=2, max=8, default is 4", "4" },
+        { "cmc-config",         "Enables a CMC library command in HMCSim", "NONE" },
+        { "cmd-map",            "Maps an existing HMC or CMC command to the target command type", "NONE" },
 	{ NULL, NULL, NULL }
 };
 #endif

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -63,6 +63,7 @@
 
 #ifdef HAVE_GOBLIN_HMCSIM
 #include "membackend/goblinHMCBackend.h"
+#include "membackend/extMemBackendConvertor.h"
 #endif
 
 #ifdef HAVE_LIBRAMULATOR
@@ -1305,6 +1306,27 @@ static const ElementInfoParam Messier_params[] = {
  *  Purpose: Memory backend, interface to HMCSim (HMC memory)
  *****************************************************************************************/
 #ifdef HAVE_GOBLIN_HMCSIM
+static SubComponent* create_Mem_ExtBackendConvertor(Component* comp, Params& params){
+    return new ExtMemBackendConvertor(comp, params);
+}
+
+static const ElementInfoStatistic extMemBackendConvertor_statistics[] = {
+    /* Cache hits and misses */
+    { "cycles_with_issue",                  "Total cycles with successful issue to back end",   "cycles",   1 },
+    { "cycles_attempted_issue_but_rejected","Total cycles where an attempt to issue to backend was rejected (indicates backend full)", "cycles", 1 },
+    { "total_cycles",                       "Total cycles called at the memory controller",     "cycles",   1 },
+    { "requests_received_GetS",             "Number of GetS (read) requests received",          "requests", 1 },
+    { "requests_received_GetSX",           "Number of GetSX (read) requests received",        "requests", 1 },
+    { "requests_received_GetX",             "Number of GetX (read) requests received",          "requests", 1 },
+    { "requests_received_PutM",             "Number of PutM (write) requests received",         "requests", 1 },
+    { "outstanding_requests",               "Total number of outstanding requests each cycle",  "requests", 1 },
+    { "latency_GetS",                       "Total latency of handled GetS requests",           "cycles",   1 },
+    { "latency_GetSX",                     "Total latency of handled GetSX requests",         "cycles",   1 },
+    { "latency_GetX",                       "Total latency of handled GetX requests",           "cycles",   1 },
+    { "latency_PutM",                       "Total latency of handled PutM requests",           "cycles",   1 },
+    { NULL, NULL, NULL, 0 }
+};
+
 static SubComponent* create_Mem_GOBLINHMCSim(Component* comp, Params& params){
     return new GOBLINHMCSimBackend(comp, params);
 }
@@ -1769,6 +1791,15 @@ static const ElementInfoSubComponent subcomponents[] = {
     },
 #endif
 #ifdef HAVE_GOBLIN_HMCSIM
+    {
+        "extMemBackendConvertor",
+        "convert MemEvent to Ext mem backend",
+        NULL, /* Advanced help */
+        create_Mem_ExtBackendConvertor, /* Module Alloc w/ params */
+        NULL,
+        extMemBackendConvertor_statistics, /* statistics */
+        "SST::MemHierarchy::MemBackend"
+    },
     {
         "goblinHMCSim",
         "GOBLIN HMC Simulator driven memory timings",

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
@@ -1,0 +1,53 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#include <sst_config.h>
+#include <vector>
+#include "sst/elements/memHierarchy/util.h"
+#include "sst/elements/memHierarchy/memoryController.h"
+#include "membackend/extMemBackendConvertor.h"
+#include "membackend/memBackend.h"
+
+using namespace SST;
+using namespace SST::MemHierarchy;
+
+#ifdef __SST_DEBUG_OUTPUT__
+#define Debug(level, fmt, ... ) m_dbg.debug( level, fmt, ##__VA_ARGS__  )
+#else
+#define Debug(level, fmt, ... )
+#endif
+
+ExtMemBackendConvertor::ExtMemBackendConvertor(Component *comp, Params &params) :
+    MemBackendConvertor(comp,params)
+{
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    static_cast<ExtMemBackend*>(m_backend)->setResponseHandler( std::bind( &ExtMemBackendConvertor::handleMemResponse, this, _1,_2 ) );
+
+}
+
+bool ExtMemBackendConvertor::issue( MemReq *req ) {
+
+    MemEvent* event = req->getMemEvent();
+    std::vector<uint64_t> NULLVEC;
+
+    return static_cast<ExtMemBackend*>(m_backend)->issueRequest( req->id(),
+                                                                     req->addr(),
+                                                                     req->isWrite(),
+                                                                     NULLVEC, // this is null for now
+                                                                     event->getFlags(),
+                                                                     m_backendRequestWidth );
+}

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
@@ -1,0 +1,38 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef __SST_MEMH_EXTMEMBACKENDCONVERTOR__
+#define __SST_MEMH_EXTMEMBACKENDCONVERTOR__
+
+#include "sst/elements/memHierarchy/membackend/memBackendConvertor.h"
+
+namespace SST {
+namespace MemHierarchy {
+
+class ExtMemBackendConvertor : public MemBackendConvertor {
+
+  public:
+    ExtMemBackendConvertor(Component *comp, Params &params);
+
+    virtual bool issue( MemReq* req );
+    virtual void handleMemResponse( ReqId reqId, uint32_t flags  ) {
+        doResponse( reqId, flags );
+    }
+};
+
+}
+}
+#endif

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -19,6 +19,141 @@
 
 using namespace SST::MemHierarchy;
 
+// all the standard and cmc hmc packets
+const HMCPacket __PACKETS[] = {
+  /* name : type : data_len : rqst_len : rsp_len : isCMC */
+  { "WR16",       WR16,       8,    16,   2,  false},
+  { "WR32",       WR32,       9,    32,   3,  false},
+  { "WR48",       WR48,       10,   48,   4,  false},
+  { "WR64",       WR64,       11,   64,   5,  false},
+  { "WR80",       WR80,       12,   80,   6,  false},
+  { "WR96",       WR96,       13,   96,   7,  false},
+  { "WR112",      WR112,      14,   112,  8,  false},
+  { "WR128",      WR128,      15,   128,  9,  false},
+  { "WR256",      WR256,      79,   256,  17, false},
+  { "P_WR16",     P_WR16,     8,    16,   2,  false},
+  { "P_WR32",     P_WR32,     9,    32,   3,  false},
+  { "P_WR48",     P_WR48,     10,   48,   4,  false},
+  { "P_WR64",     P_WR64,     11,   64,   5,  false},
+  { "P_WR80",     P_WR80,     12,   80,   6,  false},
+  { "P_WR96",     P_WR96,     13,   96,   7,  false},
+  { "P_WR112",    P_WR112,    14,   112,  8,  false},
+  { "P_WR128",    P_WR128,    15,   128,  9,  false},
+  { "P_WR256",    P_WR256,    79,   256,  17, false},
+  { "RD16",       RD16,       48,   16,   1,  false},
+  { "RD32",       RD32,       49,   32,   1,  false},
+  { "RD48",       RD48,       50,   48,   1,  false},
+  { "RD64",       RD64,       51,   64,   1,  false},
+  { "RD80",       RD80,       52,   80,   1,  false},
+  { "RD96",       RD96,       53,   96,   1,  false},
+  { "RD112",      RD112,      54,   112,  1,  false},
+  { "RD128",      RD128,      55,   128,  1,  false},
+  { "RD256",      RD256,      119,  256,  1,  false},
+  { "TWOADD8",    TWOADD8,    18,   16,   2,  false},
+  { "ADD16",      ADD16,      19,   16,   2,  false},
+  { "P_2ADD8",    P_2ADD8,    34,   16,   2,  false},
+  { "P_ADD16",    P_ADD16,    35,   16,   2,  false},
+  { "TWOADDS8R",  TWOADDS8R,  82,   16,   2,  false},
+  { "ADDS16R",    ADDS16R,    83,   16,   2,  false},
+  { "INC8",       INC8,       80,   0,    1,  false},
+  { "P_INC8",     P_INC8,     84,   0,    1,  false},
+  { "XOR16",      XOR16,      64,   16,   2,  false},
+  { "OR16",       OR16,       65,   16,   2,  false},
+  { "NOR16",      NOR16,      66,   16,   2,  false},
+  { "AND16",      AND16,      67,   16,   2,  false},
+  { "NAND16",     NAND16,     68,   16,   2,  false},
+  { "CASGT8",     CASGT8,     96,   16,   2,  false},
+  { "CASGT16",    CASGT16,    98,   16,   2,  false},
+  { "CASLT8",     CASLT8,     97,   16,   2,  false},
+  { "CASLT16",    CASLT16,    99,   16,   2,  false},
+  { "CASEQ8",     CASEQ8,     100,  16,   2,  false},
+  { "CASZERO16",  CASZERO16,  101,  16,   2,  false},
+  { "EQ8",        EQ8,        105,  16,   2,  false},
+  { "EQ16",       EQ16,       104,  16,   2,  false},
+  { "BWR",        BWR,        17,   16,   2,  false},
+  { "P_BWR",      P_BWR,      33,   16,   2,  false},
+  { "BWR8R",      BWR8R,      81,   16,   2,  false},
+  { "SWAP16",     SWAP16,     106,  16,   2,  false},
+  { "MD_WR",      MD_WR,      16,   16,   2,  false},
+  { "MD_RD",      MD_RD,      40,   8,    1,  false},
+
+  // cmc packets.  everything except for the name and the
+  // boolean is ignored
+  { "CMC04",      CMC04,      0,    0,    0,  true},
+  { "CMC05",      CMC05,      0,    0,    0,  true},
+  { "CMC06",      CMC06,      0,    0,    0,  true},
+  { "CMC07",      CMC07,      0,    0,    0,  true},
+  { "CMC20",      CMC20,      0,    0,    0,  true},
+  { "CMC21",      CMC21,      0,    0,    0,  true},
+  { "CMC22",      CMC22,      0,    0,    0,  true},
+  { "CMC23",      CMC23,      0,    0,    0,  true},
+  { "CMC32",      CMC32,      0,    0,    0,  true},
+  { "CMC36",      CMC36,      0,    0,    0,  true},
+  { "CMC37",      CMC37,      0,    0,    0,  true},
+  { "CMC38",      CMC38,      0,    0,    0,  true},
+  { "CMC39",      CMC39,      0,    0,    0,  true},
+  { "CMC41",      CMC41,      0,    0,    0,  true},
+  { "CMC42",      CMC42,      0,    0,    0,  true},
+  { "CMC43",      CMC43,      0,    0,    0,  true},
+  { "CMC44",      CMC44,      0,    0,    0,  true},
+  { "CMC45",      CMC45,      0,    0,    0,  true},
+  { "CMC46",      CMC46,      0,    0,    0,  true},
+  { "CMC47",      CMC47,      0,    0,    0,  true},
+  { "CMC56",      CMC56,      0,    0,    0,  true},
+  { "CMC57",      CMC57,      0,    0,    0,  true},
+  { "CMC58",      CMC58,      0,    0,    0,  true},
+  { "CMC59",      CMC59,      0,    0,    0,  true},
+  { "CMC60",      CMC60,      0,    0,    0,  true},
+  { "CMC61",      CMC61,      0,    0,    0,  true},
+  { "CMC62",      CMC62,      0,    0,    0,  true},
+  { "CMC63",      CMC63,      0,    0,    0,  true},
+  { "CMC69",      CMC69,      0,    0,    0,  true},
+  { "CMC70",      CMC70,      0,    0,    0,  true},
+  { "CMC71",      CMC71,      0,    0,    0,  true},
+  { "CMC72",      CMC72,      0,    0,    0,  true},
+  { "CMC73",      CMC73,      0,    0,    0,  true},
+  { "CMC74",      CMC74,      0,    0,    0,  true},
+  { "CMC75",      CMC75,      0,    0,    0,  true},
+  { "CMC76",      CMC76,      0,    0,    0,  true},
+  { "CMC77",      CMC77,      0,    0,    0,  true},
+  { "CMC78",      CMC78,      0,    0,    0,  true},
+  { "CMC85",      CMC85,      0,    0,    0,  true},
+  { "CMC86",      CMC86,      0,    0,    0,  true},
+  { "CMC87",      CMC87,      0,    0,    0,  true},
+  { "CMC88",      CMC88,      0,    0,    0,  true},
+  { "CMC89",      CMC89,      0,    0,    0,  true},
+  { "CMC90",      CMC90,      0,    0,    0,  true},
+  { "CMC91",      CMC91,      0,    0,    0,  true},
+  { "CMC92",      CMC92,      0,    0,    0,  true},
+  { "CMC93",      CMC93,      0,    0,    0,  true},
+  { "CMC94",      CMC94,      0,    0,    0,  true},
+  { "CMC102",     CMC102,     0,    0,    0,  true},
+  { "CMC103",     CMC103,     0,    0,    0,  true},
+  { "CMC107",     CMC107,     0,    0,    0,  true},
+  { "CMC108",     CMC108,     0,    0,    0,  true},
+  { "CMC109",     CMC109,     0,    0,    0,  true},
+  { "CMC110",     CMC110,     0,    0,    0,  true},
+  { "CMC111",     CMC111,     0,    0,    0,  true},
+  { "CMC112",     CMC112,     0,    0,    0,  true},
+  { "CMC113",     CMC113,     0,    0,    0,  true},
+  { "CMC114",     CMC114,     0,    0,    0,  true},
+  { "CMC115",     CMC115,     0,    0,    0,  true},
+  { "CMC116",     CMC116,     0,    0,    0,  true},
+  { "CMC117",     CMC117,     0,    0,    0,  true},
+  { "CMC118",     CMC118,     0,    0,    0,  true},
+  { "CMC120",     CMC120,     0,    0,    0,  true},
+  { "CMC121",     CMC121,     0,    0,    0,  true},
+  { "CMC122",     CMC122,     0,    0,    0,  true},
+  { "CMC123",     CMC123,     0,    0,    0,  true},
+  { "CMC124",     CMC124,     0,    0,    0,  true},
+  { "CMC125",     CMC125,     0,    0,    0,  true},
+  { "CMC126",     CMC126,     0,    0,    0,  true},
+  { "CMC127",     CMC127,     0,    0,    0,  true},
+
+  // last entry
+  { "EOL",        MD_RD,      0,    0,    0,  false}
+};
+
 GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : ExtMemBackend(comp, params),
 	owner(comp) {
 
@@ -272,6 +407,21 @@ bool GOBLINHMCSimBackend::strToHMCRqst( std::string S,
                                         hmc_rqst_t *R,
                                         bool isCMC ){
 
+  int cur = 0;
+
+  while( __PACKETS[cur].name != "EOL" ){
+    if( __PACKETS[cur].name == S ){
+      if( isCMC && __PACKETS[cur].isCMC ){
+        *R = __PACKETS[cur].type;
+        return true;
+      }else if( !isCMC ){
+        *R = __PACKETS[cur].type;
+        return true;
+      }
+    }
+    cur++;
+  }
+
   return false;
 }
 
@@ -306,7 +456,7 @@ void GOBLINHMCSimBackend::handleCMCConfig(){
       cmdstr = s.substr(0,pos);
       s.erase(0,pos+delim.length());
 
-      if( !strToHMCRqst( cmdstr, &rqst, false ) ){
+      if( !strToHMCRqst( cmdstr, &rqst, true ) ){
         output->fatal(CALL_INFO, -1,
                       "Unable find to a suitable CMC HMC command for: %s\n",
                       cmdstr.c_str() );

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -286,7 +286,17 @@ private:
         void handleCMCConfig();
         void handleCmdMap();
 
+        void splitStr(const string& s,
+                      char delim,
+                      vector<string>& v);
+
         bool strToHMCRqst( std::string, hmc_rqst_t *, bool );
+        bool isPostedRqst( hmc_rqst_t );
+
+	bool issueMappedRequest(ReqId, Addr, bool,
+                                std::vector<uint64_t>,
+                                uint32_t, unsigned,
+                                uint8_t, uint16_t, bool*);
 
         void collectStats();
         void registerStatistics();

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -33,6 +33,47 @@
 namespace SST {
 namespace MemHierarchy {
 
+typedef enum{
+  SRC_WR,
+  SRC_RD,
+  SRC_POSTED,
+  SRC_CUSTOM,
+}CMCSrcReq;
+
+class HMCCMCConfig{
+public:
+  HMCCMCConfig( std::string P, hmc_rqst_t R, int RQ, int RS ) :
+    path(P), cmd(R), rqst_flits(RQ), rsp_flits(RS) {}
+  ~HMCCMCConfig();
+
+  std::string getPath() { return path; }
+  hmc_rqst_t getCmdType() { return cmd; }
+  int getRqstFlits() { return rqst_flits; }
+  int getRspFlits() { return rsp_flits; }
+
+private:
+  std::string path;
+  hmc_rqst_t cmd;
+  int rqst_flits;
+  int rsp_flits;
+};
+
+class HMCSimCmdMap{
+public:
+  HMCSimCmdMap( CMCSrcReq SRC, int SZ, hmc_rqst_t DEST ) :
+    src(SRC), size(SZ), rqst(DEST) {}
+  ~HMCSimCmdMap() {}
+
+  CMCSrcReq getSrcType() { return src; }
+  int getSrcSize() { return size; }
+  hmc_rqst_t getTargetType() { return rqst; }
+
+private:
+  CMCSrcReq src;    // source request type
+  int size;         // size of the request
+  hmc_rqst_t rqst;  // target request type
+};
+
 class HMCSimBackEndReq {
 	public:
 		HMCSimBackEndReq(MemBackend::ReqId r, Addr a, uint64_t sTime, bool hr) :
@@ -214,17 +255,29 @@ private:
 	uint32_t nextLink;
 
         std::vector<std::string> cmclibs;
+        std::vector<std::string> cmcconfigs;
+        std::vector<std::string> cmdmaps;
+
+        std::list<HMCSimCmdMap *> CmdMapping;
+        std::list<HMCCMCConfig *> CmcConfig;
 
 	std::string hmc_trace_file;
 	FILE* hmc_trace_file_handle;
 
 	// We have to create a packet up to the maximum the sim will allow
 	uint64_t hmc_packet[HMC_MAX_UQ_PACKET];
-	// We are allowed up to 128-bytes in a payload but we may use less
-	uint64_t hmc_payload[16];
+
+	// We are allowed up to 256-bytes in a payload but we may use less
+        // now supports HMCC Spec 2.1
+	uint64_t hmc_payload[32];
 
 	std::queue<uint16_t> tag_queue;
 	std::map<uint16_t, HMCSimBackEndReq*> tag_req_map;
+
+        void handleCMCConfig();
+        void handleCmdMap();
+
+        bool strToHMCRqst( std::string, hmc_rqst_t *, bool );
 
         void collectStats();
         void registerStatistics();

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -291,6 +291,7 @@ private:
                       vector<string>& v);
 
         bool strToHMCRqst( std::string, hmc_rqst_t *, bool );
+        bool HMCRqstToStr( hmc_rqst_t R, std::string *S );
         bool isPostedRqst( hmc_rqst_t );
 
 	bool issueMappedRequest(ReqId, Addr, bool,

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -33,6 +33,15 @@
 namespace SST {
 namespace MemHierarchy {
 
+typedef struct{
+  std::string name;
+  hmc_rqst_t type;
+  int data_len;
+  int rqst_len;
+  int rsp_len;
+  bool isCMC;
+} HMCPacket;
+
 typedef enum{
   SRC_WR,
   SRC_RD,

--- a/src/sst/elements/memHierarchy/membackend/memBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/memBackend.h
@@ -27,6 +27,7 @@
 #include "sst/elements/memHierarchy/membackend/memBackendConvertor.h"
 #include "sst/elements/memHierarchy/membackend/simpleMemBackendConvertor.h"
 #include "sst/elements/memHierarchy/membackend/hmcMemBackendConvertor.h"
+#include "sst/elements/memHierarchy/membackend/extMemBackendConvertor.h"
 
 #define NO_STRING_DEFINED "N/A"
 

--- a/src/sst/elements/miranda/tests/goblin_singlestream1-trace-map.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1-trace-map.py
@@ -47,20 +47,12 @@ comp_memory.addParams({
       "clock" : "1GHz",
       "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim",
-      "backend.device_count" : "1",
-      "backend.link_count" : "8",
-      "backend.vault_count" : "64",
-      "backend.queue_depth" : "64",
-      "backend.bank_count" : "16",
-      "backend.dram_count" : "20",
-      "backend.capacity_per_device" : "8",
-      "backend.xbar_depth" : "128",
-      "backend.max_req_size" : "128",
       "backend.trace-banks" : "1",
       "backend.trace-queue" : "1",
       "backend.trace-cmds" : "1",
       "backend.trace-latency" : "1",
-      "backend.trace-stalls" : "1"
+      "backend.trace-stalls" : "1",
+      "backend.cmd-map" : "RD:64:RD96"
 })
 
 

--- a/src/sst/elements/miranda/tests/goblin_singlestream1-trace-map.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1-trace-map.py
@@ -52,7 +52,7 @@ comp_memory.addParams({
       "backend.trace-cmds" : "1",
       "backend.trace-latency" : "1",
       "backend.trace-stalls" : "1",
-      "backend.cmd-map" : "RD:64:RD96"
+      "backend.cmd-map" : "[RD:64:RD96]"
 })
 
 

--- a/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1-trace.py
@@ -45,6 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.trace-banks" : "1",
       "backend.trace-queue" : "1",

--- a/src/sst/elements/miranda/tests/goblin_singlestream1.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream1.py
@@ -45,6 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim"
 })
 

--- a/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2-trace.py
@@ -45,6 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "4",

--- a/src/sst/elements/miranda/tests/goblin_singlestream2.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream2.py
@@ -45,6 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "4",

--- a/src/sst/elements/miranda/tests/goblin_singlestream3.py
+++ b/src/sst/elements/miranda/tests/goblin_singlestream3.py
@@ -45,6 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
       "backend" : "memHierarchy.goblinHMCSim",
       "backend.device_count" : "1",
       "backend.link_count" : "8",


### PR DESCRIPTION
Backend logic for mapping existing memory requests to any other request type in goblinHMCbackend.  This also includes the necessary parameter logic to map CMC command structures as the backing request type for those commands.  This set of commits also includes a new ExtMemBackendConvertor that successfully converts the memory requests for all existing types to what is now necessary in the ExtMemBackend types.  

Note: The find_array parameter passing is currently broken on the SST Core Master TOT.  I'm sending this pull request now as the included patches have tests that can be used to reproduce the issue.  

---

----
