### PR TITLE
Cleanup compile warnings for clang and gcc before the latest release.

### DIFF
--- a/src/sst/elements/CramSim/c_Dimm.cpp
+++ b/src/sst/elements/CramSim/c_Dimm.cpp
@@ -348,6 +348,11 @@ void c_Dimm::handleInCmdUnitReqPtrEvent(SST::Event *ev) {
 		  s_refCmdsRecvd->addData(1);
 				m_refCmdsRecvd[l_rank]+=1;
 		  break;
+		case e_BankCommandType::ERR:
+		case e_BankCommandType::PREA:
+		case e_BankCommandType::PDX:
+		case e_BankCommandType::PDE:
+		  break;
 		}
 
 		sendToBank(l_cmdReq);
@@ -369,7 +374,7 @@ void c_Dimm::updateDynamicEnergy(c_BankCommand* x_bankCommandPtr)
 	assert(l_rank<m_numRanks);
 
 	switch(x_bankCommandPtr->getCommandMnemonic()) {
-		case e_BankCommandType::ACT:
+	    case e_BankCommandType::ACT:
 			l_energy = ((k_IDD0 * (k_nRAS+k_nRP))-((k_IDD3N * k_nRAS) + (k_IDD2N * (k_nRP)))) * k_VDD * k_numDevices; //active and precharge
 			m_actpreEnergy[l_rank]+=l_energy;
 			break;
@@ -390,6 +395,11 @@ void c_Dimm::updateDynamicEnergy(c_BankCommand* x_bankCommandPtr)
 			l_energy = ((k_IDD5-k_IDD3N) * k_nRFC) * k_VDD * k_numDevices;
 			m_refreshEnergy[l_rank]+=l_energy;
 			break;
+		case e_BankCommandType::ERR:
+		case e_BankCommandType::PREA:
+		case e_BankCommandType::PDX:
+		case e_BankCommandType::PDE:
+		  break;
 	}
 }
 

