### PR TITLE
Fixed compile error for Cramsim when using gcc 5.4 on CentOS 7

### DIFF
--- a/src/sst/elements/CramSim/c_Dimm.cpp
+++ b/src/sst/elements/CramSim/c_Dimm.cpp
@@ -47,6 +47,8 @@
 #include "c_CmdReqEvent.hpp"
 #include "c_CmdResEvent.hpp"
 
+#include <cmath>
+
 using namespace SST;
 using namespace SST::n_Bank;
 


### PR DESCRIPTION
Cramsim fails to compile on gcc 5.4 on CentOS 7, but does work properly on Ubuntu 16.04.  Need to add the cmath library to compile.