### PR TITLE
Adding Stake Miranda subcomponent that fuses RISC-V Spike simulator to SST for memory simulation

### DIFF
--- a/config/sst_check_stake.m4
+++ b/config/sst_check_stake.m4
@@ -1,0 +1,49 @@
+AC_DEFUN([SST_CHECK_STAKE],
+[
+  sst_check_stake_happy="yes"
+
+  AC_ARG_WITH([stake],
+    [AS_HELP_STRING([--with-stake@<:@=DIR@:>@],
+      [Use RISC-V Spike simulator installed in optionally specified DIR])])
+
+  AS_IF([test "$with_stake" = "no"], [sst_check_stake_happy="no"])
+
+  CPPFLAGS_saved="$CPPFLAGS"
+  LDFLAGS_saved="$LDFLAGS"
+
+  AS_IF([test "$sst_check_stake_happy" = "yes"], [
+    AS_IF([test ! -z "$with_stake" -a "$with_stake" != "yes"],
+      [STAKE_CPPFLAGS="-I$with_stake/include -I$with_stake/include/spike -I$with_stake/include/fesvr -I$with_stake/riscv64-unknown-elf/include/riscv-pk"
+       CPPFLAGS="$STAKE_CPPFLAGS $CPPFLAGS"
+       STAKE_LDFLAGS="-L$with_stake/lib -L$with_stake"
+       STAKE_LIB="-lriscv -lpthread -lfesvr -ldl",
+       LDFLAGS="$STAKE_LDFLAGS $LDFLAGS"
+       STAKE_LIBDIR="$with_stake/lib"],
+      [STAKE_CPPFLAGS=
+       STAKE_LDFLAGS=
+       STAKE_LIB=
+       STAKE_LIBDIR=])])
+
+  AC_LANG_PUSH([C++])
+  AC_CHECK_HEADER([sim.h], [], [sst_check_stake_happy="no"])
+  AC_LANG_POP([C++])
+
+  AC_CHECK_LIB([riscv], [_ZN5sim_t3runEv],
+    [STAKE_LIB="-lriscv -lfesvr"], [sst_check_stake_happy="no"])
+
+  CPPFLAGS="$CPPFLAGS_saved"
+  LDFLAGS="$LDFLAGS_saved"
+
+  AC_SUBST([STAKE_CPPFLAGS])
+  AC_SUBST([STAKE_LDFLAGS])
+  AC_SUBST([STAKE_LIB])
+  AC_SUBST([STAKE_LIBDIR])
+  AS_IF([test "x$sst_check_stake_happy" = "xyes"], [AC_DEFINE([HAVE_STAKE],[1],[Defines whether we have the RISC-V Spike Simulator library])])
+  AM_CONDITIONAL([USE_STAKE], [test "x$sst_check_stake_happy" = "xyes"])
+  AC_DEFINE_UNQUOTED([STAKE_LIBDIR], ["$STAKE_LIBDIR"], [Path to RISCV tools installation])
+
+  AC_MSG_CHECKING([for RISC-V Spike simulator library])
+  AC_MSG_RESULT([$sst_check_stake_happy])
+  AS_IF([test "$sst_check_stake_happy" = "no" -a ! -z "$with_stake" -a "$with_stake" != "no"], [$3])
+  AS_IF([test "$sst_check_stake_happy" = "yes"], [$1], [$2])
+])

--- a/src/sst/elements/miranda/Makefile.am
+++ b/src/sst/elements/miranda/Makefile.am
@@ -40,6 +40,14 @@ EXTRA_DIST = \
 	tests/streambench.py \
 	tests/inorderstream.py \
 	tests/copybench.py \
-	tests/gupsgen.py 
+	tests/gupsgen.py
 
 libmiranda_la_LDFLAGS = -module -avoid-version
+
+if USE_STAKE
+libmiranda_la_SOURCES += \
+	generators/stake.cc \
+	generators/stake.h
+libmiranda_la_LDFLAGS += $(STAKE_LDFLAGS) $(STAKE_LIB)
+AM_CPPFLAGS += $(STAKE_CPPFLAGS) -DHAVE_STAKE
+endif

--- a/src/sst/elements/miranda/configure.m4
+++ b/src/sst/elements/miranda/configure.m4
@@ -1,0 +1,12 @@
+dnl -*- Autoconf -*-
+dnl vim:ft=config
+dnl
+
+AC_DEFUN([SST_miranda_CONFIG], [
+	miranda_happy="yes"
+
+  # Use global Stake check
+  SST_CHECK_STAKE([],[],[AC_MSG_ERROR([Stake requests but could not be found])])
+
+  AS_IF([test "$miranda_happy" = "yes"], [$1], [$2])
+])

