### PR TITLE
Major update to include functional custom command model

### DIFF
--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.cc
@@ -28,13 +28,19 @@ CustomCmdInfo* AMOCustomCmdMemHandler::ready(MemEventBase* ev){
   CustomCmdInfo *CI = new CustomCmdInfo(ev->getID(),
                                         ev->getRqstr(),
                                         ev->getRoutingAddress(),
+                                        ev->getCustomOpc(),
                                         MemEvent::F_SUCCESS);
   return CI;
 }
 
-MemEventBase* AMOCustomCmdMemHandler::finish(MemEventBase *ev, uint64_t flags){
-  MemEventBase *MEB = new MemEventBase(ev->getSrc(),
-                                        ev->getCmd());
+MemEventBase* AMOCustomCmdMemHandler::finish(MemEventBase *ev, uint32_t flags){
+  if(ev->queryFlag(MemEventBase::F_NORESPONSE)||
+     ((flags & MemEventBase::F_NORESPONSE)>0)){
+    // posted request
+    return nullptr;
+  }
+
+  MemEventBase *MEB = ev->makeResponse();
   return MEB;
 }
 

--- a/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
+++ b/src/sst/elements/memHierarchy/amoCustomCmdHandler.h
@@ -44,7 +44,7 @@ public:
 
   CustomCmdInfo* ready(MemEventBase* ev) override;
 
-  MemEventBase* finish(MemEventBase *ev, uint64_t flags) override;
+  MemEventBase* finish(MemEventBase *ev, uint32_t flags) override;
 
 protected:
 private:

--- a/src/sst/elements/memHierarchy/customCmdMemory.h
+++ b/src/sst/elements/memHierarchy/customCmdMemory.h
@@ -31,9 +31,11 @@ class CustomCmdInfo {
 public:
     CustomCmdInfo() { }
     CustomCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr) :
-      id(id), rqstr(rqstr), baseAddr(addr) { }
+      id(id), rqstr(rqstr), baseAddr(addr), custOpc(0xFFFF) { }
     CustomCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr, uint32_t flags = 0 ) :
-      id(id), rqstr(rqstr), flags(flags), baseAddr(addr) { }
+      id(id), rqstr(rqstr), flags(flags), baseAddr(addr), custOpc(0xFFFF) { }
+    CustomCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr, uint32_t Opc, uint32_t flags = 0 ) :
+      id(id), rqstr(rqstr), flags(flags), baseAddr(addr), custOpc(Opc) { }
 
     virtual std::string getString() { /* For debug */
         std::ostringstream idstring;
@@ -60,11 +62,16 @@ public:
     void setAddr(Addr A) { baseAddr = A; }
     Addr queryAddr() { return baseAddr; }
 
+    /* Custom opcode handlers */
+    uint32_t getCustomOpc() { return custOpc; }
+    void setCustomOpc(uint32_t Opc) { custOpc = Opc; }
+
 protected:
     SST::Event::id_type id; /* MemBackendConvertor needs ID for returning a response */
     uint32_t flags;
     Addr baseAddr;
     std::string rqstr;
+    uint32_t custOpc;
 };
 
 /*
@@ -82,8 +89,7 @@ public:
 
         MemEventInfo(std::set<Addr> addrs, bool shootdown = false) : addrs(addrs), shootdown(shootdown) { }
         MemEventInfo(Addr addr, bool sdown = false) { addrs.insert(addr); shootdown = sdown; }
-        ~MemEventInfo();
-
+        ~MemEventInfo() {};
     };
 
 
@@ -131,7 +137,7 @@ public:
      *  parent->readData(): Read the backing store if the response needs data
      *  parent->translateLocalT
      */
-    virtual MemEventBase* finish(MemEventBase *ev, uint64_t flags) =0;
+    virtual MemEventBase* finish(MemEventBase *ev, uint32_t flags) =0;
 
 protected:
 

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -61,6 +61,7 @@
 #include "multithreadL1Shim.h"
 #include "scratchpad.h"
 #include "coherentMemoryController.h"
+#include "amoCustomCmdHandler.h"
 
 #ifdef HAVE_GOBLIN_HMCSIM
 #include "membackend/goblinHMCBackend.h"
@@ -910,7 +911,6 @@ static const ElementInfoPort memctrl_ports[] = {
     {NULL, NULL, NULL}
 };
 
-
 /*****************************************************************************************
  *  Component: CoherentMemController
  *  Purpose: Main memory controller, analagous to a single channel, supports custom memory
@@ -943,6 +943,27 @@ static const ElementInfoParam cohmemctrl_params[] = {
     {"customCmdMemHandler", "(string) Name of the custom command handler to load", ""},
     {NULL, NULL, NULL}
 };
+
+/*****************************************************************************************
+ *  SubComponent: AMOCustomCmdMemHandler
+ *  Purpose: (A)tomic (M)emory (O)peration CustomCmdMemHandler for issuing custom
+ *  AMO commands to memBackends that use ExtMemBackendConvertor
+ *****************************************************************************************/
+static SubComponent* create_Mem_AMOCustomCmdMemHandler(Component* comp, Params& params){
+	return new AMOCustomCmdMemHandler(comp, params);
+}
+
+#if 0
+static const ElementInfoParam amoCustomCmd_params[] = {
+    // currently no parameters
+    {NULL, NULL, NULL}
+}
+
+static const ElementInfoStatistic amoCustomCmd_statistics[] = {
+    // currently no statistics
+    { NULL, NULL, NULL, 0 }
+}
+#endif
 
 /*****************************************************************************************
  *  SubComponent: simpleMemBackendConvertor
@@ -1761,6 +1782,15 @@ static const ElementInfoSubComponent subcomponents[] = {
         requestReorderRow_params,
         NULL,
         "SST::MemHierarchy::MemBackend"
+    },
+    {
+        "amoCustomCmdHandler",
+        "AMO custom command handler",
+        NULL,
+        create_Mem_AMOCustomCmdMemHandler,
+        NULL,//amoCustomCmd_params,
+        NULL,//amoCustomCmd_statistics,
+        "SST::MemHierarchy::AMOCustomCmdMemHandler"
     },
 #if defined(HAVE_LIBRAMULATOR)
     {

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -953,18 +953,6 @@ static SubComponent* create_Mem_AMOCustomCmdMemHandler(Component* comp, Params& 
 	return new AMOCustomCmdMemHandler(comp, params);
 }
 
-#if 0
-static const ElementInfoParam amoCustomCmd_params[] = {
-    // currently no parameters
-    {NULL, NULL, NULL}
-}
-
-static const ElementInfoStatistic amoCustomCmd_statistics[] = {
-    // currently no statistics
-    { NULL, NULL, NULL, 0 }
-}
-#endif
-
 /*****************************************************************************************
  *  SubComponent: simpleMemBackendConvertor
  *  Purpose: Converts memEvents from a memory controller into cmd/addr/size for backends

--- a/src/sst/elements/memHierarchy/memEventBase.h
+++ b/src/sst/elements/memHierarchy/memEventBase.h
@@ -81,7 +81,7 @@ public:
 
     /** @return  Unique ID of this MemEvent */
     id_type getID(void) const { return eventID_; }
-    
+
     /** @return  Unique ID of the MemEvent that this is a response to */
     id_type getResponseToID(void) const { return responseToID_; }
 
@@ -202,6 +202,13 @@ public:
         return new MemEventBase(*this);
     }
 
+    /** Sets the custom command opcode */
+    void setCustomOpc(uint32_t Opc) { custOpc_ = Opc; }
+    /** Returns the custom command opcode */
+    uint32_t getCustomOpc(void) { return custOpc_; }
+    /** Returns true if the event includes a custom command */
+    bool isCustomCmd() { return cmd_ == Command::CustomReq; }
+
 protected:
     id_type         eventID_;           // Unique ID for this event
     id_type         responseToID_;      // For responses, holds the ID to which this event matches
@@ -211,6 +218,7 @@ protected:
     Command         cmd_;               // Command
     uint32_t        flags_;
     uint32_t        memFlags_;
+    uint32_t        custOpc_;           // Custom opcode
 
     MemEventBase() {} // For serialization only
 

--- a/src/sst/elements/memHierarchy/memHierarchyInterface.cc
+++ b/src/sst/elements/memHierarchy/memHierarchyInterface.cc
@@ -102,6 +102,7 @@ MemEvent* MemHierarchyInterface::createMemEvent(SimpleMem::Request *req) const{
         case SimpleMem::Request::FlushLine:     cmd = Command::FlushLine;    break;
         case SimpleMem::Request::FlushLineInv:  cmd = Command::FlushLineInv; break;
         case SimpleMem::Request::FlushLineResp: cmd = Command::FlushLineResp; break;
+        case SimpleMem::Request::CustomCmd:     cmd = Command::CustomReq;    break;
         default: output.fatal(CALL_INFO, -1, "Unknown req->cmd in createMemEvent()\n");
     }
 
