### PR TITLE
fixing memory backend convertor for ExtMemBackends

### DIFF
--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
@@ -25,13 +25,9 @@ CustomCmdMemHandler::MemEventInfo AMOCustomCmdMemHandler::receive(MemEventBase* 
 }
 
 CustomCmdInfo* AMOCustomCmdMemHandler::ready(MemEventBase* ev){
-#if 0
-  CustomCmdInfo *CI = new CustomCmdInfo(ev->getID,
+  CustomCmdInfo *CI = new CustomCmdInfo(ev->getID(),
                                         ev->getRqstr(),
                                         MemEvent::F_SUCCESS);
-#endif
-  CustomCmdInfo *CI = new CustomCmdInfo();
-
   return CI;
 }
 

--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
@@ -22,8 +22,6 @@
 #include <sst/core/output.h>
 #include <sst/core/subcomponent.h>
 
-//#include "sst/elements/memHierarchy/memEventBase.h"
-//#include "sst/elements/memHierarchy/customCmdMemory.h"
 #include "memEventBase.h"
 #include "memEvent.h"
 #include "customCmdMemory.h"

--- a/src/sst/elements/memHierarchy/customCmdMemory.h
+++ b/src/sst/elements/memHierarchy/customCmdMemory.h
@@ -30,6 +30,7 @@ namespace MemHierarchy {
 class CustomCmdInfo {
 public:
     CustomCmdInfo() { }
+    CustomCmdInfo(SST::Event::id_type id, std::string rqstr) : id(id), rqstr(rqstr){ }
     CustomCmdInfo(SST::Event::id_type id, std::string rqstr, uint32_t flags = 0 ) : id(id), rqstr(rqstr), flags(flags) { }
 
     virtual std::string getString() { /* For debug */
@@ -44,6 +45,7 @@ public:
 
     /* Flag getters/setters - same as MemEventBase */
     uint32_t getFlags(void) const { return flags; }
+    void setID(SST::Event::id_type id) {id = id;}
     void setFlag(uint32_t flag) { flags = flags | flag; }
     void clearFlag(uint32_t flag) { flags = flags & (~flag); }
     void clearFlag(void) { flags = 0; }
@@ -66,7 +68,7 @@ protected:
 class CustomCmdMemHandler : public SST::SubComponent {
 
 public:
-    
+
     class MemEventInfo {
     public:
         std::set<Addr> addrs;   /* Cache line addresses accessed by this instruction */
@@ -92,13 +94,13 @@ public:
         for (std::vector<uint64_t>::iterator it = addrArray.begin(); it != addrArray.end(); it++) {
             DEBUG_ADDR.insert(*it);
         }
-        
+
     }
-    
+
     /* Destructor */
     ~CustomCmdMemHandler() { }
 
-    /* 
+    /*
      * Interface between handler and memController
      */
 
@@ -106,14 +108,14 @@ public:
      * to the memory controller so that it knows how to process the event 
      */
     virtual MemEventInfo receive(MemEventBase* ev) =0;
-    
+
     /* The memController will call ready when the event is ready to issue.
      * Events are ready immediately (back-to-back receive() and ready()) unless
      * the event needs to stall for some coherence action.
      * The handler should return a CustomCmdReq* which will be sent to the memBackendConvertor. 
      * The memBackendConvertor will then issue the unmodified CustomCmdReq* to the backend.
      * CustomCmdReq is intended as a base class for custom commands to define as needed.
-     */ 
+     */
     virtual CustomCmdInfo* ready(MemEventBase* ev) =0;
 
     /* When the memBackendConvertor returns a response, the memController will call this function, including
@@ -124,9 +126,9 @@ public:
      *  parent->translateLocalT
      */
     virtual MemEventBase* finish(MemEventBase *ev, uint64_t flags) =0;
-    
+
 protected:
-    
+
     // Debug
     Output dbg;
     std::set<Addr> DEBUG_ADDR;

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
@@ -39,15 +39,15 @@ ExtMemBackendConvertor::ExtMemBackendConvertor(Component *comp, Params &params) 
 
 }
 
-bool ExtMemBackendConvertor::issue( MemReq *req ) {
+bool ExtMemBackendConvertor::issue( BaseReq *req ) {
 
-    MemEvent* event = req->getMemEvent();
+    MemReq * mreq = static_cast<MemReq*>(req);
     std::vector<uint64_t> NULLVEC;
 
-    return static_cast<ExtMemBackend*>(m_backend)->issueRequest( req->id(),
-                                                                     req->addr(),
-                                                                     req->isWrite(),
+    return static_cast<ExtMemBackend*>(m_backend)->issueRequest( mreq->id(),
+                                                                     mreq->addr(),
+                                                                     mreq->isWrite(),
                                                                      NULLVEC, // this is null for now
-                                                                     event->getFlags(),
+                                                                     mreq->getMemEvent()->getFlags(),
                                                                      m_backendRequestWidth );
 }

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
@@ -27,7 +27,7 @@ class ExtMemBackendConvertor : public MemBackendConvertor {
   public:
     ExtMemBackendConvertor(Component *comp, Params &params);
 
-    virtual bool issue( MemReq* req );
+    virtual bool issue( BaseReq* req );
     virtual void handleMemResponse( ReqId reqId, uint32_t flags  ) {
         doResponse( reqId, flags );
     }


### PR DESCRIPTION
Need to overhaul all the remaining memConvertors as well before everything is merged into devel.  This permits compilation with the goblinHMCSim membackend. 
