### PR TITLE
Move control messages to the "standard" VC

### DIFF
--- a/src/sst/elements/ember/tests/refFiles/test_EmberSweep.out
+++ b/src/sst/elements/ember/tests/refFiles/test_EmberSweep.out
@@ -1,8 +1,8 @@
-f9148701b5882168aef0a43d84f06535 Simulation is complete, simulated time: 720.038 us
+f9148701b5882168aef0a43d84f06535 Simulation is complete, simulated time: 757.52 us
 0e90c343d7bd6368ebca64220f3db66c Simulation is complete, simulated time: 324.598 us
 2c2c1aa59094b3948fce6f0e3bc696a9 Simulation is complete, simulated time: 106.588 us
 91aa1219e84c1087fe994713702563b8 Simulation is complete, simulated time: 106.588 us
-115ba9e30906b68930351aa80e66e883 Simulation is complete, simulated time: 132.358 us
+115ba9e30906b68930351aa80e66e883 Simulation is complete, simulated time: 138.614 us
 fe8bb43695a69f9bf4be80cf167919f3 Simulation is complete, simulated time: 87.906 us
 af9d4242ad221525caf7857252ddc8a1 Simulation is complete, simulated time: 57.304 us
 6d139a038a7bdd217a1a81a6ba2327af Simulation is complete, simulated time: 57.304 us
@@ -122,7 +122,7 @@ d83aa9f05b2e4832734ad22083a4d9e9 Simulation is complete, simulated time: 4.12 us
 144d9bce36c713bed393b5bd62bf0aed Simulation is complete, simulated time: 182.048 us
 c6e2db182577973f618cbf934efd6896 Simulation is complete, simulated time: 74.034 us
 546e93a9df1ce1dad6fff7bcb03649b5 Simulation is complete, simulated time: 74.034 us
-88bfc7de2eb0d43a909243344a5745c3 Simulation is complete, simulated time: 62.182 us
+88bfc7de2eb0d43a909243344a5745c3 Simulation is complete, simulated time: 61.244 us
 a969c19f26cbf85639768d08213c4548 Simulation is complete, simulated time: 45.21 us
 26237ef50c2515b6f2f915a2acdc6ab6 Simulation is complete, simulated time: 34.18 us
 95123412ba2c8c9aae1450f981811652 Simulation is complete, simulated time: 34.18 us
@@ -148,7 +148,7 @@ bf7ab053912211e6896d568bcdfd10aa Simulation is complete, simulated time: 32.146 
 1f4b410cb8f5af0772192bf7f7050adb Simulation is complete, simulated time: 9.51922 ms
 1c3bd562153153acccd729e64696e445 Simulation is complete, simulated time: 1.66315 ms
 b97b2a5e0fd3f06dfcd72d95b2488181 Simulation is complete, simulated time: 1.66315 ms
-ce2d511d03dc1083254fdb8149d5d78d Simulation is complete, simulated time: 984.786 us
+ce2d511d03dc1083254fdb8149d5d78d Simulation is complete, simulated time: 1.11741 ms
 76c149e1febd7e75db2490e0264a9c36 Simulation is complete, simulated time: 475.366 us
 5349a49ce4d592fcd05b7a325340f6bd Simulation is complete, simulated time: 62.678 us
 b2b4d11fbdecce0b210d1e1b160d72ee Simulation is complete, simulated time: 62.678 us