@@ -121,6 +122,10 @@ MemEvent* MemHierarchyInterface::createMemEvent(SimpleMem::Request *req) const{
             output.output("Warning: In memHierarchyInterface, write request size does not match payload size. Request size: %zu. Payload size: %zu. MemEvent will use payload size\n", req->size, req->data.size());
 
         me->setPayload(req->data);
+    }
+
+    if(SimpleMem::Request::CustomCmd == req->cmd){
+      me->setCustomOpc(req->getCustomOpc());
     }
 
     if(req->flags & SimpleMem::Request::F_NONCACHEABLE)
@@ -188,6 +193,9 @@ void MemHierarchyInterface::updateRequest(SimpleMem::Request* req, MemEvent *me)
         case Command::FlushLineResp:
         req->cmd = SimpleMem::Request::FlushLineResp;
         if (me->success()) req->flags |= (SimpleMem::Request::F_FLUSH_SUCCESS);
+        break;
+        case Command::CustomResp:
+        req->cmd = SimpleMem::Request::CustomCmd;
         break;
     default:
         output.fatal(CALL_INFO, -1, "Don't know how to deal with command %s\n", CommandString[(int)me->getCmd()]);

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
@@ -31,6 +31,7 @@ class ExtMemBackendConvertor : public MemBackendConvertor {
     virtual void handleMemResponse( ReqId reqId, uint32_t flags  ) {
         doResponse( reqId, flags );
     }
+    //virtual void handleMemEvent( MemEvent *);
     virtual void handleCustomEvent( CustomCmdInfo* );
 };
 

--- a/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/extMemBackendConvertor.h
@@ -31,7 +31,6 @@ class ExtMemBackendConvertor : public MemBackendConvertor {
     virtual void handleMemResponse( ReqId reqId, uint32_t flags  ) {
         doResponse( reqId, flags );
     }
-    //virtual void handleMemEvent( MemEvent *);
     virtual void handleCustomEvent( CustomCmdInfo* );
 };
 

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.cc
@@ -251,7 +251,9 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : ExtM
         // map all the existing commands as well as any custom
         // commands.
         // These are in the form:
-        //    {WR|RD|POSTED|CUSTOM}:SIZE:CMD
+        //    {WR|RD|POSTED|CUSTOM}:OPC:SIZE:CMD
+        // OPC = integer that designates custom command opcodes; if not
+        //        using custom commands (CUSTOM), this is ignored
         // SIZE = integer size of the request (ignored for CUSTOM)
         // CMD = target command to execute; one of "hmc_rqst_t"
         params.find_array<std::string>("cmd-map", cmdmaps);
@@ -327,12 +329,16 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : ExtM
           if( cmclibs[i].length() > 0 ){
             // attempt to add the cmc lib
             output->verbose(CALL_INFO, 1, 0,
-                            "Initializing HMC-Sim CMC Library...\n" );
-            std::vector<char> libchars( cmclibs[i].begin(), cmclibs[i].end() );
-            rc = hmcsim_load_cmc(&the_hmc, &libchars[0] );
+                            "Initializing HMC-Sim CMC Library: %s\n", cmclibs[i].c_str() );
+            char *libpath = new char[cmclibs[i].size()+1];
+            std::copy(cmclibs[i].begin(), cmclibs[i].end(), libpath);
+            libpath[cmclibs[i].size()] = '\0';
+
+            rc = hmcsim_load_cmc(&the_hmc, libpath );
+            delete libpath;
             if( rc != 0 ){
 	      output->fatal(CALL_INFO, -1,
-                            "Unable to HMC-Sim CMC Library and the return code is %d\n", rc);
+                            "Unable to load HMC-Sim CMC Library and the return code is %d\n", rc);
             }
           }
         }
@@ -349,7 +355,8 @@ GOBLINHMCSimBackend::GOBLINHMCSimBackend(Component* comp, Params& params) : ExtM
 		if(0 == rc) {
 			output->verbose(CALL_INFO, 1, 0, "Successfully configured link.\n");
 		} else {
-			output->fatal(CALL_INFO, 1, 0, "Error configuring link %" PRIu32 ", code=%d\n", i, rc);
+			output->fatal(CALL_INFO, 1, 0,
+                          "Error configuring link %" PRIu32 ", code=%" PRId32 "\n", i, rc);
 		}
 
 		nextLink = 0;
@@ -467,7 +474,7 @@ void GOBLINHMCSimBackend::handleCMCConfig(){
     if( vstr.size() != 4 ){
       // formatting error
       output->fatal(CALL_INFO, -1,
-                    "Unable to process command map: %s\n", s.c_str() );
+                    "Unable to process cmc config: %s\n", s.c_str() );
     }
 
     // -- /path/to/lib.so
@@ -482,18 +489,22 @@ void GOBLINHMCSimBackend::handleCMCConfig(){
     }
 
     // -- rqst_flits
-    std::string::size_type sz;
-    rqst_flits = std::stoi(vstr[2],&sz);
+    std::string::size_type sz1;
+    rqst_flits = std::stoi(vstr[2],&sz1);
 
     // -- rsp_flits
-    rsp_flits = std::stoi(vstr[3],&sz);
+    std::string::size_type sz2;
+    rsp_flits = std::stoi(vstr[3],&sz2);
 
     // load the cmc command in HMCSim
-    std::vector<char> libchars( path.begin(), path.end() );
-    int rc = hmcsim_load_cmc(&the_hmc, &libchars[0] );
+    char *libpath = new char[path.size()+1];
+    std::copy(path.begin(), path.end(), libpath);
+    libpath[path.size()] = '\0';
+    int rc = hmcsim_load_cmc(&the_hmc, &libpath[0] );
+    delete libpath;
     if( rc != 0 ){
       output->fatal(CALL_INFO, -1,
-        "Unable to HMC-Sim CMC Library and the return code is %d\n", rc);
+        "Unable to load the mapped HMC-Sim CMC Library %s and the return code is %d\n", path.c_str(), rc);
     }
 
     // add the new config to our list
