### PR TITLE
fixed bug in ariel core by updating clock cycles only during valid cl…

### DIFF
--- a/src/sst/elements/ariel/arielcore.cc
+++ b/src/sst/elements/ariel/arielcore.cc
@@ -615,6 +615,8 @@ bool ArielCore::processNextEvent() {
 		}
 	}
 
+	updateCycle = true;
+
 	ARIEL_CORE_VERBOSE(8, output->verbose(CALL_INFO, 8, 0, "Processing next event in core %" PRIu32 "...\n", coreID));
 
 	ArielEvent* nextEvent = coreQ->front();
@@ -730,6 +732,7 @@ bool ArielCore::processNextEvent() {
 	void ArielCore::tick() {
 		if(! isHalted) {
 			ARIEL_CORE_VERBOSE(16, output->verbose(CALL_INFO, 16, 0, "Ticking core id %" PRIu32 "\n", coreID));
+			updateCycle = false;
 			for(uint32_t i = 0; i < maxIssuePerCycle; ++i) {
 				bool didProcess = processNextEvent();
 
@@ -744,8 +747,10 @@ bool ArielCore::processNextEvent() {
 
 			}
 
-			currentCycles++;
-			statCycles->addData(1);
+			if( updateCycle ) {
+				currentCycles++;
+				statCycles->addData(1);
+			}
 		}
 
 		if(inst_count >= max_insts && (max_insts!=0) && (coreID==0))

--- a/src/sst/elements/ariel/arielcore.h
+++ b/src/sst/elements/ariel/arielcore.h
@@ -123,6 +123,7 @@ class ArielCore {
 		const uint32_t perform_checks;
 		bool enableTracing;
 		uint64_t currentCycles;
+		bool updateCycle;
 
 		// This indicates the current number of executed instructions by this core
 		long long int inst_count;


### PR DESCRIPTION
Ariel core clock should be updated only when coreQ->empty() or refillQueue() succeeds, at-least once in a clock tick.