### PR TITLE
connecting correct request structure to extMemBackendConvertor

### DIFF
--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
@@ -27,6 +27,7 @@ CustomCmdMemHandler::MemEventInfo AMOCustomCmdMemHandler::receive(MemEventBase* 
 CustomCmdInfo* AMOCustomCmdMemHandler::ready(MemEventBase* ev){
   CustomCmdInfo *CI = new CustomCmdInfo(ev->getID(),
                                         ev->getRqstr(),
+                                        ev->getRoutingAddress(),
                                         MemEvent::F_SUCCESS);
   return CI;
 }

--- a/src/sst/elements/memHierarchy/customCmdMemory.h
+++ b/src/sst/elements/memHierarchy/customCmdMemory.h
@@ -30,8 +30,10 @@ namespace MemHierarchy {
 class CustomCmdInfo {
 public:
     CustomCmdInfo() { }
-    CustomCmdInfo(SST::Event::id_type id, std::string rqstr) : id(id), rqstr(rqstr){ }
-    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, uint32_t flags = 0 ) : id(id), rqstr(rqstr), flags(flags) { }
+    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr) :
+      id(id), rqstr(rqstr), baseAddr(addr) { }
+    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr, uint32_t flags = 0 ) :
+      id(id), rqstr(rqstr), flags(flags), baseAddr(addr) { }
 
     virtual std::string getString() { /* For debug */
         std::ostringstream idstring;
@@ -55,9 +57,13 @@ public:
     std::string getRqstr() { return rqstr; }
     void setRqstr(std::string rq) { rqstr = rq; }
 
+    void setAddr(Addr A) { baseAddr = A; }
+    Addr queryAddr() { return baseAddr; }
+
 protected:
     SST::Event::id_type id; /* MemBackendConvertor needs ID for returning a response */
     uint32_t flags;
+    Addr baseAddr;
     std::string rqstr;
 };
 
@@ -112,7 +118,7 @@ public:
     /* The memController will call ready when the event is ready to issue.
      * Events are ready immediately (back-to-back receive() and ready()) unless
      * the event needs to stall for some coherence action.
-     * The handler should return a CustomCmdReq* which will be sent to the memBackendConvertor. 
+     * The handler should return a CustomCmdInfo* which will be sent to the memBackendConvertor. 
      * The memBackendConvertor will then issue the unmodified CustomCmdReq* to the backend.
      * CustomCmdReq is intended as a base class for custom commands to define as needed.
      */

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.cc
@@ -45,9 +45,22 @@ bool ExtMemBackendConvertor::issue( BaseReq *req ) {
     std::vector<uint64_t> NULLVEC;
 
     return static_cast<ExtMemBackend*>(m_backend)->issueRequest( mreq->id(),
-                                                                     mreq->addr(),
-                                                                     mreq->isWrite(),
-                                                                     NULLVEC, // this is null for now
-                                                                     mreq->getMemEvent()->getFlags(),
-                                                                     m_backendRequestWidth );
+                                                                 mreq->addr(),
+                                                                 mreq->isWrite(),
+                                                                 NULLVEC, // this is null for normal requests
+                                                                 mreq->getMemEvent()->getFlags(),
+                                                                 m_backendRequestWidth );
 }
+
+void ExtMemBackendConvertor::handleCustomEvent( CustomCmdInfo* info ){
+
+    std::vector<uint64_t> NULLVEC;
+    static_cast<ExtMemBackend*>(m_backend)->issueRequest( info->getID().first,
+                                                          info->queryAddr(),
+                                                          false,  // this is handled by command mapping
+                                                          NULLVEC, // this is null for normal requests
+                                                          info->getFlags(),
+                                                          m_backendRequestWidth );
+}
+
+// EOF

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
@@ -31,6 +31,7 @@ class ExtMemBackendConvertor : public MemBackendConvertor {
     virtual void handleMemResponse( ReqId reqId, uint32_t flags  ) {
         doResponse( reqId, flags );
     }
+    virtual void handleCustomEvent( CustomCmdInfo* );
 };
 
 }

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -613,7 +613,6 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
   if( (flags & MemEvent::F_NORESPONSE) > 0 ){
     Src = SRC_POSTED;
   }
-  // TODO: handle SRC_CUSTOM requests
 
   // Step 2: walk the CmdMapping table and look for a mapping
   HMCSimCmdMap *MapCmd = NULL;
@@ -714,6 +713,12 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
   return true;
 }
 
+bool GOBLINHMCSimBackend::issueCustomRequest(ReqId reqId, Addr addr, uint32_t cmd,
+                                            std::vector<uint64_t> ins, uint32_t flags,
+                                            unsigned numBytes) {
+  // TODO: currently a placeholder
+  return true;
+}
 bool GOBLINHMCSimBackend::issueRequest(ReqId reqId, Addr addr, bool isWrite,
                                        std::vector<uint64_t> ins, uint32_t flags,
                                        unsigned numBytes) {

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -117,6 +117,9 @@ public:
 	bool issueRequest(ReqId, Addr, bool,
                           std::vector<uint64_t>,
                           uint32_t, unsigned);
+	bool issueCustomRequest(ReqId, Addr, uint32_t,
+                                std::vector<uint64_t>,
+                                uint32_t, unsigned);
 	void setup();
 	void finish();
 	virtual bool clock(Cycle_t cycle);

--- a/src/sst/elements/memHierarchy/membackend/memBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/memBackend.h
@@ -142,6 +142,9 @@ class ExtMemBackend : public MemBackend {
     virtual bool issueRequest( ReqId, Addr, bool isWrite,
                                std::vector<uint64_t> ins,
                                uint32_t flags, unsigned numBytes ) = 0;
+    virtual bool issueCustomRequest( ReqId, Addr, uint32_t Cmd,
+                                     std::vector<uint64_t> ins,
+                                     uint32_t flags, unsigned numBytes );
 
     void handleMemResponse( ReqId id, uint32_t flags ) {
         m_respFunc( id, flags );


### PR DESCRIPTION
connecting correct request structure to extMemBackendConvertor
adding ExtMemBackend interface to handle custom incoming commands
need access to uint32_t command field in CustomCmdInfo

The ExtMemBackend type now has an optional template for issuing "issueCustomRequest" commands.  This should only be utilized when the backend supports custom memory requests through the custom memory request path.  The request ID's are now hooked up to the CustomCmdInfo structure.  However, we still need an integer identifier to uniquely classify individual requests coming all the way down from a processor model.  As soon as we have this, we can build the necessary command mappers in the memBackend to handle any potential custom requests.    