@@ -521,9 +532,11 @@ void GOBLINHMCSimBackend::handleCmdMap(){
   size_t pos = 0;
   CMCSrcReq ctype_int;
   int csize_int = -1;
+  uint32_t copc_uint = 0xFFFF;
   std::string ctype;
   std::string cstr;
   std::string csize;
+  std::string copc;
   hmc_rqst_t rqst;
 
   for( unsigned i=0; i<cmdmaps.size(); i++ ){
@@ -534,7 +547,7 @@ void GOBLINHMCSimBackend::handleCmdMap(){
     std::vector<std::string> vstr;
     splitStr(s,':',vstr);
 
-    if( vstr.size() != 3 ){
+    if( vstr.size() != 4 ){
       // formatting error
       output->fatal(CALL_INFO, -1,
                     "Unable to process command map: %s\n", s.c_str() );
@@ -558,14 +571,18 @@ void GOBLINHMCSimBackend::handleCmdMap(){
                     ctype.c_str() );
     }
 
-    // -- size
-    csize = vstr[1];
+    // -- opcode
+    copc = vstr[1];
     std::string::size_type sz;
+    copc_uint = std::stoi(copc,&sz);
+
+    // -- size
+    csize = vstr[2];
     csize_int = std::stoi(csize,&sz);
 
 
     // -- cmd
-    cstr = vstr[2];
+    cstr = vstr[3];
     if( !strToHMCRqst( cstr, &rqst, false ) ){
       output->fatal(CALL_INFO, -1,
                     "Unable find to a suitable HMC command for: %s\n",
@@ -573,8 +590,27 @@ void GOBLINHMCSimBackend::handleCmdMap(){
     }
 
     // add the new mapping to our list
-    CmdMapping.push_back( new HMCSimCmdMap(ctype_int, csize_int, rqst) );
+    CmdMapping.push_back( new HMCSimCmdMap(ctype_int, copc_uint,
+                                           csize_int, rqst) );
   }
+}
+
+bool GOBLINHMCSimBackend::isReadRqst( hmc_rqst_t R ){
+  switch(R){
+  case RD16:
+  case RD32:
+  case RD48:
+  case RD64:
+  case RD80:
+  case RD96:
+  case RD112:
+  case RD128:
+  case RD256:
+    return true;
+  default:
+    return false;
+  }
+  return false;
 }
 
 bool GOBLINHMCSimBackend::isPostedRqst( hmc_rqst_t R ){
@@ -607,6 +643,7 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
   // Step 1: decode the incoming command type
   CMCSrcReq Src = SRC_RD;
   bool isPosted = false;
+  bool isRead = false;
   if( isWrite ){
     Src = SRC_WR;
   }
@@ -648,6 +685,13 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
     isPosted = false;
   }
 
+  // -- check to see whether this is a read request
+  isRead = isReadRqst( req_type );
+  if( isPosted && isRead ){
+    // can't have posted reads
+    output->fatal(CALL_INFO, -1, "Mapped posted reads are illegal\n" );
+  }
+
   const uint8_t           req_link   = (uint8_t) (nextLink);
   nextLink = nextLink + 1;
   nextLink = (nextLink == hmc_link_count) ? 0 : nextLink;
@@ -687,12 +731,12 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
     // back to us when we are free
     *Success = false;
   } else if(0 == rc) {
-    output->verbose(CALL_INFO, 4, 0, "Issue of mapped request for address %" PRIu64 " successfully accepted by HMC.\n", addr);
+    output->verbose(CALL_INFO, 4, 0, "Issue of mapped request for address 0X%" PRIx64 " successfully accepted by HMC.\n", addr);
 
     // Create the request entry which we keep in a table
     HMCSimBackEndReq* reqEntry = new HMCSimBackEndReq(reqId, addr,
                                                       owner->getCurrentSimTimeNano(),
-                                                      isPosted);
+                                                      !isPosted);
 
     // Add the tag and request into our table of pending
     tag_req_map.insert( std::pair<uint16_t, HMCSimBackEndReq*>(req_tag, reqEntry) );
@@ -716,7 +760,129 @@ bool GOBLINHMCSimBackend::issueMappedRequest(ReqId reqId, Addr addr, bool isWrit
 bool GOBLINHMCSimBackend::issueCustomRequest(ReqId reqId, Addr addr, uint32_t cmd,
                                             std::vector<uint64_t> ins, uint32_t flags,
                                             unsigned numBytes) {
-  // TODO: currently a placeholder
+  // Step 1: try to grab a tag
+  // We have run out of tags
+  if(tag_queue.empty()) {
+    output->verbose(CALL_INFO, 4, 0,
+                    "Will not issue request this call, tag queue has no free entries.\n");
+    return false;
+  }
+
+  output->verbose(CALL_INFO, 8, 0,
+    "Received custom request of opcode %" PRIu32 " of size: %" PRIu32 "\n",
+    cmd, numBytes);
+
+
+  // Step 2: walk the CmdMapping table and look for a mapping
+  HMCSimCmdMap *MapCmd = NULL;
+  std::string name;
+  for( auto itr = CmdMapping.begin(); itr != CmdMapping.end(); ++itr ){
+    MapCmd = *itr;
+    if( (MapCmd->getOpcode() == cmd) &&
+        ((unsigned)(MapCmd->getSrcSize()) == numBytes) ){
+      // found a positive map
+      if( !HMCRqstToStr(MapCmd->getTargetType(), &name) ){
+        std::string tStr;
+        output->fatal(CALL_INFO, -1, "Unable to map hmc_rqst_t=%d to name\n", (int)(MapCmd->getTargetType()));
+      }
+      output->verbose(CALL_INFO, 8, 0,
+                      "Found mapped request target of %s\n", name.c_str() );
+
+      break;
+    }
+    MapCmd = NULL;
+  }
+
+  // -- if our MapCmd is NULL, then nothing was found
+  if( MapCmd == NULL ){
+    return false;
+  }
+
+  // Step 3: attempt to issue the request
+
+  // Zero out the packet ready for us to populate it with values below
+  zeroPacket(hmc_packet);
+
+  output->verbose(CALL_INFO, 4, 0, "Queue front is: %" PRIu16 "\n", tag_queue.front());
+
+  const uint8_t     req_dev  = 0;
+  const uint16_t    req_tag  = (uint16_t) tag_queue.front();
+  tag_queue.pop();
+
+  hmc_rqst_t req_type = MapCmd->getTargetType();
+
+  const uint8_t     req_link   = (uint8_t) (nextLink);
+  nextLink = nextLink + 1;
+  nextLink = (nextLink == hmc_link_count) ? 0 : nextLink;
+
+  uint64_t          req_header = (uint64_t) 0;
+  uint64_t          req_tail   = (uint64_t) 0;
+
+  // -- determine if the request is posted
+  bool isPosted = isPostedRqst(req_type);
+
+  // -- check to see whether this is a read request
+  bool isRead = isReadRqst( req_type );
+  if( isPosted && isRead ){
+    // can't have posted reads
+    output->fatal(CALL_INFO, -1, "Mapped posted reads are illegal\n" );
+  }
+
+  output->verbose(CALL_INFO, 8, 0,
+    "Issuing custom request: %" PRIu64 " cmd=%s tag: %" PRIu16 " dev: %" PRIu8 " link: %" PRIu8 "\n",
+    addr, name.c_str(), req_tag, req_dev, req_dev);
+
+  int rc = hmcsim_build_memrequest(&the_hmc,
+                                  req_dev,
+                                  addr,
+                                  req_tag,
+                                  req_type,
+                                  req_link,
+                                  hmc_payload,
+                                  &req_header,
+                                  &req_tail);
+
+  if(rc > 0) {
+    output->fatal(CALL_INFO, -1, "Unable to build a custom request for address: %" PRIu64 "\n", addr);
+  }
+
+  hmc_packet[0] = req_header;
+  hmc_packet[1] = req_tail;
+  
+  rc = hmcsim_send(&the_hmc, &hmc_packet[0]);
+
+  if(HMC_STALL == rc) {
+    output->verbose(CALL_INFO, 2, 0, "Issue revoked by HMC, reason: cube is stalled.\n");
+
+    // Restore tag for use later, remember this request did not succeed
+    tag_queue.push(req_tag);
+
+    // Return false, the request was not issued so we must tell memory controller to give it
+    // back to us when we are free
+    return false;
+  } else if(0 == rc) {
+    output->verbose(CALL_INFO, 4, 0,
+      "Issue of custom request for %s at address 0x%" PRIx64 " successfully accepted by HMC.\n",
+      name.c_str(), addr);
+
+    // Create the request entry which we keep in a table
+    HMCSimBackEndReq* reqEntry = new HMCSimBackEndReq(reqId, addr,
+                                                      owner->getCurrentSimTimeNano(),
+                                                      !isPosted);
+
+    // Add the tag and request into our table of pending
+    tag_req_map.insert( std::pair<uint16_t, HMCSimBackEndReq*>(req_tag, reqEntry) );
+
+    // Record the I/O statistics
+    if( (hmc_trace_level & HMC_TRACE_CMD) > 0 ){
+      recordIOStats( hmc_packet[0] );
+    }
+  } else {
+    output->fatal(CALL_INFO, -1,
+      "Error issue request for %s at address %" PRIu64 " into HMC on link %" PRIu8 "\n",
+      name.c_str(), addr, req_link);
+  }
+
   return true;
 }
 bool GOBLINHMCSimBackend::issueRequest(ReqId reqId, Addr addr, bool isWrite,
@@ -763,6 +929,12 @@ bool GOBLINHMCSimBackend::issueRequest(ReqId reqId, Addr addr, bool isWrite,
 	  output->verbose(CALL_INFO, 4, 0, "Request is marked as posted\n");
           isPosted = true;
         }
+        bool isRead = isReadRqst( req_type );
+        if( isPosted && isRead ){
+          // can't have posted reads
+          output->fatal(CALL_INFO, -1, "Mapped posted reads are illegal\n" );
+        }
+
 
 	// Check if the request is for a read or write then transform this into something
 	// for HMC simulator to use
@@ -902,6 +1074,9 @@ bool GOBLINHMCSimBackend::issueRequest(ReqId reqId, Addr addr, bool isWrite,
 
 	rc = hmcsim_send(&the_hmc, &hmc_packet[0]);
 
+        std::string RqstStr;
+        HMCRqstToStr( req_type, &RqstStr );
+
 	if(HMC_STALL == rc) {
 		output->verbose(CALL_INFO, 2, 0, "Issue revoked by HMC, reason: cube is stalled.\n");
 
@@ -913,15 +1088,15 @@ bool GOBLINHMCSimBackend::issueRequest(ReqId reqId, Addr addr, bool isWrite,
 		return false;
 	} else if(0 == rc) {
                 if( isPosted ){
-		  output->verbose(CALL_INFO, 4, 0, "Issue of posted request for address %" PRIu64 " successfully accepted by HMC.\n", addr);
+		  output->verbose(CALL_INFO, 4, 0, "Issue of posted request %s for address 0X%" PRIx64 " successfully accepted by HMC.\n", RqstStr.c_str(), addr);
                 }else{
-		  output->verbose(CALL_INFO, 4, 0, "Issue of request for address %" PRIu64 " successfully accepted by HMC.\n", addr);
+		  output->verbose(CALL_INFO, 4, 0, "Issue of request %s for address 0X%" PRIx64 " successfully accepted by HMC.\n", RqstStr.c_str(), addr);
                 }
 
 		// Create the request entry which we keep in a table
 		HMCSimBackEndReq* reqEntry = new HMCSimBackEndReq(reqId, addr,
                                                                   owner->getCurrentSimTimeNano(),
-                                                                  isPosted);
+                                                                  !isPosted);
 
 		// Add the tag and request into our table of pending
 		tag_req_map.insert( std::pair<uint16_t, HMCSimBackEndReq*>(req_tag, reqEntry) );
@@ -1030,7 +1205,7 @@ void GOBLINHMCSimBackend::processResponses() {
 	printPendingRequests();
 
 	for(uint32_t i = 0; i < (uint32_t) the_hmc.num_links; ++i) {
-		output->verbose(CALL_INFO, 4, 0, "Pooling responses on link %d...\n", i);
+		output->verbose(CALL_INFO, 6, 0, "Polling responses on link %d...\n", i);
 
 		rc = HMC_OK;
 
@@ -1080,7 +1255,7 @@ void GOBLINHMCSimBackend::processResponses() {
 					} else {
 						HMCSimBackEndReq* matchedReq = locate_tag->second;
 
-						output->verbose(CALL_INFO, 4, 0, "Matched tag %" PRIu16 " to request for address: %" PRIu64 ", processing time: %" PRIu64 "ns\n",
+						output->verbose(CALL_INFO, 4, 0, "Matched tag %" PRIu16 " to request for address: 0x%" PRIx64 ", processing time: %" PRIu64 "ns\n",
 							resp_tag, matchedReq->getAddr(),
 							owner->getCurrentSimTimeNano() - matchedReq->getStartTime());
 
@@ -1111,13 +1286,12 @@ void GOBLINHMCSimBackend::processResponses() {
 		}
 	}
 
-#if 0
         // handle all the posted requests
         std::map<uint16_t, HMCSimBackEndReq*>::iterator it;
         for(it=tag_req_map.begin(); it!=tag_req_map.end(); it++ ){
           uint16_t resp_tag = it->first;
           HMCSimBackEndReq* matchedReq = it->second;
-          if( matchedReq->hasResponse() ){
+          if( !matchedReq->hasResponse() ){
             // i am a posted request
 	    output->verbose(CALL_INFO, 4, 0, "Handling posted memory response for tag: %" PRIu16 "\n", resp_tag);
             handleMemResponse(matchedReq->getRequest(),flags);
@@ -1126,7 +1300,6 @@ void GOBLINHMCSimBackend::processResponses() {
             delete matchedReq;
           }
         }
-#endif
 }
 
 GOBLINHMCSimBackend::~GOBLINHMCSimBackend() {
@@ -1473,12 +1646,12 @@ void GOBLINHMCSimBackend::zeroPacket(uint64_t* packet) const {
 }
 
 void GOBLINHMCSimBackend::printPendingRequests() {
-	output->verbose(CALL_INFO, 4, 0, "Pending requests:\n");
+	output->verbose(CALL_INFO, 8, 0, "Pending requests:\n");
 
 	std::map<uint16_t, HMCSimBackEndReq*>::iterator pending_itr;
 
 	for(pending_itr = tag_req_map.begin(); pending_itr != tag_req_map.end(); pending_itr++) {
-		output->verbose(CALL_INFO, 8, 0, "Tag: %8" PRIu16 " for address %" PRIu64 "\n",
+		output->verbose(CALL_INFO, 8, 0, "Tag: %8" PRIu16 " for address 0X%" PRIx64 "\n",
 			pending_itr->first, pending_itr->second->getAddr());
 	}
 }

--- a/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/goblinHMCBackend.h
@@ -69,18 +69,20 @@ private:
 
 class HMCSimCmdMap{
 public:
-  HMCSimCmdMap( CMCSrcReq SRC, int SZ, hmc_rqst_t DEST ) :
-    src(SRC), size(SZ), rqst(DEST) {}
+  HMCSimCmdMap( CMCSrcReq SRC, uint32_t OPC, int SZ, hmc_rqst_t DEST ) :
+    src(SRC), opc(OPC), size(SZ), rqst(DEST) {}
   ~HMCSimCmdMap() {}
 
   CMCSrcReq getSrcType() { return src; }
   int getSrcSize() { return size; }
+  uint32_t getOpcode() { return opc; }
   hmc_rqst_t getTargetType() { return rqst; }
 
 private:
   CMCSrcReq src;    // source request type
   int size;         // size of the request
   hmc_rqst_t rqst;  // target request type
+  uint32_t opc;     // custom opcode
 };
 
 class HMCSimBackEndReq {
@@ -296,6 +298,7 @@ private:
         bool strToHMCRqst( std::string, hmc_rqst_t *, bool );
         bool HMCRqstToStr( hmc_rqst_t R, std::string *S );
         bool isPostedRqst( hmc_rqst_t );
+        bool isReadRqst( hmc_rqst_t );
 
 	bool issueMappedRequest(ReqId, Addr, bool,
                                 std::vector<uint64_t>,

--- a/src/sst/elements/memHierarchy/membackend/memBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/memBackend.h
@@ -144,7 +144,7 @@ class ExtMemBackend : public MemBackend {
                                uint32_t flags, unsigned numBytes ) = 0;
     virtual bool issueCustomRequest( ReqId, Addr, uint32_t Cmd,
                                      std::vector<uint64_t> ins,
-                                     uint32_t flags, unsigned numBytes );
+                                     uint32_t flags, unsigned numBytes ) = 0;
 
     void handleMemResponse( ReqId id, uint32_t flags ) {
         m_respFunc( id, flags );

--- a/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
@@ -82,9 +82,6 @@ void MemBackendConvertor::handleMemEvent(  MemEvent* ev ) {
     Debug(_L10_,"Creating MemReq. BaseAddr = %" PRIx64 ", Size: %" PRIu32 ", %s\n",
                         ev->getBaseAddr(), ev->getSize(), CommandString[(int)ev->getCmd()]);
 
-    printf( "Creating MemReq. BaseAddr = 0x%" PRIx64 ", Size: %" PRIu32 ", %s\n",
-                        ev->getBaseAddr(), ev->getSize(), CommandString[(int)ev->getCmd()]);
-
     if (!setupMemReq(ev)) {
         sendResponse(ev->getID(), ev->getFlags());
     }

--- a/src/sst/elements/memHierarchy/tests/goblinCustomCmd-1.py
+++ b/src/sst/elements/memHierarchy/tests/goblinCustomCmd-1.py
@@ -1,0 +1,85 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 8,
+	"generator" : "miranda.STREAMBenchGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+        "generatorParams.write_cmd" : 10,
+        #"generatorParams.read_cmd" : 20,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+#comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory = sst.Component("memory", "memHierarchy.CoherentMemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "customCmdHandler" : "memHierarchy.amoCustomCmdHandler",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.verbose" : "8",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1",
+
+      "backend.cmd-map" : "[CUSTOM:10:64:WR64]"
+
+      #"backend.cmd-map" : "[CUSTOM:10:64:CMC125]",
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libhmc_lock.so:CMC125:2:2]"
+
+      #"backend.cmd-map" : "[CUSTOM:10:64:CMC77,CUSTOM:20:64:CMC74]",
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libwritexe.so:CMC77:2:2,/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libreadxx.so:CMC74:1:2]"
+
+      #"backend.cmd-map" : "[RD:0:64:RD96]"
+      #"backend.cmd-map" : "[CUSTOM:10:64:CMC77]",    #-- write --> WriteXE
+      #"backend.cmd-map" : "[CUSTOM:20:64:CMC74]",    #-- read --> ReadXX
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libwritexe.so:CMC77:2:2]",  #-- WriteXE
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libreadxx.so:CMC74:1:2]"    #-- ReadXX
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libhmc_lock.so:CMC125:2:2]"
+      #"backend.cmd-config" : "[/jenkins/sst/install/volatile/TOT/hmcsim/cmc/libreadxx.so:CMC74:1:2]"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/memHierarchy/tests/goblinCustomCmd-2.py
+++ b/src/sst/elements/memHierarchy/tests/goblinCustomCmd-2.py
@@ -13,7 +13,7 @@ comp_cpu.addParams({
 	"generatorParams.startat" : 3,
 	"generatorParams.count" : 500000,
 	"generatorParams.max_address" : 512000,
-        "generatorParams.write_cmd" : 10,
+        "generatorParams.read_cmd" : 20,
 	"printStats" : 1,
 })
 
@@ -57,7 +57,7 @@ comp_memory.addParams({
       "backend.trace-latency" : "1",
       "backend.trace-stalls" : "1",
 
-      "backend.cmd-map" : "[CUSTOM:10:64:WR64]"
+      "backend.cmd-map" : "[CUSTOM:20:64:RD64]"
 })
 
 

--- a/src/sst/elements/memHierarchy/tests/goblinCustomCmd-3.py
+++ b/src/sst/elements/memHierarchy/tests/goblinCustomCmd-3.py
@@ -1,0 +1,71 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 0,
+	"generator" : "miranda.STREAMBenchGenerator",
+	"generatorParams.verbose" : 0,
+	"generatorParams.startat" : 3,
+	"generatorParams.count" : 500000,
+	"generatorParams.max_address" : 512000,
+        "generatorParams.write_cmd" : 10,
+        "generatorParams.read_cmd" : 20,
+	"printStats" : 1,
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(4)
+
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+      "access_latency_cycles" : "2",
+      "cache_frequency" : "2 Ghz",
+      "replacement_policy" : "lru",
+      "coherence_protocol" : "MESI",
+      "associativity" : "4",
+      "cache_line_size" : "64",
+      "prefetcher" : "cassini.StridePrefetcher",
+      "debug" : "1",
+      "L1" : "1",
+      "cache_size" : "2KB"
+})
+
+# Enable statistics outputs
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+
+#comp_memory = sst.Component("memory", "memHierarchy.MemController")
+comp_memory = sst.Component("memory", "memHierarchy.CoherentMemController")
+comp_memory.addParams({
+      "coherence_protocol" : "MESI",
+      "backend.access_time" : "1000 ns",
+      "backend.mem_size" : "512MiB",
+      "clock" : "1GHz",
+      "customCmdHandler" : "memHierarchy.amoCustomCmdHandler",
+      "backendConvertor" : "memHierarchy.extMemBackendConvertor",
+      "backend" : "memHierarchy.goblinHMCSim",
+      "backend.verbose" : "0",
+      "backend.trace-banks" : "1",
+      "backend.trace-queue" : "1",
+      "backend.trace-cmds" : "1",
+      "backend.trace-latency" : "1",
+      "backend.trace-stalls" : "1",
+
+      "backend.cmd-map" : "[CUSTOM:10:64:WR64,CUSTOM:20:64:RD64]"
+})
+
+
+# Define the simulation links
+link_cpu_cache_link = sst.Link("link_cpu_cache_link")
+link_cpu_cache_link.connect( (comp_cpu, "cache_link", "1000ps"), (comp_l1cache, "high_network_0", "1000ps") )
+link_cpu_cache_link.setNoCut()
+
+link_mem_bus_link = sst.Link("link_mem_bus_link")
+link_mem_bus_link.connect( (comp_l1cache, "low_network_0", "50ps"), (comp_memory, "direct_link", "50ps") )

--- a/src/sst/elements/miranda/generators/gupsgen.h
+++ b/src/sst/elements/miranda/generators/gupsgen.h
@@ -44,6 +44,8 @@ private:
 	uint64_t iterations;
 	uint64_t seed_a;
 	uint64_t seed_b;
+        uint32_t write_cmd;
+        uint32_t read_cmd;
 	SSTRandom* rng;
 	Output*  out;
 	bool issueOpFences;

--- a/src/sst/elements/miranda/generators/randomgen.cc
+++ b/src/sst/elements/miranda/generators/randomgen.cc
@@ -37,8 +37,17 @@ RandomGenerator::RandomGenerator( Component* owner, Params& params ) :
 	out->verbose(CALL_INFO, 1, 0, "Will issue %" PRIu64 " operations\n", issueCount);
 	out->verbose(CALL_INFO, 1, 0, "Request lengths: %" PRIu64 " bytes\n", reqLength);
 	out->verbose(CALL_INFO, 1, 0, "Maximum address: %" PRIu64 "\n", maxAddr);
+        write_cmd  = params.find<uint32_t>("write_cmd", 0xFFFF );
+        read_cmd   = params.find<uint32_t>("read_cmd", 0xFFFF );
 
 	issueOpFences = params.find<std::string>("issue_op_fences", "yes") == "yes";
+
+        if( write_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode %" PRIu32 "\n", write_cmd );
+        }
+        if( read_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode %" PRIu32 "\n", read_cmd );
+        }
 }
 
 RandomGenerator::~RandomGenerator() {
@@ -58,7 +67,19 @@ void RandomGenerator::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
 	const double op_decide = rng->nextUniform();
 
 	// Populate request
-	q->push_back(new MemoryOpRequest(addr, reqLength, (op_decide < 0.5) ? READ : WRITE));
+        if( write_cmd == 0xFFFF ){
+          // issue standard operation
+	  q->push_back(new MemoryOpRequest(addr, reqLength, (op_decide < 0.5) ? READ : WRITE));
+        }else{
+          // issue custom operation
+          MemoryOpRequest *op;
+          if( op_decide < 0.5 ){
+            op = new MemoryOpRequest( addr, reqLength, read_cmd );
+          }else{
+            op = new MemoryOpRequest( addr, reqLength, write_cmd );
+          }
+          q->push_back(op);
+        }
 
 	if(issueOpFences) {
 		q->push_back(new FenceOpRequest());

--- a/src/sst/elements/miranda/generators/randomgen.h
+++ b/src/sst/elements/miranda/generators/randomgen.h
@@ -41,6 +41,8 @@ private:
 	uint64_t reqLength;
 	uint64_t maxAddr;
 	uint64_t issueCount;
+        uint32_t write_cmd;
+        uint32_t read_cmd;
 	bool issueOpFences;
 	SSTRandom* rng;
 	Output*  out;

--- a/src/sst/elements/miranda/generators/revsinglestream.cc
+++ b/src/sst/elements/miranda/generators/revsinglestream.cc
@@ -31,6 +31,7 @@ ReverseSingleStreamGenerator::ReverseSingleStreamGenerator( Component* owner, Pa
 	startIndex  = params.find<uint64_t>("start_at", 1024);
 	datawidth   = params.find<uint64_t>("datawidth", 8);
 	stride      = params.find<uint64_t>("stride", 1);
+        read_cmd    = params.find<uint32_t>("read_cmd", 0xFFFF );
 
 	if(startIndex < stopIndex) {
 		out->fatal(CALL_INFO, -1, "Start address (%" PRIu64 ") must be greater than stop address (%" PRIu64 ") in reverse stream generator",
@@ -42,6 +43,10 @@ ReverseSingleStreamGenerator::ReverseSingleStreamGenerator( Component* owner, Pa
 	out->verbose(CALL_INFO, 1, 0, "Data width:            %" PRIu64 "\n", datawidth);
 	out->verbose(CALL_INFO, 1, 0, "Stride:                %" PRIu64 "\n", stride);
 
+        if( read_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode %" PRIu32 "\n", read_cmd );
+        }
+
 	nextIndex = startIndex;
 }
 
@@ -52,7 +57,13 @@ ReverseSingleStreamGenerator::~ReverseSingleStreamGenerator() {
 void ReverseSingleStreamGenerator::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
 	out->verbose(CALL_INFO, 4, 0, "Generating next request at address: %" PRIu64 "\n", nextIndex);
 
-	q->push_back(new MemoryOpRequest(nextIndex * datawidth, datawidth, READ));
+        if( read_cmd == 0xFFFF ){
+          // issue standard request
+	  q->push_back(new MemoryOpRequest(nextIndex * datawidth, datawidth, READ));
+        }else{
+          // issue custom request
+	  q->push_back(new MemoryOpRequest(nextIndex * datawidth, datawidth, read_cmd));
+        }
 
 	// What is the next address?
 	nextIndex = nextIndex - stride;

--- a/src/sst/elements/miranda/generators/revsinglestream.h
+++ b/src/sst/elements/miranda/generators/revsinglestream.h
@@ -40,6 +40,7 @@ private:
 	uint64_t datawidth;
 	uint64_t nextIndex;
 	uint64_t stride;
+        uint32_t read_cmd;
 
 	Output*  out;
 

--- a/src/sst/elements/miranda/generators/singlestream.cc
+++ b/src/sst/elements/miranda/generators/singlestream.cc
@@ -31,6 +31,8 @@ SingleStreamGenerator::SingleStreamGenerator( Component* owner, Params& params )
 	reqLength  = params.find<uint64_t>("length", 8);
 	startAddr  = params.find<uint64_t>("startat", 0);
 	maxAddr    = params.find<uint64_t>("max_address", 524288);
+        write_cmd  = params.find<uint32_t>("write_cmd", 0xFFFF );
+        read_cmd   = params.find<uint32_t>("read_cmd", 0xFFFF );
 
 	nextAddr   = startAddr;
 
@@ -48,6 +50,13 @@ SingleStreamGenerator::SingleStreamGenerator( Component* owner, Params& params )
 	out->verbose(CALL_INFO, 1, 0, "Request lengths: %" PRIu64 " bytes\n", reqLength);
 	out->verbose(CALL_INFO, 1, 0, "Maximum address: %" PRIx64 "\n", maxAddr);
 	out->verbose(CALL_INFO, 1, 0, "First address: %" PRIx64 "\n", nextAddr);
+
+        if( write_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode %" PRIu32 "\n", write_cmd );
+        }
+        if( read_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode %" PRIu32 "\n", read_cmd );
+        }
 }
 
 SingleStreamGenerator::~SingleStreamGenerator() {
@@ -57,7 +66,15 @@ SingleStreamGenerator::~SingleStreamGenerator() {
 void SingleStreamGenerator::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
 	out->verbose(CALL_INFO, 4, 0, "Generating next request number: %" PRIu64 "\n", issueCount);
 
-	q->push_back(new MemoryOpRequest(nextAddr, reqLength, memOp));
+        if( (memOp == READ) && (read_cmd == 0xFFFF) ){
+	  q->push_back(new MemoryOpRequest(nextAddr, reqLength, memOp));
+        }else if( (memOp == READ) && (read_cmd != 0xFFFF ) ){
+	  q->push_back(new MemoryOpRequest(nextAddr, reqLength, read_cmd));
+        }else if( (memOp == WRITE) && (write_cmd = 0xFFFF ) ){
+	  q->push_back(new MemoryOpRequest(nextAddr, reqLength, memOp));
+        }else if( (memOp == WRITE) && (write_cmd != 0xFFFF ) ){
+	  q->push_back(new MemoryOpRequest(nextAddr, reqLength, write_cmd));
+        }
 
 	// What is the next address?
 	nextAddr = (nextAddr + reqLength) % maxAddr;

--- a/src/sst/elements/miranda/generators/singlestream.h
+++ b/src/sst/elements/miranda/generators/singlestream.h
@@ -40,6 +40,8 @@ private:
 	uint64_t issueCount;
 	uint64_t nextAddr;
 	uint64_t startAddr;
+        uint32_t write_cmd;
+        uint32_t read_cmd;
 	Output*  out;
 	ReqOperation memOp;
 

--- a/src/sst/elements/miranda/generators/spmvgen.h
+++ b/src/sst/elements/miranda/generators/spmvgen.h
@@ -62,6 +62,9 @@ public:
 		matrixElementsStartAddr = params.find<uint64_t>("matrix_element_start_addr", nextStartAddr);
 
 		iterations = params.find<uint64_t>("iterations", 1);
+
+                write_cmd = params.find<uint32_t>("write_cmd", 0xFFFF );
+                read_cmd = params.find<uint32_t>("read_cmd", 0xFFFF );
 	}
 
 	~SPMVGenerator() {
@@ -72,16 +75,36 @@ public:
 		for(uint64_t row = localRowStart; row < localRowEnd; row++) {
 			out->verbose(CALL_INFO, 2, 0, "Generating access for row %" PRIu64 "\n", row);
 
-			MemoryOpRequest* readStart = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * row), ordinalWidth, READ);
-			MemoryOpRequest* readEnd   = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * (row + 1)), ordinalWidth, READ);
+                        MemoryOpRequest* readStart;
+                        MemoryOpRequest* readEnd;
+                        if( read_cmd == 0xFFFF ){
+                          // issue standard read
+			  readStart = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * row), ordinalWidth, READ);
+			  readEnd   = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * (row + 1)), ordinalWidth, READ);
+                        }else{
+                          // issue custom read
+			  readStart = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * row), ordinalWidth, read_cmd);
+			  readEnd   = new MemoryOpRequest(matrixRowIndicesStartAddr + (ordinalWidth * (row + 1)), ordinalWidth, read_cmd);
+                        }
 
 			q->push_back(readStart);
 			q->push_back(readEnd);
 
-			MemoryOpRequest* readResultCurrentValue = new MemoryOpRequest(rhsVecStartAddr +
+                        MemoryOpRequest* readResultCurrentValue;
+                        MemoryOpRequest* writeResult;
+                        if( write_cmd == 0xFFFF ){
+                          // issue standard write
+			  readResultCurrentValue = new MemoryOpRequest(rhsVecStartAddr +
 				(row * matrixNNZPerRow), elementWidth, WRITE);
-			MemoryOpRequest* writeResult = new MemoryOpRequest(rhsVecStartAddr +
+			  writeResult = new MemoryOpRequest(rhsVecStartAddr +
 				(row * matrixNNZPerRow), elementWidth, WRITE);
+                        }else{
+                          // issue custom write
+			  readResultCurrentValue = new MemoryOpRequest(rhsVecStartAddr +
+				(row * matrixNNZPerRow), elementWidth, write_cmd);
+			  writeResult = new MemoryOpRequest(rhsVecStartAddr +
+				(row * matrixNNZPerRow), elementWidth, write_cmd);
+                        }
 
 			writeResult->addDependency(readResultCurrentValue->getRequestID());
 
@@ -95,12 +118,26 @@ public:
 				out->verbose(CALL_INFO, 4, 0, "Generating access for row %" PRIu64 ", column: %" PRIu64 "\n",
 					row, col);
 
-				MemoryOpRequest* readMatElement = new MemoryOpRequest(matrixElementsStartAddr +
+                                MemoryOpRequest* readMatElement;
+                                MemoryOpRequest* readCol;
+                                MemoryOpRequest* readLHSElem;
+                                if( read_cmd == 0xFFFF ){
+                                  // issue standard read
+				  readMatElement = new MemoryOpRequest(matrixElementsStartAddr +
 					(row * matrixNNZPerRow + col) * elementWidth, elementWidth, READ);
-				MemoryOpRequest* readCol = new MemoryOpRequest(matrixColumnIndicesStartAddr +
+				  readCol = new MemoryOpRequest(matrixColumnIndicesStartAddr +
 					(row * matrixNNZPerRow + col) * ordinalWidth, ordinalWidth, READ);
-				MemoryOpRequest* readLHSElem = new MemoryOpRequest(lhsVecStartAddr +
+				  readLHSElem = new MemoryOpRequest(lhsVecStartAddr +
 					(row * matrixNNZPerRow + col) * elementWidth, elementWidth, READ);
+                                }else{
+                                  // issue custom read
+				  readMatElement = new MemoryOpRequest(matrixElementsStartAddr +
+					(row * matrixNNZPerRow + col) * elementWidth, elementWidth, read_cmd);
+				  readCol = new MemoryOpRequest(matrixColumnIndicesStartAddr +
+					(row * matrixNNZPerRow + col) * ordinalWidth, ordinalWidth, read_cmd);
+				  readLHSElem = new MemoryOpRequest(lhsVecStartAddr +
+					(row * matrixNNZPerRow + col) * elementWidth, elementWidth, read_cmd);
+                                }
 
 				readCol->addDependency(readStart->getRequestID());
 				readCol->addDependency(readEnd->getRequestID());
@@ -142,6 +179,8 @@ private:
 	uint64_t localRowEnd;
 	uint64_t matrixColumnIndicesStartAddr;
 	uint64_t matrixElementsStartAddr;
+        uint32_t write_cmd;
+        uint32_t read_cmd;
 
 };
 

--- a/src/sst/elements/miranda/generators/stencil3dbench.cc
+++ b/src/sst/elements/miranda/generators/stencil3dbench.cc
@@ -37,9 +37,18 @@ Stencil3DBenchGenerator::Stencil3DBenchGenerator( Component* owner, Params& para
 	endZ   = params.find<uint32_t>("endz",   nZ);
 
 	maxItr = params.find<uint32_t>("iterations", 1);
+        write_cmd  = params.find<uint32_t>("write_cmd", 0xFFFF );
+        read_cmd   = params.find<uint32_t>("read_cmd", 0xFFFF );
 	currentItr = 0;
 
 	currentZ = startZ + 1;
+
+        if( write_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode %" PRIu32 "\n", write_cmd );
+        }
+        if( read_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode %" PRIu32 "\n", read_cmd );
+        }
 }
 
 Stencil3DBenchGenerator::~Stencil3DBenchGenerator() {
@@ -59,44 +68,130 @@ void Stencil3DBenchGenerator::generate(MirandaRequestQueue<GeneratorRequest*>* q
 			out->verbose(CALL_INFO, 4, 0, "Generating for plane (Z=%" PRIu32 ", Y=%" PRIu32 ")...\n", currentZ, curY);
 
 			for(uint32_t curX = 1; curX < (nX - 1); curX++) {
-				MemoryOpRequest* read_a = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_b = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_c = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ - 1), datawidth, READ);
+				MemoryOpRequest* read_a;
+				MemoryOpRequest* read_b;
+				MemoryOpRequest* read_c;
 
-				MemoryOpRequest* read_d = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_e = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_f = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ - 1), datawidth, READ);
+				MemoryOpRequest* read_d;
+				MemoryOpRequest* read_e;
+				MemoryOpRequest* read_f;
 
-				MemoryOpRequest* read_g = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_h = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ - 1), datawidth, READ);
-				MemoryOpRequest* read_i = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ - 1), datawidth, READ);
+				MemoryOpRequest* read_g;
+				MemoryOpRequest* read_h;
+				MemoryOpRequest* read_i;
 
-				MemoryOpRequest* read_j = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_k = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_l = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ    ), datawidth, READ);
+				MemoryOpRequest* read_j;
+				MemoryOpRequest* read_k;
+				MemoryOpRequest* read_l;
 
-				MemoryOpRequest* read_m = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_n = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_o = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ    ), datawidth, READ);
+				MemoryOpRequest* read_m;
+				MemoryOpRequest* read_n;
+				MemoryOpRequest* read_o;
 
-				MemoryOpRequest* read_p = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_q = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ    ), datawidth, READ);
-				MemoryOpRequest* read_r = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ    ), datawidth, READ);
+				MemoryOpRequest* read_p;
+				MemoryOpRequest* read_q;
+				MemoryOpRequest* read_r;
 
