### PR TITLE
Bug fixes and tests for cache coherency shootdowns with custom memory commands

### DIFF
--- a/src/sst/elements/memHierarchy/customcmd/amoCustomCmdHandler.cc
+++ b/src/sst/elements/memHierarchy/customcmd/amoCustomCmdHandler.cc
@@ -24,7 +24,7 @@ using namespace SST;
 using namespace SST::MemHierarchy;
 
 CustomCmdMemHandler::MemEventInfo AMOCustomCmdMemHandler::receive(MemEventBase* ev){
-    CustomCmdMemHandler::MemEventInfo MEI(ev->getRoutingAddress(),false);
+    CustomCmdMemHandler::MemEventInfo MEI(ev->getRoutingAddress(),true);
     return MEI;
 }
 

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -218,6 +218,7 @@ DirectoryController::DirectoryController(ComponentId_t id, Params &params) :
     stat_PutSRespReceived           = registerStatistic<uint64_t>("responses_received_PutS");
     stat_dataReads                  = registerStatistic<uint64_t>("memory_requests_data_read");
     stat_dataWrites                 = registerStatistic<uint64_t>("memory_requests_data_write");
+    stat_dataCustom                 = registerStatistic<uint64_t>("memory_requests_data_custom");
     stat_dirEntryReads              = registerStatistic<uint64_t>("memory_requests_directory_entry_read");
     stat_dirEntryWrites             = registerStatistic<uint64_t>("memory_requests_directory_entry_write");
     stat_InvSent                    = registerStatistic<uint64_t>("requests_sent_Inv"); 
@@ -348,9 +349,11 @@ inline void DirectoryController::profileRequestSent(MemEvent * event) {
         case Command::Inv:
         stat_InvSent->addData(1);
         break;
+        case Command::CustomReq:
+        stat_dataCustom->addData(1);
     default:
         break;
-        
+
     }
 }
 

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -172,7 +172,7 @@ DirectoryController::DirectoryController(ComponentId_t id, Params &params) :
             memParams.insert("interleave_size", ilSize, false);
             memParams.insert("interleave_step", ilStep, false);
             memLink = dynamic_cast<MemLink*>(loadSubComponent("memHierarchy.MemLink", this, memParams));
-            memLink->setRecvHandler(new Event::Handler<DirectoryController>(this, &DirectoryController::handleMemoryResponse));
+            memLink->setRecvHandler(new Event::Handler<DirectoryController>(this, &DirectoryController::handlePacket));
             if (!memLink) {
                 dbg.fatal(CALL_INFO, -1, "%s, Error creating link to memory from directory controller\n", getName().c_str());
             }