--- a/src/sst/elements/miranda/generators/stake.cc
+++ b/src/sst/elements/miranda/generators/stake.cc
@@ -1,0 +1,163 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#include <sst_config.h>
+#include <sst/core/params.h>
+#include <sst/elements/miranda/generators/stake.h>
+
+using namespace SST::Miranda;
+
+Stake::Stake( Component* owner, Params& params ) :
+	RequestGenerator(owner, params) {
+
+        // default parameters
+        spike = NULL;
+        rtn = 0;
+
+	const uint32_t verbose = params.find<uint32_t>("verbose", 0);
+
+	out = new Output("Stake[@p:@l]: ", verbose, 0, Output::STDOUT);
+
+        log = params.find<bool>("log", false);
+        cores = params.find<size_t>("cores", 1);
+        pc = params.find<uint64_t>("pc", 0x80000000);
+        isa = params.find<std::string>("isa", "RV64IMAFDC");
+        pk = params.find<std::string>("proxy_kernel", "pk");
+        bin = params.find<std::string>("bin", "");
+        ext = params.find<std::string>("ext", "");
+        extlib = params.find<std::string>("extlib","");
+
+        if( log ){
+          out->verbose(CALL_INFO, 1, 0, "Logging is enabled\n" );
+        }else{
+          out->verbose(CALL_INFO, 1, 0, "Logging is disabled\n" );
+        }
+
+        if( bin.length() == 0 ){
+          out->fatal(CALL_INFO, -1, "Failed to specify the RISC-V binary" );
+        }
+
+        out->verbose(CALL_INFO, 1, 0, "RISC-V Cores = %" PRIu32 "\n", cores );
+        out->verbose(CALL_INFO, 1, 0, "Starting PC = %" PRIx64 "\n", pc );
+        out->verbose(CALL_INFO, 1, 0, "ISA = %s\n", isa );
+        if( ext.length() > 0 ){
+          out->verbose(CALL_INFO, 1, 0, "RoCC Extension = %s\n", ext );
+        }
+        if( extlib.length() > 0 ){
+          out->verbose(CALL_INFO, 1, 0, "External Library = %s\n", extlib );
+        }
+
+        done = false;
+}
+
+Stake::~Stake() {
+        delete spike;
+	delete out;
+}
+
+// adapted from the original make_mems source from the spike.cc driver
+std::vector<std::pair<reg_t, mem_t*>> Stake::make_mems(const char* arg){
+        // handle legacy mem argument
+        char* p;
+        auto mb = strtoull(arg, &p, 0);
+        if (*p == 0) {
+          reg_t size = reg_t(mb) << 20;
+          if (size != (size_t)size)
+            out->fatal(CALL_INFO, -1, "Memsize would overflow size_t" );
+          return std::vector<std::pair<reg_t, mem_t*>>(1, std::make_pair(reg_t(DRAM_BASE), new mem_t(size)));
+        }
+
+        // handle base/size tuples
+        std::vector<std::pair<reg_t, mem_t*>> res;
+        while (true) {
+          auto base = strtoull(arg, &p, 0);
+          if (!*p || *p != ':')
+            out->fatal(CALL_INFO, -1, "Failed to parse memory string" );
+          auto size = strtoull(p + 1, &p, 0);
+          if ((size | base) % PGSIZE != 0)
+            out->fatal(CALL_INFO, -1, "Failed to parse memory string" );
+          res.push_back(std::make_pair(reg_t(base), new mem_t(size)));
+          if (!*p)
+            break;
+          if (*p != ',')
+            out->fatal(CALL_INFO, -1, "Failed to parse memory string" );
+          arg = p + 1;
+        }
+        return res;
+}
+
+void Stake::StakeRequest(uint64_t addr,
+                         uint32_t reqLength,
+                         bool Read,
+                         bool Write,
+                         bool Atomic,
+                         bool Custom,
+                         uint32_t Code ){
+
+        MemoryOpRequest *req = NULL;
+        if( Read ){
+          req = new MemoryOpRequest( addr, reqLength, READ );
+          out->verbose(CALL_INFO, 8, 0,
+                       "Issuing READ request for address %" PRIu64 "\n", addr );
+        }else if( Write ){
+          req = new MemoryOpRequest( addr, reqLength, WRITE );
+          out->verbose(CALL_INFO, 8, 0,
+                       "Issuing WRITE request for address %" PRIu64 "\n", addr );
+        }else if( Atomic ){
+          out->verbose(CALL_INFO, 8, 0,
+                       "Issuing ATOMIC request for address %" PRIu64 "\n", addr );
+        }else if( Custom ){
+          out->verbose(CALL_INFO, 8, 0,
+                       "Issuing CUSTOM request for address %" PRIu64 "\n", addr );
+        }else{
+          out->fatal(CALL_INFO, -1, "Unkown request type" );
+        }
+
+        MQ->push_back(req);
+}
+
+void Stake::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
+
+        // save the request queue for later
+        MQ = q;
+
+        // setup the input variables
+        std::vector<std::pair<reg_t, mem_t*>> mems = make_mems("2048");
+        std::vector<std::string> htif_args;
+        std::vector<int> hartids; // null hartid vector
+
+        // initiate the spike simulator
+        htif_args.push_back(pk);
+        htif_args.push_back(bin);
+        spike = new sim_t(isa.c_str(), cores, false, (reg_t)(pc),
+                          mems, htif_args, hartids, 2 );
+
+        // setup the pre-runtime parameters
+        spike->set_debug(false);
+        spike->set_log(log);
+        spike->set_histogram(false);
+        spike->set_sst_func((void *)(&SST::Miranda::Stake::StakeRequest));
+
+        // run the sim
+        rtn = spike->run();
+}
+
+bool Stake::isFinished() {
+	return done;
+}
+
+void Stake::completed() {
+}