-				MemoryOpRequest* read_s = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_t = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_u = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ + 1), datawidth, READ);
+				MemoryOpRequest* read_s;
+				MemoryOpRequest* read_t;
+				MemoryOpRequest* read_u;
 
-				MemoryOpRequest* read_v = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_w = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_x = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ + 1), datawidth, READ);
+				MemoryOpRequest* read_v;
+				MemoryOpRequest* read_w;
+				MemoryOpRequest* read_x;
 
-				MemoryOpRequest* read_y = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_z = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ + 1), datawidth, READ);
-				MemoryOpRequest* read_zz = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ + 1), datawidth, READ);
+				MemoryOpRequest* read_y;
+				MemoryOpRequest* read_z;
+				MemoryOpRequest* read_zz;
 
-				MemoryOpRequest* write_a = new MemoryOpRequest( (nX * nY * nZ * datawidth) +
+                                if( read_cmd == 0xFFFF ){
+                                  // issue standard read
+				   read_a = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ - 1), datawidth, READ);
+				   read_b = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ - 1), datawidth, READ);
+				   read_c = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ - 1), datawidth, READ);
+
+				   read_d = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ - 1), datawidth, READ);
+				   read_e = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ - 1), datawidth, READ);
+				   read_f = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ - 1), datawidth, READ);
+
+				   read_g = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ - 1), datawidth, READ);
+				   read_h = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ - 1), datawidth, READ);
+				   read_i = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ - 1), datawidth, READ);
+
+				   read_j = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ    ), datawidth, READ);
+				   read_k = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ    ), datawidth, READ);
+				   read_l = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ    ), datawidth, READ);
+
+				   read_m = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ    ), datawidth, READ);
+				   read_n = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ    ), datawidth, READ);
+				   read_o = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ    ), datawidth, READ);
+
+				   read_p = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ    ), datawidth, READ);
+				   read_q = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ    ), datawidth, READ);
+				   read_r = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ    ), datawidth, READ);
+
+				   read_s = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ + 1), datawidth, READ);
+				   read_t = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ + 1), datawidth, READ);
+				   read_u = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ + 1), datawidth, READ);
+
+				   read_v = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ + 1), datawidth, READ);
+				   read_w = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ + 1), datawidth, READ);
+				   read_x = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ + 1), datawidth, READ);
+
+				   read_y = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ + 1), datawidth, READ);
+				   read_z = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ + 1), datawidth, READ);
+				   read_zz = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ + 1), datawidth, READ);
+
+                                }else{
+                                  // issue custom read
+				   read_a = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ - 1), datawidth, read_cmd);
+				   read_b = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ - 1), datawidth, read_cmd);
+				   read_c = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ - 1), datawidth, read_cmd);
+
+				   read_d = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ - 1), datawidth, read_cmd);
+				   read_e = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ - 1), datawidth, read_cmd);
+				   read_f = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ - 1), datawidth, read_cmd);
+
+				   read_g = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ - 1), datawidth, read_cmd);
+				   read_h = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ - 1), datawidth, read_cmd);
+				   read_i = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ - 1), datawidth, read_cmd);
+
+				   read_j = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ    ), datawidth, read_cmd);
+				   read_k = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ    ), datawidth, read_cmd);
+				   read_l = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ    ), datawidth, read_cmd);
+
+				   read_m = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ    ), datawidth, read_cmd);
+				   read_n = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ    ), datawidth, read_cmd);
+				   read_o = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ    ), datawidth, read_cmd);
+
+				   read_p = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ    ), datawidth, read_cmd);
+				   read_q = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ    ), datawidth, read_cmd);
+				   read_r = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ    ), datawidth, read_cmd);
+
+				   read_s = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY - 1, currentZ + 1), datawidth, read_cmd);
+				   read_t = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY - 1, currentZ + 1), datawidth, read_cmd);
+				   read_u = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY - 1, currentZ + 1), datawidth, read_cmd);
+
+				   read_v = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY    , currentZ + 1), datawidth, read_cmd);
+				   read_w = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY    , currentZ + 1), datawidth, read_cmd);
+				   read_x = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY    , currentZ + 1), datawidth, read_cmd);
+
+				   read_y = new MemoryOpRequest(datawidth * convertPositionToIndex(curX - 1, curY + 1, currentZ + 1), datawidth, read_cmd);
+				   read_z = new MemoryOpRequest(datawidth * convertPositionToIndex(curX,     curY + 1, currentZ + 1), datawidth, read_cmd);
+				   read_zz = new MemoryOpRequest(datawidth * convertPositionToIndex(curX + 1, curY + 1, currentZ + 1), datawidth, read_cmd);
+
+                                }
+
+                                MemoryOpRequest *write_a;
+                                if( write_cmd != 0xFFFF ){
+                                  // issue standard write
+				  write_a = new MemoryOpRequest( (nX * nY * nZ * datawidth) +
 					                            datawidth * convertPositionToIndex(curX    , curY    , currentZ    ), datawidth, WRITE);
+                                }else{
+                                  // issue custom write
+				  write_a = new MemoryOpRequest( (nX * nY * nZ * datawidth) +
+					                            datawidth * convertPositionToIndex(curX    , curY    , currentZ    ), datawidth, write_cmd);
+                                }
 
 				write_a->addDependency(read_a->getRequestID());
 				write_a->addDependency(read_b->getRequestID());

