### PR TITLE
fixing HBMDramSim test fixtures to reflect new subcomponent name

### DIFF
--- a/src/sst/elements/memHierarchy/tests/hbm-2-trace.py
+++ b/src/sst/elements/memHierarchy/tests/hbm-2-trace.py
@@ -31,7 +31,7 @@ comp_memory.addParams({
       "backend.device_ini" : "HBMDevice.ini",
       "backend.system_ini" : "HBMSystem.ini",
       "backend.mem_size" : "512MiB",
-      "backend" : "memHierarchy.hbmdramsim",
+      "backend" : "memHierarchy.HBMDRAMSimMemory",
       "backend.tracing" : "1"
 })
 

--- a/src/sst/elements/memHierarchy/tests/hbm-2.py
+++ b/src/sst/elements/memHierarchy/tests/hbm-2.py
@@ -31,7 +31,7 @@ comp_memory.addParams({
       "backend.device_ini" : "HBMDevice.ini",
       "backend.system_ini" : "HBMSystem.ini",
       "backend.mem_size" : "512MiB",
-      "backend" : "memHierarchy.hbmdramsim"
+      "backend" : "memHierarchy.HBMDRAMSimMemory"
 })
 
 # Enable statistics

--- a/src/sst/elements/miranda/tests/hbm_singlestream1-trace.py
+++ b/src/sst/elements/miranda/tests/hbm_singlestream1-trace.py
@@ -45,7 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
-      "backend" : "memHierarchy.hbmdramsim",
+      "backend" : "memHierarchy.HBMDRAMSimMemory",
       "backend.access_time" : "100 ns",
       "backend.device_ini" : "HBMDevice.ini",
       "backend.system_ini" : "HBMSystem.ini",

--- a/src/sst/elements/miranda/tests/hbm_singlestream1.py
+++ b/src/sst/elements/miranda/tests/hbm_singlestream1.py
@@ -45,8 +45,7 @@ comp_memory.addParams({
       "backend.access_time" : "1000 ns",
       "backend.mem_size" : "512MiB",
       "clock" : "1GHz",
-      #"backend" : "memHierarchy.goblinHMCSim"
-      "backend" : "memHierarchy.hbmdramsim",
+      "backend" : "memHierarchy.HBMDRAMSimMemory",
       "backend.access_time" : "100 ns",
       "backend.device_ini" : "HBMDevice.ini",
       "backend.system_ini" : "HBMSystem.ini",


### PR DESCRIPTION
fixing HBMDramSim test fixtures to reflect new subcomponent name

This fixes the currently failing tests for HBMDRAMSim2.  The only change here is to enforce the new naming convention when loading the subcomponent through memHierarchy.  
