### PR TITLE
Ship memLinkBase.h as a public header

### DIFF
--- a/src/sst/elements/memHierarchy/Makefile.am
+++ b/src/sst/elements/memHierarchy/Makefile.am
@@ -161,6 +161,7 @@ nobase_sst_HEADERS = \
 	memEventBase.h \
 	memEvent.h \
 	memNIC.h \
+	memLinkBase.h \
 	membackend/memBackend.h \
 	membackend/vaultSimBackend.h \
 	membackend/MessierBackend.h \


### PR DESCRIPTION
memNIC.h is a public header that includes memLinkBase.h and so
memLinkBase.h should also be shipped.