--- a/src/sst/elements/miranda/generators/stencil3dbench.h
+++ b/src/sst/elements/miranda/generators/stencil3dbench.h
@@ -52,6 +52,9 @@ private:
 	uint32_t currentItr;
 	uint32_t maxItr;
 
+        uint32_t write_cmd;
+        uint32_t read_cmd;
+
 	Output*  out;
 
 };

--- a/src/sst/elements/miranda/generators/streambench.cc
+++ b/src/sst/elements/miranda/generators/streambench.cc
@@ -55,10 +55,10 @@ STREAMBenchGenerator::STREAMBenchGenerator( Component* owner, Params& params ) :
 	out->verbose(CALL_INFO, 1, 0, "Total arrays:      %" PRIu64 " bytes\n", (3 * n * reqLength));
 	out->verbose(CALL_INFO, 1, 0, "N-per-generate     %" PRIu64 "\n", n_per_call);
         if( write_cmd != 0xFFFF ){
-          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode   %" PRIu32 "\b", write_cmd );
+          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode   %" PRIu32 "\n", write_cmd );
         }
         if( read_cmd != 0xFFFF ){
-          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode   %" PRIu32 "\b", read_cmd );
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode   %" PRIu32 "\n", read_cmd );
         }
 }
 

--- a/src/sst/elements/miranda/generators/streambench.cc
+++ b/src/sst/elements/miranda/generators/streambench.cc
@@ -40,6 +40,10 @@ STREAMBenchGenerator::STREAMBenchGenerator( Component* owner, Params& params ) :
 
 	n_per_call = params.find<uint64_t>("n_per_call", 1);
 