--- a/src/sst/elements/firefly/merlinEvent.h
+++ b/src/sst/elements/firefly/merlinEvent.h
@@ -28,16 +28,18 @@ class FireflyNetworkEvent : public Event {
 
   public:
 
-    FireflyNetworkEvent( ) : offset(0), bufLen(0), isHdr(false), pktOverhead(0) {
+    FireflyNetworkEvent( ) : offset(0), bufLen(0), isHdr(false), isCtrl(false), pktOverhead(0) {
         buf.reserve( 1000 );
         assert( 0 == buf.size() );
     }
 
-    FireflyNetworkEvent( int pktOverhead, size_t reserve = 1000 ) : offset(0), bufLen(0), isHdr(false), pktOverhead(pktOverhead) {
+    FireflyNetworkEvent( int pktOverhead, size_t reserve = 1000 ) : offset(0), bufLen(0), isHdr(false), isCtrl(false), pktOverhead(pktOverhead) {
         buf.reserve( reserve );
         assert( 0 == buf.size() );
     }
 
+    void setIsCtrl() { isCtrl = true; }
+    bool getIsCtrl() { return isCtrl; }
     void setIsHdr() { isHdr = true; }
     bool getIsHdr() { return isHdr; }
     int calcPayloadSizeInBits() { return payloadSize() * 8; }
@@ -88,6 +90,7 @@ class FireflyNetworkEvent : public Event {
         srcPid = me->srcPid;
         destPid = me->destPid;
         isHdr = me->isHdr;
+        isCtrl = me->isCtrl;
         offset = me->offset;
         pktOverhead = me->pktOverhead;
     }
@@ -101,6 +104,7 @@ class FireflyNetworkEvent : public Event {
         srcPid = me.srcPid;
         destPid = me.destPid;
         isHdr = me.isHdr;
+        isCtrl = me.isCtrl;
         offset = me.offset;
         pktOverhead = me.pktOverhead;
     }
@@ -128,6 +132,7 @@ class FireflyNetworkEvent : public Event {
     int             srcPid;
     int             destPid;
     bool            isHdr;
+    bool            isCtrl;
     int             pktOverhead;
     
     size_t          offset;
@@ -145,6 +150,8 @@ class FireflyNetworkEvent : public Event {
         ser & srcPid;
         ser & destPid;
         ser & pktOverhead;
+        ser & isHdr;
+        ser & isCtrl;
     }
     
     ImplementSerializable(SST::Firefly::FireflyNetworkEvent);     

--- a/src/sst/elements/firefly/nicEntryBase.cc
+++ b/src/sst/elements/firefly/nicEntryBase.cc
@@ -84,12 +84,12 @@ bool Nic::EntryBase::copyIn( Output& dbg,
     return ( currentVec() == ioVec().size() ) ;
 }
 
-void Nic::EntryBase::copyOut( Output& dbg, int vc, int numBytes,
+void Nic::EntryBase::copyOut( Output& dbg, int numBytes,
                 FireflyNetworkEvent& event,
                 std::vector<MemOp>& vec  )
 {
     dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"Send: "
-                    "%d: ioVec.size()=%lu\n", vc, ioVec().size() );
+                    "ioVec.size()=%lu\n", ioVec().size() );
 
     for ( ; currentVec() < ioVec().size() &&
                 event.bufSize() <  numBytes;

--- a/src/sst/elements/firefly/nicEntryBase.h
+++ b/src/sst/elements/firefly/nicEntryBase.h
@@ -29,7 +29,7 @@ class EntryBase {
         }
         return bytes;
     }
-    virtual void copyOut( Output&, int vc, int numBytes,
+    virtual void copyOut( Output&, int numBytes,
                FireflyNetworkEvent&, std::vector<MemOp>& vec );
     virtual bool copyIn( Output&,
                FireflyNetworkEvent&, std::vector<MemOp>& vec );

--- a/src/sst/elements/firefly/nicRdmaStream.cc
+++ b/src/sst/elements/firefly/nicRdmaStream.cc
@@ -39,11 +39,27 @@ Nic::RecvMachine::RdmaStream::RdmaStream( Output& output, Ctx* ctx, int unit, in
           m_recvEntry = m_ctx->findPut( m_srcNode, hdr, rdmaHdr );
           ev->bufPop(sizeof(MsgHdr) + sizeof(rdmaHdr) );
           m_startCallback  = std::bind( &Nic::RecvMachine::StreamBase::processPkt, this, ev );
+          m_matched_len = m_recvEntry->totalBytes();
+        }
+        break;
+      case RdmaMsgHdr::Get:
+        {
+          m_dbg.verbose(CALL_INFO,1,NIC_DBG_RECV_MACHINE,"CtlMsg Get Operation srcNode=%d op=%d rgn=%d resp=%d, offset=%d\n",
+                ev->getSrcNode(), rdmaHdr.op, rdmaHdr.rgnNum, rdmaHdr.respKey, rdmaHdr.offset );
+
+          SendEntryBase* entry = m_ctx->findGet( ev->getSrcNode(), ev->getSrcPid(), rdmaHdr );
+          assert(entry);
+
+          ev->bufPop(sizeof(MsgHdr) + sizeof(rdmaHdr) );
+
+          m_startCallback = std::bind( &Nic::RecvMachine::StreamBase::qSend, this, entry );
+          m_startDelay = m_ctx->getHostReadDelay();
+
+        delete ev;
         }
         break;
 
       default:
         assert(0);
     }
-    m_matched_len = m_recvEntry->totalBytes();
 }

--- a/src/sst/elements/firefly/nicRecvCtx.h
+++ b/src/sst/elements/firefly/nicRecvCtx.h
@@ -8,6 +8,7 @@
                 m_prefix = "@t:"+ std::to_string(rm.nic().getNodeId()) +":Nic::RecvMachine::Ctx" + std::to_string(pid) + "::@p():@l ";
             }
 
+            int getHostReadDelay() { return m_rm.m_hostReadDelay; }
             bool processPkt( FireflyNetworkEvent* ev );
             DmaRecvEntry* findPut( int src, MsgHdr& hdr, RdmaMsgHdr& rdmahdr );
             EntryBase* findRecv( int srcNode, int srcPid, MsgHdr& hdr, MatchMsgHdr& matchHdr  );
@@ -68,7 +69,7 @@
             }
 
             void runSend( int num, SendEntryBase* entry ) {
-                m_rm.nic().m_sendMachine[0]->run( entry );
+                m_rm.nic().qSendEntry( entry );
             } 
 
             // this function is called by a Stream object, we don't want to delete ourself,

--- a/src/sst/elements/firefly/nicRecvStream.cc
+++ b/src/sst/elements/firefly/nicRecvStream.cc
@@ -39,7 +39,7 @@ Nic::RecvMachine::StreamBase::~StreamBase() {
         delete m_recvEntry;
     }
     if ( m_sendEntry ) {
-        m_ctx->nic().m_sendMachine[0]->run( m_sendEntry );
+        m_ctx->nic().qSendEntry( m_sendEntry );
     }
 }
 

