### PR TITLE
adding skeleton for amo custom command handler

### DIFF
--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -64,6 +64,8 @@ libmemHierarchy_la_SOURCES = \
 	memNIC.h \
 	memNIC.cc \
 	customCmdMemory.h \
+	amoCustomCmdHandler.cc \
+	amoCustomCmdHandler.h \
 	directoryController.h \
 	directoryController.cc \
 	scratchpad.h \
@@ -163,6 +165,7 @@ nobase_sst_HEADERS = \
 	memEvent.h \
 	memNIC.h \
 	customCmdMemory.h \
+	amoCustomCmdHandler.h \
 	membackend/memBackend.h \
 	membackend/vaultSimBackend.h \
 	membackend/MessierBackend.h \

--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
@@ -1,0 +1,44 @@
+// Copyright 2013-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2013-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#include "amoCustomCmdHandler.h"
+
+using namespace std;
+using namespace SST;
+using namespace SST::MemHierarchy;
+
+CustomCmdMemHandler::MemEventInfo AMOCustomCmdMemHandler::receive(MemEventBase* ev){
+  CustomCmdMemHandler::MemEventInfo MEI(ev->getRoutingAddress(),false);
+  return MEI;
+}
+
+CustomCmdInfo* AMOCustomCmdMemHandler::ready(MemEventBase* ev){
+#if 0
+  CustomCmdInfo *CI = new CustomCmdInfo(ev->getID,
+                                        ev->getRqstr(),
+                                        MemEvent::F_SUCCESS);
+#endif
+  CustomCmdInfo *CI = new CustomCmdInfo();
+
+  return CI;
+}
+
+MemEventBase* AMOCustomCmdMemHandler::finish(MemEventBase *ev, uint64_t flags){
+  MemEventBase *MEB = new MemEventBase(ev->getSrc(),
+                                        ev->getCmd());
+  return MEB;
+}
+
+// EOF

--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
@@ -1,0 +1,57 @@
+// Copyright 2013-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2013-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _MEMHIERARCHY_AMOCUSTOMCMDHANDLER_H_
+#define _MEMHIERARCHY_AMOCUSTOMCMDHANDLER_H_
+
+#include <string>
+
+#include <sst/core/event.h>
+#include <sst/core/output.h>
+#include <sst/core/subcomponent.h>
+
+//#include "sst/elements/memHierarchy/memEventBase.h"
+//#include "sst/elements/memHierarchy/customCmdMemory.h"
+#include "memEventBase.h"
+#include "memEvent.h"
+#include "customCmdMemory.h"
+
+namespace SST {
+namespace MemHierarchy {
+
+/*
+ * Atomic Memory Operation (AMO)
+ * Custom Command Handler
+ */
+class AMOCustomCmdMemHandler : public CustomCmdMemHandler {
+public:
+  AMOCustomCmdMemHandler(Component * comp, Params &params)
+    : CustomCmdMemHandler(comp,params) {}
+
+  ~AMOCustomCmdMemHandler() {}
+
+  CustomCmdMemHandler::MemEventInfo receive(MemEventBase* ev) override;
+
+  CustomCmdInfo* ready(MemEventBase* ev) override;
+
+  MemEventBase* finish(MemEventBase *ev, uint64_t flags) override;
+
+protected:
+private:
+};    // class AMOCustomCmdMemHandler
+}     // namespace MemHierarchy
+}     // namespace SST
+
+#endif

--- a/src/sst/elements/memHierarchy/customCmdMemory.h
+++ b/src/sst/elements/memHierarchy/customCmdMemory.h
@@ -21,6 +21,7 @@
 #include <sst/core/event.h>
 #include <sst/core/output.h>
 #include <sst/core/subcomponent.h>
+#include "sst/elements/memHierarchy/memEventBase.h"
 
 namespace SST {
 namespace MemHierarchy {
@@ -28,7 +29,8 @@ namespace MemHierarchy {
 /* Class defining information sent to memBackendConvertor */
 class CustomCmdInfo {
 public:
-    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, uint32_t flags = 0) : id(id), rqstr(rqstr), flags(flags) { }
+    CustomCmdInfo() { }
+    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, uint32_t flags = 0 ) : id(id), rqstr(rqstr), flags(flags) { }
 
     virtual std::string getString() { /* For debug */
         std::ostringstream idstring;
@@ -47,7 +49,7 @@ public:
     void clearFlag(void) { flags = 0; }
     bool queryFlag(uint32_t flag) const { return flags & flag; }
     void setFlags(uint32_t nflags) { flags = nflags; }
-    
+
     std::string getRqstr() { return rqstr; }
     void setRqstr(std::string rq) { rqstr = rq; }
 


### PR DESCRIPTION
adding skeleton for amo custom command handler; this will eventually include basic AMO type support (one per customcmd).  this version compiles and links, but is not tested.  