--- a/src/sst/elements/memHierarchy/directoryController.h
+++ b/src/sst/elements/memHierarchy/directoryController.h
@@ -107,6 +107,7 @@ class DirectoryController : public Component {
     // Sent events - to mem
     Statistic<uint64_t> * stat_dataReads;
     Statistic<uint64_t> * stat_dataWrites;
+    Statistic<uint64_t> * stat_dataCustom;
     Statistic<uint64_t> * stat_dirEntryReads;
     Statistic<uint64_t> * stat_dirEntryWrites;
     // Sent events - to caches

--- a/src/sst/elements/memHierarchy/libmemHierarchy.cc
+++ b/src/sst/elements/memHierarchy/libmemHierarchy.cc
@@ -1590,6 +1590,7 @@ static const ElementInfoStatistic dirctrl_statistics[] = {
     {"memory_requests_directory_entry_write","Number of write requests for a directory entry sent to memory",   "requests",     1},
     {"memory_requests_data_read",       "Number of read requests for data sent to memory",                      "requests",     1},
     {"memory_requests_data_write",      "Number of write requests for data sent to memory",                     "requests",     1},
+    {"memory_requests_data_custom",     "Number of custom requests for data sent to memory",                    "requests",     1},
     {"requests_sent_Inv",               "Number of Inv (invalidate) requests sent to LLCs",                     "requests",     1},
     {"requests_sent_FetchInv",          "Number of FetchInv (invalidate and fetch exclusive data) requests sent to LLCs",   "requests",     1},
     {"requests_sent_FetchInvX",         "Number of FetchInvX (fetch exclusive data and downgrade) requests sent to LLCs",   "requests",     1},

--- a/src/sst/elements/memHierarchy/tests/goblinCustomCmdDC.py
+++ b/src/sst/elements/memHierarchy/tests/goblinCustomCmdDC.py
@@ -1,0 +1,89 @@
+import sst
+import sys
+import ConfigParser, argparse
+from utils import *
+
+
+# Parse commandline arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--config", help="specify configuration file", required=False)
+parser.add_argument("-v", "--verbose", help="increase verbosity of output", action="store_true")
+parser.add_argument("-s", "--statfile", help="statistics file", default="./stats.csv")
+parser.add_argument("-l", "--statlevel", help="statistics level", type=int, default=16)
+
+args = parser.parse_args()
+
+verbose = args.verbose
+cfgFile = "miranda.cfg"
+statFile = args.statfile
+statLevel = args.statlevel
+
+# Build Configuration Information
+config = Config(cfgFile, verbose=verbose)
+
+print "Configuring Network-on-Chip..."
+
+router = sst.Component("router", "merlin.hr_router")
+router.addParams(config.getRouterParams())
+router.addParam('id', 0)
+
+# Connect Cores & caches
+for next_core_id in range(config.total_cores):
+    print "Configuring core %d..."%next_core_id
+
+    cpu = sst.Component("cpu%d"%(next_core_id), "miranda.BaseCPU")
+    cpu.addParams(config.getCoreConfig(next_core_id))
+
+    l1 = sst.Component("l1cache_%d"%(next_core_id), "memHierarchy.Cache")
+    l1.addParams(config.getL1Params())
+
+    l2 = sst.Component("l2cache_%d"%(next_core_id), "memHierarchy.Cache")
+    l2.addParams(config.getL2Params())
+    l2.addParam( "network_address", next_core_id )
+
+    connect("cpu_cache_link_%d"%next_core_id,
+            cpu, "cache_link",
+            l1, "high_network_0",
+            config.ring_latency).setNoCut()
+
+    connect("l2cache_%d_link"%next_core_id,
+            l1, "low_network_0",
+            l2, "high_network_0",
+            config.ring_latency).setNoCut()
+
+    connect("l2_ring_link_%d"%next_core_id,
+            l2, "directory",
+            router, "port%d"%next_core_id,
+            config.ring_latency)
+
+# Connect Memory and Memory Controller to the ring
+mem = sst.Component("memory", "memHierarchy.CoherentMemController")
+mem.addParams(config.getMemParams())
+
+dc = sst.Component("dc", "memHierarchy.DirectoryController")
+dc.addParams(config.getDCParams(0))
+dc.addParam("network_address", config.total_cores)
+
+connect("mem_link_0",
+        mem, "direct_link",
+        dc, "memory",
+        config.ring_latency)
+
+connect("dc_link_0",
+        dc, "network",
+        router, "port%d"%config.total_cores,
+        config.ring_latency)
+
+# ===============================================================================
+
+# Enable SST Statistics Outputs for this simulation
+sst.setStatisticLoadLevel(statLevel)
+sst.enableAllStatisticsForAllComponents({"type":"sst.AccumulatorStatistic"})
+
+sst.setStatisticOutput("sst.statOutputCSV")
+sst.setStatisticOutputOptions( {
+    "filepath"  : statFile,
+    "separator" : ", "
+    } )
+
+print "Completed configuring the EX3 model"

--- a/src/sst/elements/memHierarchy/tests/miranda.cfg
+++ b/src/sst/elements/memHierarchy/tests/miranda.cfg
@@ -1,0 +1,30 @@
+[CPU]
+clock: 2660MHz
+num_cores: 16
+application: miranda.STREAMBenchGenerator
+max_reqs_cycle: 3
+
+[miranda.STREAMBenchGenerator]
+total_streamN: 5000
+
+[miranda.SPMVGenerator]
+total_streamN: 5000
+
+[miranda.RandomGenerator]
+total_streamN: 5000
+
+[miranda.GUPSGenerator]
+total_streamN: 500
+
+[Memory]
+clock: 200MHz
+network_bw: 96GB/s
+capacity: 32768MiB
+
+[Network]
+#2.66 GHz time period plus slack for ringstop latency
+latency: 300ps
+# 2.66 GHz clock, moves 64B / cycle, plus overhead -> 36B/c
+bandwidth: 96GB/s
+flit_size: 8B
+

--- a/src/sst/elements/memHierarchy/tests/utils.py
+++ b/src/sst/elements/memHierarchy/tests/utils.py
@@ -1,0 +1,211 @@
+import sst
+import os
+import ConfigParser
+
+
+
+def connect(name, c0, port0, c1, port1, latency):
+    link = sst.Link(name)
+    link.connect( (c0, port0, latency), (c1, port1, latency) )
+    return link
+
+
+
+class Config:
+    def __init__(self, cfgFile, **kwargs):
+        cp = ConfigParser.ConfigParser()
+        if not cp.read(cfgFile):
+            raise Exception('Unable to read file "%s"'%cfgFile)
+
+        self.verbose = "verbose" in kwargs and kwargs["verbose"]
+
+        self.clock = cp.get('CPU', 'clock')
+        self.total_cores = cp.getint('CPU', 'num_cores')
+        self.max_reqs_cycle = cp.get('CPU', 'max_reqs_cycle')
+
+        self.memory_clock = cp.get('Memory', 'clock')
+        self.memory_network_bandwidth = cp.get('Memory', 'network_bw')
+        self.memory_capacity = cp.get('Memory', 'capacity')
+        self.coherence_protocol = "MESI"
+
+        self.num_ring_stops = self.total_cores + 1
+
+        self.ring_latency = cp.get('Network', 'latency')
+        self.ring_bandwidth = cp.get('Network', 'bandwidth')
+        self.ring_flit_size = cp.get('Network', 'flit_size')
+
+        self.app = cp.get('CPU', 'application')
+        self.coreConfigParams = dict(cp.items(self.app))
+        if self.app == 'miranda.STREAMBenchGenerator':
+            self.coreConfig = self._streamCoreConfig
+        elif self.app == 'miranda.SPMVGenerator':
+            self.coreConfig = self._SPMVCoreConfig
+        elif self.app == 'miranda.RandomGenerator':
+            self.coreConfig = self._randomCoreConfig
+        elif self.app == 'miranda.GUPSGenerator':
+            self.coreConfig = self._GUPSCoreConfig
+        else:
+            raise Exception("Unknown application '%s'"%app)
+
+    def getCoreConfig(self, core_id):
+        params = dict({
+                'clock': self.clock,
+                'verbose': int(self.verbose)
+                })
+        params.update(self.coreConfig(core_id))
+        return params
+
+    def _streamCoreConfig(self, core_id):
+        streamN = int(self.coreConfigParams['total_streamn'])
+        params = dict()
+        params['max_reqs_cycle'] =  self.max_reqs_cycle
+        params['generator'] = 'miranda.STREAMBenchGenerator'
+        params['generatorParams.n'] = streamN / self.total_cores
+        params['generatorParams.start_a'] = ( (streamN * 32) / self.total_cores ) * core_id
+        params['generatorParams.start_b'] = ( (streamN * 32) / self.total_cores ) * core_id + (streamN * 32)
+        params['generatorParams.start_c'] = ( (streamN * 32) / self.total_cores ) * core_id + (2 * streamN * 32)
+        params['generatorParams.operandwidth'] = 32
+        params['generatorParams.verbose'] = int(self.verbose)
+        params['generatorParams.write_cmd'] = 10
+        return params
+
+    def _GUPSCoreConfig(self, core_id):
+        streamN = int(self.coreConfigParams['total_streamn'])
+        params = dict()
+        # params['max_reqs_cycle'] =  self.max_reqs_cycle
+        params['generator'] = 'miranda.GUPSGenerator'
+        params['generatorParams.count'] = streamN / self.total_cores
+        params['generatorParams.seed_a'] = 11
+        params['generatorParams.seed_b'] = 31
+        params['generatorParams.length'] = 32
+        params['generatorParams.iterations'] = 1
+        params['generatorParams.verbose'] = int(self.verbose)
+        params['generatorParams.issue_op_fences'] = "no"
+        return params
+
+    def _randomCoreConfig(self, core_id):
+        streamN = int(self.coreConfigParams['total_streamn'])
+        params = dict()
+        # params['max_reqs_cycle'] =  self.max_reqs_cycle
+        params['generator'] = 'miranda.RandomGenerator'
+        params['generatorParams.count'] = streamN / self.total_cores
+        params['generatorParams.max_address'] = 16384
+        params['generatorParams.issue_op_fences'] = "no"
+        params['generatorParams.length'] = 32
+        params['generatorParams.verbose'] = int(self.verbose)
+        params['generatorParams.write_cmd'] = 10
+        return params
+
+    def _SPMVCoreConfig(self, core_id):
+        streamN = int(self.coreConfigParams['total_streamn'])
+        params = dict()
+        params['generatorParams.verbose'] = int(self.verbose)
+        params['generator'] = 'miranda.SPMVGenerator'
+        params['generatorParams.matrixnx'] = 10
+        params['generatorParams.matrixny'] = 10
+        params['generatorParams.element_width'] = 32
+        params['generatorParams.lhs_start_addr'] = 0
+        params['generatorParams.rhs_start_addr'] = 320
+        params['generatorParams.local_row_start'] = 0
+        params['generatorParams.local_row_end'] = 10
+        params['generatorParams.ordinal_width'] = 8
+        params['generatorParams.matrix_row_indices_start_addr'] = 0
+        params['generatorParams.matrix_col_indices_start_addr'] = 0
+        params['generatorParams.matrix_element_start_addr'] = 0
+        params['generatorParams.iterations'] = streamN / self.total_cores
+        params['generatorParams.matrix_nnz_per_row'] = 9
+        return params
+
+    def getL1Params(self):
+        return dict({
+            "prefetcher": "cassini.StridePrefetcher",
+            "prefetcher.reach": 4,
+            "detect_range" : 1,
+            "cache_frequency": self.clock,
+            "cache_size": "32KB",
+            "associativity": 8,
+            "access_latency_cycles": 4,
+            "L1": 1,
+            # Default params
+            # "cache_line_size": 64,
+            # "coherence_protocol": self.coherence_protocol,
+            # "replacement_policy": "lru",
+            # Not neccessary for simple cases:
+            #"maxRequestDelay" : "1000000",
+            })
+
+    def getL2Params(self):
+        return dict({
+            "prefetcher": "cassini.StridePrefetcher",
+            "prefetcher.reach": 16,
+            "prefetcher.detect_range" : 1,
+            "cache_frequency": self.clock,
+            "cache_size": "256KB",
+            "associativity": 8,
+            "access_latency_cycles": 6,
+            "mshr_num_entries" : 16,
+            "network_bw": self.ring_bandwidth,
+            # Default params
+            #"cache_line_size": 64,
+            #"coherence_protocol": self.coherence_protocol,
+            #"replacement_policy": "lru",
+            })
+
+    def getMemParams(self):
+        return dict({
+            #"backend" : "memHierarchy.simpleMem",
+            #"backend.access_time" : "30ns",
+            #"network_bw": self.ring_bandwidth,
+            "backend.mem_size" : self.memory_capacity,
+            "backend.clock" : self.memory_clock,
+            "do_not_back" : 1,
+            "debug" : "1",
+            #"system_ini" : "system.ini",
+            #"clock" : "1Ghz",
+            #"backend.access_time" : "100 ns",
+            #"backend.device_ini" : "HBMDevice.ini",
+            #"backend.system_ini" : "HBMSystem.ini",
+            #"backend.tracing" : "1",
+            #"backend" : "memHierarchy.hbmdramsim",
+
+            "coherence_protocol" : "MESI",
+            "backend.access_time" : "1000 ns",
+            "backend.mem_size" : "512MiB",
+            "clock" : "1GHz",
+            "customCmdHandler" : "memHierarchy.amoCustomCmdHandler",
+            "backendConvertor" : "memHierarchy.extMemBackendConvertor",
+            "backend" : "memHierarchy.goblinHMCSim",
+            "backend.verbose" : "0",
+            "backend.trace-banks" : "1",
+            "backend.trace-queue" : "1",
+            "backend.trace-cmds" : "1",
+            "backend.trace-latency" : "1",
+            "backend.trace-stalls" : "1",
+            "backend.cmd-map" : "[CUSTOM:10:64:WR64]"
+            })
+
+    def getDCParams(self, dc_id):
+        return dict({
+            "entry_cache_size": 256*1024*1024, #Entry cache size of mem/blocksize
+            "clock": self.memory_clock,
+            "network_bw": self.ring_bandwidth,
+            "debug" : 0,
+            "debug_level" : 10,
+            "addr_range_start" : 0,
+            "addr_range_end" : (int(filter(str.isdigit, self.memory_capacity)) * 1024 * 1024),
+            # Default params
+            # "coherence_protocol": coherence_protocol,
+            })
+
+    def getRouterParams(self):
+        return dict({
+            "output_latency" : "25ps",
+            "xbar_bw" : self.ring_bandwidth,
+            "input_buf_size" : "2KB",
+            "input_latency" : "25ps",
+            "num_ports" : self.total_cores + 1,
+            "flit_size" : self.ring_flit_size,
+            "output_buf_size" : "2KB",
+            "link_bw" : self.ring_bandwidth,
+            "topology" : "merlin.singlerouter"
+        })


### PR DESCRIPTION
Bug fixes to the directoryController code to handle cached custom memory requests.  Added statistics to directoryController for custom commands.  Test to verify functional shootdowns in the presence of custom memory commands.  Execute the test as follows (from src/sst/elements/memHierarchy/tests/goblinCustomCmdDC.py): 

sst [-v] goblinCustomCmdDC.py

The test requires the goblinHMCBackend to be enabled (as this is the only backend that currently supports custom commands)