--- a/src/sst/elements/miranda/generators/stake.h
+++ b/src/sst/elements/miranda/generators/stake.h
@@ -1,0 +1,78 @@
+// Copyright 2009-2017 Sandia Corporation. Under the terms
+// of Contract DE-NA0003525 with Sandia Corporation, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2017, Sandia Corporation
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef _H_SST_MIRANDA_STAKE
+#define _H_SST_MIRANDA_STAKE
+
+#include <sst/elements/miranda/mirandaGenerator.h>
+#include <sst/core/output.h>
+
+#include <queue>
+
+// Spike required headers
+#include "sim.h"
+#include "mmu.h"
+#include "remote_bitbang.h"
+#include "cachesim.h"
+#include "extension.h"
+#include <dlfcn.h>
+#include <fesvr/option_parser.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <vector>
+#include <string>
+#include <memory>
+
+namespace SST {
+namespace Miranda {
+
+class Stake : public RequestGenerator {
+
+public:
+	Stake( Component* owner, Params& params );
+	~Stake();
+	void generate(MirandaRequestQueue<GeneratorRequest*>* q);
+	bool isFinished();
+	void completed();
+
+        void StakeRequest(uint64_t addr, uint32_t RegLen,
+                          bool Read, bool Write, bool Atomic, bool Custom,
+                          uint32_t Code );
+
+private:
+        bool done;          // holds the completion code of the sim
+        bool log;           // log the Spike execution to a file
+        int rtn;            // return code from the simulator
+        size_t cores;       // number of RISC-V cores
+        uint64_t pc;        // starting pc
+        std::string isa;    // isa string
+        std::string pk;     // proxy kernel
+        std::string bin;    // ELF binary
+        std::string ext;    // RoCC extension
+        std::string extlib; // extension library
+
+        MirandaRequestQueue<GeneratorRequest*>* MQ; // memory request queue
+        std::vector<std::pair<reg_t, mem_t*>> make_mems(const char* arg);
+
+	Output*  out;     // output handle
+
+        sim_t *spike;     // spike simulator instance
+};
+
+}
+}
+
+#endif

--- a/src/sst/elements/miranda/generators/stake.h
+++ b/src/sst/elements/miranda/generators/stake.h
@@ -58,6 +58,7 @@ private:
         int rtn;            // return code from the simulator
         size_t cores;       // number of RISC-V cores
         uint64_t pc;        // starting pc
+        std::string msize;  // size of the memory subsystem
         std::string isa;    // isa string
         std::string pk;     // proxy kernel
         std::string bin;    // ELF binary
@@ -74,5 +75,15 @@ private:
 
 }
 }
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+void SR(uint64_t addr, uint32_t RegLen,
+        bool Read, bool Write, bool Atomic, bool Custom,
+        uint32_t Code );
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #endif

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -33,7 +33,10 @@
 #include "generators/copygen.h"
 #include "generators/spmvgen.h"
 #include "generators/streambench_customcmd.h"
+
+#ifdef HAVE_STAKE
 #include "generators/stake.h"
+#endif
 
 using namespace SST;
 using namespace SST::Miranda;
@@ -82,9 +85,11 @@ static SubComponent* load_STREAMGenerator_CustomCmd(Component* owner, Params& pa
         return new STREAMBenchGenerator_CustomCmd(owner, params);
 }
 
+#ifdef HAVE_STAKE
 static SubComponent* load_Stake(Component* owner, Params& params) {
         return new Stake(owner, params);
 }