+        write_cmd = params.find<uint32_t>("write_cmd", 0xFFFF );
+
+        read_cmd = params.find<uint32_t>("read_cmd", 0xFFFF );
+
 	i = 0;
 
 	out->verbose(CALL_INFO, 1, 0, "STREAM-N length is %" PRIu64 "\n", n);
@@ -50,6 +54,12 @@ STREAMBenchGenerator::STREAMBenchGenerator( Component* owner, Params& params ) :
 	out->verbose(CALL_INFO, 1, 0, "Array Length:      %" PRIu64 " bytes\n", (n * reqLength));
 	out->verbose(CALL_INFO, 1, 0, "Total arrays:      %" PRIu64 " bytes\n", (3 * n * reqLength));
 	out->verbose(CALL_INFO, 1, 0, "N-per-generate     %" PRIu64 "\n", n_per_call);
+        if( write_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom WR opcode   %" PRIu32 "\b", write_cmd );
+        }
+        if( read_cmd != 0xFFFF ){
+          out->verbose(CALL_INFO, 1, 0, "Custom RD opcode   %" PRIu32 "\b", read_cmd );
+        }
 }
 
 STREAMBenchGenerator::~STREAMBenchGenerator() {
@@ -65,9 +75,39 @@ void STREAMBenchGenerator::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
 			break;
 		}
 
