### PR TITLE
Fix Samba and Messier compilation with SystemC

### DIFF
--- a/src/sst/elements/Messier/Makefile.am
+++ b/src/sst/elements/Messier/Makefile.am
@@ -29,6 +29,7 @@ libMessier_la_CPPFLAGS = \
 	$(MPI_CPPFLAGS)
 
 libMessier_la_LDFLAGS = \
+	$(SST_SYSTEMC_LDFLAGS) \
 	-avoid-version
 
 libMessier_la_LIBADD = \

--- a/src/sst/elements/Samba/Makefile.am
+++ b/src/sst/elements/Samba/Makefile.am
@@ -24,6 +24,7 @@ libSamba_la_CPPFLAGS = \
 	$(MPI_CPPFLAGS)
 
 libSamba_la_LDFLAGS = \
+	$(SST_SYSTEMC_LDFLAGS) \
 	-avoid-version
 
 libSamba_la_LIBADD = \


### PR DESCRIPTION
The SystemC LDFLAGS don't get propagated down to these modules and so
builds against SystemC in non-global locations will fail.