+#endif
 
 static Component* load_MirandaBaseCPU(ComponentId_t id, Params& params) {
 	return new RequestGenCPU(id, params);
@@ -206,6 +211,7 @@ static const ElementInfoParam streamBench_customcmd_params[] = {
     { NULL, NULL, NULL }
 };
 
+#ifdef HAVE_STAKE
 static const ElementInfoParam stake_params[] = {
     { "verbose",          "Sets the verbosity output of the generator", "0" },
     { "cores",            "Sets the number of cores in the spike instance", "1" },
@@ -219,6 +225,7 @@ static const ElementInfoParam stake_params[] = {
     { "extlib",           "Shared library to load", "NULL" },
     { NULL, NULL, NULL }
 };
+#endif
 
 
 static const ElementInfoSubComponent subcomponents[] = {
@@ -321,6 +328,7 @@ static const ElementInfoSubComponent subcomponents[] = {
 		NULL,
 		"SST::Miranda::RequestGenerator"
 	},
+#ifdef HAVE_STAKE
         {
                 "Stake",
                 "Instantiates a RISC-V Spike instance to drive memory traffic",
@@ -330,6 +338,7 @@ static const ElementInfoSubComponent subcomponents[] = {
                 NULL,
                 "SST::Miranda::RequestGenerator"
         },
+#endif
 	{ NULL, NULL, NULL, NULL, NULL, NULL }
 };
 

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -209,6 +209,7 @@ static const ElementInfoParam streamBench_customcmd_params[] = {
 static const ElementInfoParam stake_params[] = {
     { "verbose",          "Sets the verbosity output of the generator", "0" },
     { "cores",            "Sets the number of cores in the spike instance", "1" },
+    { "mem_size",         "Sets the RISC-V Spike memory subsystem size", "2048" },
     { "log",              "Generate a log of the execution", "0" },
     { "isa",              "Set the respective RISC-V ISA", "RV64IMAFDC" },
     { "pc",               "Override the default ELF entry point", "0x80000000"},

--- a/src/sst/elements/miranda/miranda.cc
+++ b/src/sst/elements/miranda/miranda.cc
@@ -33,6 +33,7 @@
 #include "generators/copygen.h"
 #include "generators/spmvgen.h"
 #include "generators/streambench_customcmd.h"
+#include "generators/stake.h"
 
 using namespace SST;
 using namespace SST::Miranda;
@@ -79,6 +80,10 @@ static SubComponent* load_SPMVGenerator(Component* owner, Params& params) {
 
 static SubComponent* load_STREAMGenerator_CustomCmd(Component* owner, Params& params) {
         return new STREAMBenchGenerator_CustomCmd(owner, params);
+}
+
+static SubComponent* load_Stake(Component* owner, Params& params) {
+        return new Stake(owner, params);
 }
 
 static Component* load_MirandaBaseCPU(ComponentId_t id, Params& params) {
@@ -201,6 +206,19 @@ static const ElementInfoParam streamBench_customcmd_params[] = {
     { NULL, NULL, NULL }
 };
 
+static const ElementInfoParam stake_params[] = {
+    { "verbose",          "Sets the verbosity output of the generator", "0" },
+    { "cores",            "Sets the number of cores in the spike instance", "1" },
+    { "log",              "Generate a log of the execution", "0" },
+    { "isa",              "Set the respective RISC-V ISA", "RV64IMAFDC" },
+    { "pc",               "Override the default ELF entry point", "0x80000000"},
+    { "proxy_kernel",     "Set the default proxy kernel", "pk"},
+    { "bin",              "Set the RISC-V ELF binary", "NULL"},
+    { "extension",        "Specify the RoCC extension", "NULL" },
+    { "extlib",           "Shared library to load", "NULL" },
+    { NULL, NULL, NULL }
+};
+
 
 static const ElementInfoSubComponent subcomponents[] = {
 	{
@@ -302,6 +320,15 @@ static const ElementInfoSubComponent subcomponents[] = {
 		NULL,
 		"SST::Miranda::RequestGenerator"
 	},
+        {
+                "Stake",
+                "Instantiates a RISC-V Spike instance to drive memory traffic",
+                NULL,
+                load_Stake,
+                stake_params,
+                NULL,
+                "SST::Miranda::RequestGenerator"
+        },
 	{ NULL, NULL, NULL, NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
Adding the Stake "generator" subcomponent to Miranda.  This subcomponent provides a shim layer for the RISC-V "Spike" simulator to drive the SST memory simulation components.  All the standard functional simulation layers in the RISC-V Spike (riscv-isa-sim) infrastructure remain.  Stake provides a simple generator with a C-based callback routine that allows Spike to directly send memory requests to SST.  With these commits, we can directly drive memory experiments with RISC-V ELF binaries (including booting Linux on Spike)

Caveats: 
- This requires a modified riscv-isa-sim that is currently located here: https://github.com/tactcomplabs/riscv-isa-sim/tree/sst
- Atomic and custom memory operations are currently mapped to read requests.  We will update this in future commits to provide more flexible configuration of atomics
- We did not commit any tests with this pull request.  Spike executes ELF binary payloads.  As a result, we elected not to commit individual binary blobs into the SST source tree.  If the main SST developers feel that this is ok, we can most certainly provide sample execution scripts.  