-		MemoryOpRequest* read_b  = new MemoryOpRequest(start_b + (i * reqLength), reqLength, READ);
-		MemoryOpRequest* read_c  = new MemoryOpRequest(start_c + (i * reqLength), reqLength, READ);
-		MemoryOpRequest* write_a = new MemoryOpRequest(start_a + (i * reqLength), reqLength, WRITE);
+                MemoryOpRequest* read_b;
+                MemoryOpRequest* read_c;
+                MemoryOpRequest* write_a;
+
+                if( read_cmd == 0xFFFF ){
+                  // issue standard read
+		  read_b  = new MemoryOpRequest(start_b + (i * reqLength),
+                                                reqLength,
+                                                READ);
+		  read_c  = new MemoryOpRequest(start_c + (i * reqLength),
+                                                reqLength,
+                                                READ);
+                }else{
+                  // issue custom read
+		  read_b  = new MemoryOpRequest(start_b + (i * reqLength),
+                                                reqLength,
+                                                read_cmd);
+		  read_c  = new MemoryOpRequest(start_c + (i * reqLength),
+                                                reqLength,
+                                                read_cmd);
+                }
+
+                if( write_cmd == 0xFFFF ){
+                  // issue standard write
+		  write_a = new MemoryOpRequest(start_a + (i * reqLength),
+                                                reqLength,
+                                                WRITE);
+                }else{
+                  // issue custom write
+		  write_a = new MemoryOpRequest(start_a + (i * reqLength),
+                                                reqLength,
+                                                write_cmd);
+                }
 
 		write_a->addDependency(read_b->getRequestID());
 		write_a->addDependency(read_c->getRequestID());