--- a/src/sst/elements/firefly/nicRecvStream.h
+++ b/src/sst/elements/firefly/nicRecvStream.h
@@ -16,6 +16,12 @@ class StreamBase {
             virtual void processPkt( FireflyNetworkEvent* ev );
             bool isBlocked();
             void needRecv( FireflyNetworkEvent* ev );
+        
+            void qSend( SendEntryBase* entry ) {
+                m_dbg.verbosePrefix(prefix(),CALL_INFO,2,NIC_DBG_RECV_MACHINE,"\n");
+                m_ctx->runSend( m_unit, entry );
+                m_ctx->deleteStream( this );
+            }
 
             void setWakeup( Callback callback )    {
                 m_dbg.verbosePrefix(prefix(),CALL_INFO,2,NIC_DBG_RECV_MACHINE,"\n");

--- a/src/sst/elements/firefly/nicSendEntry.h
+++ b/src/sst/elements/firefly/nicSendEntry.h
@@ -21,8 +21,6 @@ class SendEntryBase {
     virtual ~SendEntryBase() { }
 
     virtual int local_vNic()   { return m_local_vNic; }
-    virtual int getUnit() { return m_nicUnit; }
-    virtual void setUnit( int unit ) { m_nicUnit = unit; }
 
     virtual MsgHdr::Op getOp() = 0;
     virtual size_t totalBytes() = 0;
@@ -42,7 +40,6 @@ class SendEntryBase {
 
   private:
     int m_local_vNic;
-    int m_nicUnit;
 };
 
 class CmdSendEntry: public SendEntryBase, public EntryBase {

--- a/src/sst/elements/firefly/nicSendMachine.h
+++ b/src/sst/elements/firefly/nicSendMachine.h
@@ -24,11 +24,11 @@ class SendMachine {
             const char* prefix() { return m_prefix.c_str(); }
           public:
 
-            OutQ( Nic& nic, Output& output, int vc, int maxQsize ) : 
-                m_nic(nic), m_dbg(output), m_maxQsize(maxQsize),
-                m_vc(vc), m_wakeUpCallback(NULL), m_notifyCallback(NULL), m_scheduled(false) 
+            OutQ( Nic& nic, Output& output, int myId, int maxQsize ) : 
+                m_nic(nic), m_dbg(output), m_id(myId), m_maxQsize(maxQsize),
+                m_wakeUpCallback(NULL)
             {
-                m_prefix = "@t:"+ std::to_string(nic.getNodeId()) +":Nic::SendMachine::OutQ::@p():@l ";
+                m_prefix = "@t:"+ std::to_string(nic.getNodeId()) +":Nic::SendMachine" + std::to_string(myId) + "::OutQ::@p():@l ";
             }
 
             void enque( FireflyNetworkEvent* ev, int dest );
@@ -43,41 +43,27 @@ class SendMachine {
                 m_wakeUpCallback = callback;
             }
 
-            void notify() {
-                m_dbg.verbosePrefix(prefix(),CALL_INFO,2,NIC_DBG_SEND_MACHINE, "network is unblocked\n");
-                assert( m_notifyCallback );
-                m_scheduled = true;
-                m_nic.schedCallback( m_notifyCallback ); 
-                m_notifyCallback = NULL;
+            bool empty() {
+                return m_queue.empty();
+            }
+            std::pair< FireflyNetworkEvent*, int>& front() {
+                return m_queue.front();
+            }
+            void pop() {
+                if ( m_wakeUpCallback ) {
+                    m_dbg.verbosePrefix(prefix(),CALL_INFO,2,NIC_DBG_SEND_MACHINE, "call wakeup callback\n");
+                    m_nic.schedCallback( m_wakeUpCallback, 0);
+                    m_wakeUpCallback = NULL;
+                }
+                return m_queue.pop_front();
             }
 
           private:
-            void send( std::pair< FireflyNetworkEvent*, int>& );
-
-            void runSendQ( );
-
-            bool canSend( uint64_t numBytes ) {
-                bool ret = m_nic.m_linkControl->spaceToSend( m_vc, numBytes * 8); 
-                if ( ! ret ) {
-                    m_dbg.verbosePrefix(prefix(),CALL_INFO,2,NIC_DBG_SEND_MACHINE, "network is blocked\n");
-                    setCanSendCallback( std::bind( &Nic::SendMachine::OutQ::runSendQ, this ) ); 
-                }
-                return ret;
-            }
-
-            void setCanSendCallback( Callback callback ) {
-                assert( ! m_notifyCallback );
-                m_notifyCallback = callback;
-                m_nic.setNotifyOnSend( m_vc );
-            }
 
             Nic&        m_nic;
             Output&     m_dbg;
-            int         m_vc;
+            int         m_id;
             int         m_maxQsize;
-            bool        m_scheduled;
-            static int  m_packetId;
-            Callback    m_notifyCallback;
             Callback    m_wakeUpCallback;
 
             std::deque< std::pair< FireflyNetworkEvent*, int> > m_queue;
@@ -90,11 +76,11 @@ class SendMachine {
           public:
             typedef std::function<void()> Callback;
 
-            InQ(Nic& nic, Output& output, OutQ* outQ, int maxQsize ) : 
+            InQ(Nic& nic, Output& output, int myId, OutQ* outQ, int maxQsize ) : 
                 m_nic(nic), m_dbg(output), m_outQ(outQ), m_numPending(0),m_maxQsize(maxQsize), m_callback(NULL),
                 m_pktNum(0), m_expectedPkt(0)
             {
-                m_prefix = "@t:"+ std::to_string(nic.getNodeId()) +":Nic::SendMachine::InQ::@p():@l ";
+                m_prefix = "@t:"+ std::to_string(nic.getNodeId()) +":Nic::SendMachine" + std::to_string(myId)  +"::InQ::@p():@l ";
             }
 
             bool isFull() {
@@ -134,37 +120,45 @@ class SendMachine {
         };
 
       public:
-        typedef std::function<void()> Callback;
-        SendMachine( Nic& nic, int nodeId, int verboseLevel, int verboseMask,
-              int txDelay, int packetSizeInBytes, int pktOverhead, int vc, int maxQsize, int unit ) :
-            m_nic(nic), m_txDelay( txDelay ), m_packetSizeInBytes( packetSizeInBytes - pktOverhead), m_vc(vc), m_unit(unit),
-            m_pktOverhead(pktOverhead)
+
+        SendMachine( Nic& nic, int nodeId, int verboseLevel, int verboseMask, int myId,
+              int txDelay, int packetSizeInBytes, int pktOverhead, int maxQsize, int unit, bool flag = false ) :
+            m_nic(nic), m_id(myId), m_txDelay( txDelay ), m_packetSizeInBytes( packetSizeInBytes - pktOverhead ), 
+            m_unit(unit), m_pktOverhead(pktOverhead), m_activeEntry(NULL), m_I_manage( flag )
         {
             char buffer[100];
-            snprintf(buffer,100,"@t:%d:Nic::SendMachine::@p():@l vc=%d ",nodeId,vc);
+            snprintf(buffer,100,"@t:%d:Nic::SendMachine%d::@p():@l ",nodeId,myId);
 
             m_dbg.init(buffer, verboseLevel, verboseMask, Output::STDOUT);
-            m_outQ = new OutQ( nic, m_dbg, vc, maxQsize );
-            m_inQ = new InQ( nic, m_dbg, m_outQ, maxQsize );
+            m_outQ = new OutQ( nic, m_dbg, myId, maxQsize );
+            m_inQ = new InQ( nic, m_dbg, myId, m_outQ, maxQsize );
         }
 
         ~SendMachine() { }
 
+        bool isBusy() {
+            return m_activeEntry;
+        }       
+
         void run( SendEntryBase* entry ) {
-            entry->setUnit( m_nic.allocNicUnit( entry->local_vNic(), m_unit ) );
+            m_dbg.verbose(CALL_INFO,1,NIC_DBG_SEND_MACHINE, "new stream\n");
+            assert( ! m_I_manage );
+            m_activeEntry = entry;
+            streamInit( entry );
+        }
+
+        void qSendEntry( SendEntryBase* entry ) {
+            m_dbg.verbose(CALL_INFO,1,NIC_DBG_SEND_MACHINE, "new stream\n");
+            assert( m_I_manage );
             m_sendQ.push_back( entry );
-            if ( 1 == m_sendQ.size() ) {
-                streamInit( m_sendQ.front() );
-            } else {
-                m_dbg.verbose(CALL_INFO,1,NIC_DBG_SEND_MACHINE, "Q send entry\n");
+            if ( m_sendQ.size() == 1 ) {
+                streamInit( entry );
             }
         }
 
-        void notify() {
-            m_outQ->notify();
-        }
-
-        void printStatus( Output& out ); 
+        bool netPktQ_empty() { return m_outQ->empty(); }
+        void netPktQ_pop() { return m_outQ->pop(); }
+        std::pair< FireflyNetworkEvent*, int>& netPktQ_front() { return m_outQ->front(); }
 
       private:
 
@@ -172,15 +166,16 @@ class SendMachine {
         void getPayload( SendEntryBase*, FireflyNetworkEvent* );
         void streamFini( SendEntryBase* );
 
+        int     m_id;
         Nic&    m_nic;
         Output  m_dbg;
         OutQ*   m_outQ;
         InQ*    m_inQ;
         int     m_txDelay;
         int     m_packetSizeInBytes;
-        int     m_vc;
         int     m_unit;
         int     m_pktOverhead;
-
-        std::deque<SendEntryBase*>  m_sendQ;
+        bool    m_I_manage;
+        SendEntryBase* m_activeEntry;
+        std::deque< SendEntryBase* > m_sendQ;
 };

--- a/src/sst/elements/firefly/nicShmem.cc
+++ b/src/sst/elements/firefly/nicShmem.cc
@@ -216,7 +216,7 @@ void Nic::Shmem::put( NicShmemPutCmdEvent* event, int id )
 					}
     );
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 
 }
 
@@ -235,7 +235,7 @@ void Nic::Shmem::putv( NicShmemPutvCmdEvent* event, int id )
 					} 
     );
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 
 }
 
@@ -254,7 +254,7 @@ void Nic::Shmem::getv( NicShmemGetvCmdEvent* event, int id )
 
     entry->setRespKey(m_nic.genRespKey(entry));
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 }
 
 void Nic::Shmem::get( NicShmemGetCmdEvent* event, int id )
@@ -279,7 +279,7 @@ void Nic::Shmem::get( NicShmemGetCmdEvent* event, int id )
 
     entry->setRespKey(m_nic.genRespKey(entry));
 
-	m_nic.m_sendMachine[0]->run( entry );
+	m_nic.qSendEntry( entry );
 }
 
 
@@ -298,7 +298,7 @@ void Nic::Shmem::add( NicShmemAddCmdEvent* event, int id )
 					} 
     ); 
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 
 }
 