--- a/src/sst/elements/CramSim/c_MemhBridge.hpp
+++ b/src/sst/elements/CramSim/c_MemhBridge.hpp
@@ -32,6 +32,12 @@
 
 namespace SST {
 namespace n_Bank {
+    
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+    
 class c_MemhBridge: public c_TxnGenBase {
 
 
@@ -63,6 +69,10 @@ private:
 
 
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 } // namespace n_Bank
 } // namespace SST

--- a/src/sst/elements/CramSim/memReqEvent.hpp
+++ b/src/sst/elements/CramSim/memReqEvent.hpp
@@ -21,6 +21,11 @@
 namespace SST {
 namespace CramSim {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
 typedef uint64_t Addr;
 typedef uint64_t ReqId;
 
@@ -95,6 +100,11 @@ class MemRespEvent : public SST::Event {
 
     ImplementSerializable(MemRespEvent);
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
 }
 }
 

--- a/src/sst/elements/Messier/Messier_Event.h
+++ b/src/sst/elements/Messier/Messier_Event.h
@@ -34,6 +34,11 @@ using namespace SST;
 
 namespace SST{ namespace MessierComponent{
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+    
 	enum EventType { READ_COMPLETION, WRITE_COMPLETION, DEVICE_READY, HIT_MISS, INVALIDATE_WRITE};
 
 	// Thie defines a class for events of Messier
@@ -71,6 +76,9 @@ namespace SST{ namespace MessierComponent{
 
 	};
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 }}
 

--- a/src/sst/elements/Messier/NVM_DIMM.cc
+++ b/src/sst/elements/Messier/NVM_DIMM.cc
@@ -291,7 +291,7 @@ bool NVM_DIMM::try_flush_wb()
 
 	bool flush_write = false;
 
-	bool pull_idle = false;
+//	bool pull_idle = false;
 	int MAX_WRITES = params->max_writes;
 
 	if(WB->flush() || (transactions.empty() && !WB->empty()) || (params->modulo && !WB->empty()))
@@ -834,7 +834,8 @@ void NVM_DIMM::handleEvent( SST::Event* e )
 
 						m_memChan->send(respEvent);
 
-						if(cache!=NULL)
+						if(cache!=NULL) 
+						{
 							if(!cache->check_hit(temp->Address))
 							{
 								cache->insert_block(temp->Address, false);
@@ -846,7 +847,7 @@ void NVM_DIMM::handleEvent( SST::Event* e )
 								cache->update_lru(temp->Address);
 
 							}
-
+                        }
 
 						delete NVM_EVENT_MAP[temp->req_ID];
 
@@ -866,6 +867,7 @@ void NVM_DIMM::handleEvent( SST::Event* e )
 					m_memChan->send(respEvent);
 
 					if(cache!=NULL)
+					{
 						if(!cache->check_hit(temp->Address))
 						{
 							cache->insert_block(temp->Address, false);
@@ -877,6 +879,7 @@ void NVM_DIMM::handleEvent( SST::Event* e )
 							cache->update_lru(temp->Address);
 
 						}
+					}
 
 
 					delete NVM_EVENT_MAP[temp->req_ID];

--- a/src/sst/elements/Messier/NVM_DIMM.cc
+++ b/src/sst/elements/Messier/NVM_DIMM.cc
@@ -36,8 +36,11 @@ using namespace SST::MemHierarchy;
 using namespace SST;
 using namespace SST::MessierComponent;
 
-
-
+#if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
 
 // This is the constructor of the NVM-based DIMM
 
@@ -1000,3 +1003,6 @@ void NVM_DIMM::handleRequest(SST::Event* e)
 		push_request(tmp); // Push the request
 }
 
+#if ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))
+#pragma GCC diagnostic pop
+#endif

--- a/src/sst/elements/Messier/WriteBuffer.cc
+++ b/src/sst/elements/Messier/WriteBuffer.cc
@@ -61,7 +61,7 @@ bool NVM_WRITE_BUFFER::insert_write_request(NVM_Request * req)
 			std::cout<<"Massive error 1"<<std::endl;
 
 
-		if( curr_entries >= (int) (flush_th*1.0*max_size/100.0) )
+		if( curr_entries >= (flush_th*1.0*max_size/100.0) )
 			still_flushing=true;
 
 
@@ -100,7 +100,7 @@ NVM_Request * NVM_WRITE_BUFFER::pop_entry()
 		if(mem_reqs.size() != curr_entries)
 			std::cout<<"Massive error 2"<<std::endl;
 
-	if(curr_entries <= (int) (flush_th_low*1.0*max_size/100.0) )
+	if(curr_entries <= (flush_th_low*1.0*max_size/100.0) )
 		still_flushing=false;
 
 	return TEMP;
@@ -118,7 +118,7 @@ void NVM_WRITE_BUFFER::erase_entry(NVM_Request * TEMP)
 		if(mem_reqs.size() != curr_entries)
 			std::cout<<"Massive error 3  curr_entrie="<<curr_entries<<"  mem_reqs.size()= "<<mem_reqs.size()<<std::endl;
 
-	 if(curr_entries <= (int) (flush_th_low*1.0*max_size/100.0) )
+	 if(curr_entries <= (flush_th_low*1.0*max_size/100.0) )
                 still_flushing=false;
 
 }

--- a/src/sst/elements/Messier/WriteBuffer.h
+++ b/src/sst/elements/Messier/WriteBuffer.h
@@ -37,7 +37,7 @@ class NVM_WRITE_BUFFER
 { 
 
 	// This determines the size in number of entries
-	int max_size;
+	unsigned int max_size;
 
 	// scheduling mode: this can be used to optimize writing to NVMs, cache lines within the same rowbuffer are prioritized to be written together
 	int sched_mode;
@@ -49,7 +49,7 @@ class NVM_WRITE_BUFFER
 	int flush_th_low;
 
 	// the current number of entries
-	int curr_entries;
+	unsigned int curr_entries;
 
 	// This tracks them in order
 	std::list<NVM_Request *> mem_reqs;

--- a/src/sst/elements/ember/tools/spygen/spygen.cc
+++ b/src/sst/elements/ember/tools/spygen/spygen.cc
@@ -299,9 +299,9 @@ int main(int argc, char* argv[]) {
 		}
 
 		char whiteBlock[3];
-		whiteBlock[0] = 255;
-		whiteBlock[1] = 255;
-		whiteBlock[2] = 255;
+		whiteBlock[0] = (char)255;
+		whiteBlock[1] = (char)255;
+		whiteBlock[2] = (char)255;
 
 		char commBlock[3];
 

--- a/src/sst/elements/firefly/nicEvents.h
+++ b/src/sst/elements/firefly/nicEvents.h
@@ -13,6 +13,11 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
 class NicInitEvent : public Event {
 
   public:
@@ -449,3 +454,7 @@ class NicRespEvent : public NicRespBaseEvent {
 
     NotSerializable(NicRespEvent)
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/src/sst/elements/firefly/simpleMemoryModel.h
+++ b/src/sst/elements/firefly/simpleMemoryModel.h
@@ -85,7 +85,12 @@ class SimpleMemoryModel {
 		case MemOp::LocalStore: return "LocalStore";
 		case MemOp::HostLoad: return "HostLoad";
 		case MemOp::HostStore: return "HostStore";
+		case MemOp::NotInit: return "NotInit"; 
+		case MemOp::HostCopy: return "HostCopy"; 
+		case MemOp::BusDmaToHost: return "BusDmaToHost"; 
+		case MemOp::BusDmaFromHost: return "BusDmaFromHost";	
 		}
+		return "";
 	}
 }; 
 

--- a/src/sst/elements/memHierarchy/customcmd/customCmdEvent.h
+++ b/src/sst/elements/memHierarchy/customcmd/customCmdEvent.h
@@ -24,6 +24,11 @@
 
 namespace SST { namespace MemHierarchy {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
 using namespace std;
 
 class CustomCmdEvent : public MemEventBase {
@@ -132,6 +137,10 @@ public:
     ImplementSerializable(SST::MemHierarchy::CustomCmdEvent);
 
 };
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 }}
 

--- a/src/sst/elements/memHierarchy/memTypes.h
+++ b/src/sst/elements/memHierarchy/memTypes.h
@@ -197,7 +197,7 @@ static const char* StateString[] __attribute__((unused)) = {
 #undef X
 };
 
-static State NextState[] = {
+static State NextState[] __attribute__((unused)) = {
 #define X(a,b) b,
     STATE_TYPES
 #undef X

--- a/src/sst/elements/memHierarchy/membackend/memBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/memBackendConvertor.h
@@ -26,6 +26,11 @@
 namespace SST {
 namespace MemHierarchy {
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Winconsistent-missing-override"
+#endif
+
 class MemBackend;
 
 class MemBackendConvertor : public SubComponent {
@@ -280,6 +285,9 @@ class MemBackendConvertor : public SubComponent {
 
 };
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 }
 #endif


### PR DESCRIPTION
Cleanup compile warnings for clang and gcc before the latest release.
Tested XCode 8 and 9, and GCC 4.8 & 5.4