--- a/src/sst/elements/miranda/generators/streambench.h
+++ b/src/sst/elements/miranda/generators/streambench.h
@@ -45,6 +45,9 @@ private:
 	uint64_t n_per_call;
 	uint64_t i;
 
+        uint32_t write_cmd;
+        uint32_t read_cmd;
+
 	Output*  out;
 
 };

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -141,6 +141,8 @@ static const ElementInfoParam gupsGen_params[] = {
     { "iterations",       "Number of iterations to perform", "1" },
     { "max_address",      "Maximum address allowed for generation", "536870912" /* 512MB */ },
     { "issue_op_fences",  "Issue operation fences, \"yes\" or \"no\", default is yes", "yes" },
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -90,6 +90,8 @@ static const ElementInfoParam singleStreamGen_params[] = {
     { "length",           "Length of requests", "8" },
     { "max_address",      "Maximum address allowed for generation", "16384" },
     { "startat",          "Sets the start address for generation", "0" },
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -189,6 +189,8 @@ static const ElementInfoParam spmvBench_params[] = {
     { "matrix_element_start_addr", "Sets the start address of the elements array", "0" },
     { "iterations",     "Sets the number of repeats to perform" },
     { "matrix_nnz_per_row", "Sets the number of non-zero elements per row", "9" },
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -111,6 +111,7 @@ static const ElementInfoParam revSingleStreamGen_params[] = {
     { "verbose",          "Sets the verbosity of the output", "0" },
     { "datawidth",        "Sets the width of the memory operation", "8" },
     { "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -152,6 +152,8 @@ static const ElementInfoParam streamBench_params[] = {
     { "start_a",          "Sets the start address of the array a", "0" },
     { "start_b",          "Sets the start address of the array b", "1024" },
     { "start_c",          "Sets the start address of the array c", "2048" },
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 
@@ -280,10 +282,13 @@ static const ElementInfoSubComponent subcomponents[] = {
 static const ElementInfoStatistic basecpu_stats[] = {
 	{ "split_read_reqs",	"Number of read requests split over a cache line boundary",	"requests", 2 },
 	{ "split_write_reqs",	"Number of write requests split over a cache line boundary", 	"requests", 2 },
+        { "split_custom_reqs",  "NUmber of custom requests split over a cache line boundary",   "requests", 2 },
 	{ "read_reqs", 		"Number of read requests issued", 				"requests", 1 },
 	{ "write_reqs", 	"Number of write requests issued", 				"requests", 1 },
+        { "custom_reqs",        "Number of custom requests issued",                             "requests", 1 },
 	{ "total_bytes_read",   "Count the total bytes requested by read operations",		"bytes",    1 },
 	{ "total_bytes_write",  "Count the total bytes requested by write operations",      	"bytes",    1 },
+        { "total_bytes_custom", "Count the total bytes requested by custom operations",         "bytes",    1 },
 	{ "req_latency",        "Running total of all latency for all requests",                "ns",       2 },
     { "cycles_with_issue",  "Number of cycles which CPU was able to issue requests",        "cycles",   1 },
     { "cycles_no_issue",    "Number of cycles which CPU was not able to issue requests",    "cycles",   1 },

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -129,6 +129,8 @@ static const ElementInfoParam randomGen_params[] = {
     { "length",           "Length of requests", "8" },
     { "max_address",      "Maximum address allowed for generation", "16384" },
     { "issue_op_fences",  "Issue operation fences, \"yes\" or \"no\", default is yes", "yes" },
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -104,6 +104,8 @@ static const ElementInfoParam stencil3dGen_params[] = {
     { "startz",           "Sets the start location in Z-plane for this instance, parallelism implemented as Z-plane decomposition", "0" },
     { "endz",             "Sets the end location in Z-plane for this instance, parallelism implemented as Z-plane decomposition", "10" },
     { "iterations",       "Sets the number of iterations to perform over this mesh", "1"},
+    { "write_cmd",        "Sets the custom opcode for writes", "0xFFFF" },
+    { "read_cmd",         "Sets the custom opcode for reads",  "0xFFFF" },
     { NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/mirandaCPU.h
+++ b/src/sst/elements/miranda/mirandaCPU.h
@@ -83,21 +83,26 @@ private:
 
 	uint32_t maxLoadRequestsPending;
 	uint32_t maxStoreRequestsPending;
+        uint32_t maxCustomRequestsPending;
 	uint32_t requestsLoadPending;
 	uint32_t requestsStorePending;
+        uint32_t requestsCustomPending;
 	uint32_t reqMaxPerCycle;
 	uint64_t cacheLine;
 	uint32_t maxOpLookup;
 
 	Statistic<uint64_t>* statReadReqs;
 	Statistic<uint64_t>* statWriteReqs;
+        Statistic<uint64_t>* statCustomReqs;
 	Statistic<uint64_t>* statSplitReadReqs;
 	Statistic<uint64_t>* statSplitWriteReqs;
+	Statistic<uint64_t>* statSplitCustomReqs;
 	Statistic<uint64_t>* statCyclesWithIssue;
 	Statistic<uint64_t>* statMaxIssuePerCycle;
 	Statistic<uint64_t>* statCyclesWithoutIssue;
 	Statistic<uint64_t>* statBytesRead;
 	Statistic<uint64_t>* statBytesWritten;
+	Statistic<uint64_t>* statBytesCustom;
 	Statistic<uint64_t>* statReqLatency;
 	Statistic<uint64_t>* statTime;
 	Statistic<uint64_t>* statCyclesHitFence;

--- a/src/sst/elements/miranda/mirandaGenerator.h
+++ b/src/sst/elements/miranda/mirandaGenerator.h
@@ -31,7 +31,8 @@ namespace Miranda {
 typedef enum {
 	READ,
 	WRITE,
-	REQ_FENCE
+	REQ_FENCE,
+        CUSTOM
 } ReqOperation;
 
 static uint64_t nextGeneratorRequestID = 0;
@@ -178,16 +179,25 @@ public:
 		const ReqOperation cOpType) :
 		GeneratorRequest(),
 		addr(cAddr), length(cLength), op(cOpType) {}
+	MemoryOpRequest(const uint64_t cAddr,
+		const uint64_t cLength,
+                const uint32_t opc ) :
+		GeneratorRequest(),
+		addr(cAddr), length(cLength),
+                opcode(opc), op(CUSTOM) {}
 	~MemoryOpRequest() {}
 	ReqOperation getOperation() const { return op; }
 	bool isRead() const { return op == READ; }
 	bool isWrite() const { return op == WRITE; }
+        bool isCustom() const { return op == CUSTOM; }
 	uint64_t getAddress() const { return addr; }
 	uint64_t getLength() const { return length; }
+        uint32_t getOpcode() const { return opcode; }
 
 protected:
 	uint64_t addr;
 	uint64_t length;
+        uint32_t opcode;
 	ReqOperation op;
 };
 

--- a/src/sst/elements/miranda/tests/streambench.py
+++ b/src/sst/elements/miranda/tests/streambench.py
@@ -16,6 +16,8 @@ comp_cpu.addParams({
 	"generatorParams.verbose" : 0,
 	"generatorParams.n" : 10000,
         "generatorParams.operandwidth" : 16,
+        "generatorParams.write_cmd" : 10,
+        "generatorParams.read_cmd" : 20,
 	"printStats" : 1,
 })
 


### PR DESCRIPTION
This is the major merge request for the full support of custom command requests through the memHierarchy and the membackend.  The goblinHMCSim membackend is currently the only backend infrastructure that has full support for this.  Adding tests in memHierarchy/tests/ to override standard reads and writes for sample miranda drivers.

Porting the entire Miranda infrastructure forward to dispatch custom requests with "write_cmd" or "read_cmd" is set in the test script.  Command opcodes are uint32_t values < 0xFFFF.  This pull request requires the sst-core pull request: https://github.com/sstsimulator/sst-core/pull/318