@@ -316,7 +316,7 @@ void Nic::Shmem::fadd( NicShmemFaddCmdEvent* event, int id )
 
     entry->setRespKey(m_nic.genRespKey(entry));
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 }
 
 void Nic::Shmem::cswap( NicShmemCswapCmdEvent* event, int id )
@@ -333,7 +333,7 @@ void Nic::Shmem::cswap( NicShmemCswapCmdEvent* event, int id )
 
     entry->setRespKey(m_nic.genRespKey(entry));
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 }
 
 void Nic::Shmem::swap( NicShmemSwapCmdEvent* event, int id )
@@ -350,7 +350,7 @@ void Nic::Shmem::swap( NicShmemSwapCmdEvent* event, int id )
 
     entry->setRespKey(m_nic.genRespKey(entry));
 
-    m_nic.m_sendMachine[0]->run( entry );
+    m_nic.qSendEntry( entry );
 }
 
 void Nic::Shmem::hostWait( NicShmemOpCmdEvent* event, int id )

--- a/src/sst/elements/firefly/nicShmemMove.cc
+++ b/src/sst/elements/firefly/nicShmemMove.cc
@@ -21,7 +21,7 @@ using namespace SST;
 using namespace SST::Firefly;
 
 
-void Nic::ShmemSendMoveMem::copyOut( Output& dbg, int vc, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
+void Nic::ShmemSendMoveMem::copyOut( Output& dbg, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
 {
 
     size_t bufSpace = numBytes - event.bufSize(); 
@@ -34,8 +34,8 @@ void Nic::ShmemSendMoveMem::copyOut( Output& dbg, int vc, int numBytes, FireflyN
         len = left;
     } 
 
-    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"Shmem: %d: pktSpace=%lu dataLeft=%lu xferSize=%lu\n",
-                vc, bufSpace, left, len  );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"pktSpace=%lu dataLeft=%lu xferSize=%lu\n",
+                bufSpace, left, len  );
 
 	vec.push_back( MemOp( m_addr + m_offset, len, MemOp::Op::BusDmaFromHost ));
 
@@ -48,13 +48,13 @@ void Nic::ShmemSendMoveMem::copyOut( Output& dbg, int vc, int numBytes, FireflyN
     m_offset += len; 
 }
 
-void Nic::ShmemSendMoveValue::copyOut( Output& dbg, int vc, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
+void Nic::ShmemSendMoveValue::copyOut( Output& dbg, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
 {
     size_t space = numBytes - event.bufSize(); 
     size_t len = m_value.getLength() > space ? space : m_value.getLength(); 
 
-    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"Shmem: %d: PacketSize=%d event.bufSpace()=%lu space=%lu len=%lu\n",
-                vc, numBytes, event.bufSize(), space, len );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"PacketSize=%d event.bufSpace()=%lu space=%lu len=%lu\n",
+                numBytes, event.bufSize(), space, len );
 
 	vec.push_back( MemOp( 0, len, MemOp::Op::LocalLoad ));
 
@@ -68,13 +68,13 @@ void Nic::ShmemSendMoveValue::copyOut( Output& dbg, int vc, int numBytes, Firefl
     event.bufAppend( m_value.getPtr() ,len );
 }
 
-void Nic::ShmemSendMove2Value::copyOut( Output& dbg, int vc, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
+void Nic::ShmemSendMove2Value::copyOut( Output& dbg, int numBytes, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
 {
     size_t space = numBytes - event.bufSize(); 
     assert( getLength() <= space );
 
-    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"Shmem: %d: PacketSize=%d event.bufSpace()=%lu space=%lu len=%lu\n",
-                vc, numBytes, event.bufSize(), space, getLength() );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_SEND_MACHINE,"PacketSize=%d event.bufSpace()=%lu space=%lu len=%lu\n",
+                numBytes, event.bufSize(), space, getLength() );
 
     m_offset += getLength(); 
 	vec.push_back( MemOp( 0, getLength(), MemOp::Op::LocalLoad ));
@@ -95,9 +95,9 @@ bool Nic::ShmemRecvMoveMem::copyIn( Output& dbg, FireflyNetworkEvent& event, std
 {
     size_t length = event.bufSize();
 
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: event.bufSize()=%lu\n",event.bufSize() );
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: length=%lu offset=%lu\n",m_length, m_offset );
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: backing=%p addr=%#" PRIx64 "\n", m_ptr + m_offset, m_addr + m_offset );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"event.bufSize()=%lu\n",event.bufSize() );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"length=%lu offset=%lu\n",m_length, m_offset );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"backing=%p addr=%#" PRIx64 "\n", m_ptr + m_offset, m_addr + m_offset );
 
     assert( length <= m_length - m_offset );
 
@@ -122,8 +122,8 @@ bool Nic::ShmemRecvMoveMem::copyIn( Output& dbg, FireflyNetworkEvent& event, std
 bool Nic::ShmemRecvMoveMemOp::copyIn( Output& dbg, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
 {
     size_t length = event.bufSize();
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: event.bufSize()=%lu\n",event.bufSize());
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: backing=%p addr=%#" PRIx64 "\n", m_ptr, m_addr );
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"event.bufSize()=%lu\n",event.bufSize());
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"backing=%p addr=%#" PRIx64 "\n", m_ptr, m_addr );
 
     assert ( m_ptr );
     size_t dataLength = Hermes::Value::getLength(m_dataType);
@@ -194,7 +194,7 @@ bool Nic::ShmemRecvMoveMemOp::copyIn( Output& dbg, FireflyNetworkEvent& event, s
 bool Nic::ShmemRecvMoveValue::copyIn( Output& dbg, FireflyNetworkEvent& event, std::vector<MemOp>& vec )
 {
     size_t length = event.bufSize();
-    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"Shmem: event.bufSize()=%lu\n",event.bufSize());
+    dbg.verbose(CALL_INFO,3,NIC_DBG_RECV_MACHINE,"event.bufSize()=%lu\n",event.bufSize());
 
 	vec.push_back( MemOp( 0, length, MemOp::Op::LocalStore ));
     if ( m_value.getPtr() ) {

--- a/src/sst/elements/firefly/nicShmemMove.h
+++ b/src/sst/elements/firefly/nicShmemMove.h
@@ -70,7 +70,7 @@ class ShmemRecvMoveValue : public ShmemRecvMove {
 class ShmemSendMove {
   public:
     virtual ~ShmemSendMove() {}
-    virtual void copyOut( Output& dbg, int vc, int numBytes,
+    virtual void copyOut( Output& dbg, int numBytes,
             FireflyNetworkEvent&, std::vector<MemOp>& ) = 0;
 
     virtual bool isDone() = 0;
@@ -83,7 +83,7 @@ class ShmemSendMoveMem : public ShmemSendMove {
     ShmemSendMoveMem( void* ptr, size_t length, Hermes::Vaddr addr ) :
         m_ptr((uint8_t*)ptr), m_length( length ), m_offset(0), m_addr(addr)  { }
 
-    virtual void copyOut( Output& dbg, int vc, int numBytes,
+    virtual void copyOut( Output& dbg, int numBytes,
             FireflyNetworkEvent&, std::vector<MemOp>& );
     bool isDone() { return m_offset == m_length; }
 
@@ -100,7 +100,7 @@ class ShmemSendMoveValue : public ShmemSendMove {
     ShmemSendMoveValue( Hermes::Value& value ) :
         m_value( value ), m_offset(0)  { }
 
-    virtual void copyOut( Output& dbg, int vc, int numBytes,
+    virtual void copyOut( Output& dbg, int numBytes,
             FireflyNetworkEvent&, std::vector<MemOp>& );
     bool isDone() { return m_offset == m_value.getLength(); }
 
@@ -115,7 +115,7 @@ class ShmemSendMove2Value : public ShmemSendMove {
     ShmemSendMove2Value( Hermes::Value& value1, Hermes::Value& value2 ) :
         m_value1( value1 ), m_value2( value2), m_offset(0)  { }
 
-    virtual void copyOut( Output& dbg, int vc, int numBytes,
+    virtual void copyOut( Output& dbg, int numBytes,
             FireflyNetworkEvent&, std::vector<MemOp>& );
 
     bool isDone() { return m_offset == getLength(); }

--- a/src/sst/elements/firefly/nicShmemSendEntry.h
+++ b/src/sst/elements/firefly/nicShmemSendEntry.h
@@ -47,7 +47,7 @@ class ShmemAckSendEntry: public ShmemSendEntryBase {
     int dest() { return m_dest_node; }
     size_t totalBytes() { return 0; } 
     bool isDone() { return true; }
-    virtual void copyOut( Output&, int vc, int numBytes, 
+    virtual void copyOut( Output&, int numBytes, 
             FireflyNetworkEvent&, std::vector<MemOp>& ) {};
   private:
 	int m_dest_vNic;
@@ -71,7 +71,7 @@ class ShmemRespSendEntry: public ShmemCmdSendEntry {
 
     size_t totalBytes() { return 0; } 
     bool isDone() { return true; }
-    virtual void copyOut( Output&, int vc, int numBytes, 
+    virtual void copyOut( Output&, int numBytes, 
             FireflyNetworkEvent&, std::vector<MemOp>& ) {};
     NicShmemSendCmdEvent* getCmd() { return m_event; }
 };
@@ -106,9 +106,9 @@ class ShmemFaddSendEntry: public ShmemRespSendEntry {
 
     void callback( Hermes::Value& value ) { m_callback(value); }
 
-    void copyOut( Output& dbg, int vc, int numBytes, 
+    void copyOut( Output& dbg, int numBytes, 
             FireflyNetworkEvent& ev, std::vector<MemOp>&  vec) { 
-        m_shmemMove->copyOut( dbg, vc, numBytes, ev, vec ); 
+        m_shmemMove->copyOut( dbg, numBytes, ev, vec ); 
     }
   private:
     Callback  m_callback;
@@ -129,9 +129,9 @@ class ShmemSwapSendEntry: public ShmemRespSendEntry {
 
     void callback( Hermes::Value& value ) { m_callback(value); }
 
-    void copyOut( Output& dbg, int vc, int numBytes, 
+    void copyOut( Output& dbg, int numBytes, 
             FireflyNetworkEvent& ev, std::vector<MemOp>&  vec) { 
-        m_shmemMove->copyOut( dbg, vc, numBytes, ev, vec ); 
+        m_shmemMove->copyOut( dbg, numBytes, ev, vec ); 
     }
   private:
     Callback        m_callback;
@@ -152,9 +152,9 @@ class ShmemCswapSendEntry: public ShmemRespSendEntry {
 
     void callback( Hermes::Value& value ) { m_callback(value); }
 
-    void copyOut( Output& dbg, int vc, int numBytes, 
+    void copyOut( Output& dbg, int numBytes, 
             FireflyNetworkEvent& ev, std::vector<MemOp>&  vec) { 
-        m_shmemMove->copyOut( dbg, vc, numBytes, ev, vec ); 
+        m_shmemMove->copyOut( dbg, numBytes, ev, vec ); 
     }
   private:
     Callback        m_callback;
@@ -199,9 +199,9 @@ class ShmemPutSendEntry: public ShmemCmdSendEntry  {
 
     size_t totalBytes() { return m_hdr.length; } 
     bool isDone() { return m_shmemMove->isDone(); }
-    void copyOut( Output& dbg, int vc, int numBytes, 
+    void copyOut( Output& dbg, int numBytes, 
             FireflyNetworkEvent& ev, std::vector<MemOp>& vec ) {
-        m_shmemMove->copyOut( dbg, vc, numBytes, ev, vec ); 
+        m_shmemMove->copyOut( dbg, numBytes, ev, vec ); 
     };
 
   protected:
@@ -281,10 +281,9 @@ class ShmemPut2SendEntry: public ShmemSendEntryBase  {
 
     size_t totalBytes() { return m_hdr.length; } 
     bool isDone() { return m_shmemMove->isDone(); }
-    void copyOut( Output& dbg, int vc, int numBytes, 
+    void copyOut( Output& dbg, int numBytes, 
             FireflyNetworkEvent& ev, std::vector<MemOp>& vec ) {
-        m_shmemMove->copyOut( dbg, vc, numBytes, ev, vec ); 
-    };
+        m_shmemMove->copyOut( dbg, numBytes, ev, vec ); };
 
   private:
     ShmemSendMove* m_shmemMove;


### PR DESCRIPTION
To keep control messages from getting backed up behind long messages it was sent out over VC1. Control messages are now sent over VC0 (with standard messages). Control messages do not have to wait until pending long messages complete. The receive machine checks for control messages and processes them immediately.