### PR TITLE
MemH debug

### DIFF
--- a/src/sst/elements/memHierarchy/cacheArray.h
+++ b/src/sst/elements/memHierarchy/cacheArray.h
@@ -124,6 +124,18 @@ public:
             LLSCAtomic_             = false;
         }
 
+        std::string getString() {
+            std::ostringstream str;
+            str << std::hex << "0x" << baseAddr_;
+            str << " State: " << StateString[state_];
+            str << " Sharers: [";
+            for (std::set<std::string>::iterator it = sharers_.begin(); it != sharers_.end(); it++) {
+                if (it != sharers_.begin()) str << ",";
+                str << *it;
+            }
+            str << "] Owner: " << owner_;
+            return str.str();
+        }
 
         /** Getter for size. Constant field - no setter */
         unsigned int getSize() { return size_; }
@@ -281,6 +293,12 @@ public:
 
     void setBanked(unsigned int numBanks) {
         banks_ = numBanks;
+    }
+
+    void printCacheArray(Output &out) {
+        for (unsigned int i = 0; i < numLines_; i++) {
+            out.output("   %u %s\n", i, lines_[i]->getString().c_str());
+        }
     }
 
 private:

--- a/src/sst/elements/memHierarchy/cacheController.h
+++ b/src/sst/elements/memHierarchy/cacheController.h
@@ -180,6 +180,10 @@ public:
         return (addr) & ~(cacheArray_->getLineSize() - 1);
     }
 
+    /* Debug/fatal */
+    void printStatus(Output & out); // Called on SIGUSR2
+    void emergencyShutdown();       // Called on output.fatal(), (SIGINT/SIGTERM)
+
 private:
     /** Constructor helper methods */
     void checkDeprecatedParams(Params &params);
@@ -295,6 +299,8 @@ private:
     /**  Clock Handler.  Every cycle events are executed (if any).  If clock is idle long enough, 
          the clock gets deregistered from TimeVortx and reregistered only when an event is received */
     bool clockTick(Cycle_t time);
+    void turnClockOn();
+    void turnClockOff();
 
     void maxWaitWakeup(SST::Event * ev) {
         checkMaxWait();
@@ -318,7 +324,7 @@ private:
         if ( oldReq ) {
             SimTime_t waitTime = curTime - oldReq->getInitializationTime();
             if ( waitTime > maxWaitTime_ ) {
-                d_->fatal(CALL_INFO, 1, "%s, Error: Maximum Cache Request time reached!\n"
+                out_->fatal(CALL_INFO, 1, "%s, Error: Maximum Cache Request time reached!\n"
                         "Event: %s 0x%" PRIx64 " from %s. Time = %" PRIu64 " ns\n",
                         getName().c_str(), CommandString[(int)oldReq->getCmd()], oldReq->getAddr(), oldReq->getSrc().c_str(), curTime);
             }
@@ -355,6 +361,7 @@ private:
     TimeConverter*          defaultTimeBase_;
     
     /* Debug and output */
+    Output*                 out_;
     Output*                 d_;
     Output*                 d2_;
     std::set<Addr>          DEBUG_ADDR;

--- a/src/sst/elements/memHierarchy/cacheFactory.cc
+++ b/src/sst/elements/memHierarchy/cacheFactory.cc
@@ -41,6 +41,9 @@ using namespace std;
 Cache::Cache(ComponentId_t id, Params &params) : Component(id) {
  
     /* --------------- Output Class --------------- */
+    out_ = new Output();
+    out_->init("", 1, 0, Output::STDOUT);
+
     d_ = new Output();
     d_->init("--->  ", params.find<int>("debug_level", 1), 0,(Output::output_location_t)params.find<int>("debug", 0));
     
@@ -68,29 +71,29 @@ Cache::Cache(ComponentId_t id, Params &params) : Component(id) {
     if (protStr == "mesi") protocol_ = CoherenceProtocol::MESI;
     else if (protStr == "msi") protocol_ = CoherenceProtocol::MSI;
     else if (protStr == "none") protocol_ = CoherenceProtocol::NONE;
-    else d_->fatal(CALL_INFO,-1, "%s, Invalid param: coherence_protocol - must be 'msi', 'mesi', or 'none'.\n", getName().c_str());
+    else out_->fatal(CALL_INFO,-1, "%s, Invalid param: coherence_protocol - must be 'msi', 'mesi', or 'none'.\n", getName().c_str());
     
     // Type
     type_ = params.find<std::string>("cache_type", "inclusive");
     to_lower(type_);
     if (type_ != "inclusive" && type_ != "noninclusive" && type_ != "noninclusive_with_directory")
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_type - valid options are 'inclusive' or 'noninclusive' or 'noninclusive_with_directory'. You specified '%s'.\n", getName().c_str(), type_.c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_type - valid options are 'inclusive' or 'noninclusive' or 'noninclusive_with_directory'. You specified '%s'.\n", getName().c_str(), type_.c_str());
     
     // Latency
     accessLatency_ = params.find<uint64_t>("access_latency_cycles", 0, found);
-    if (!found) d_->fatal(CALL_INFO, -1, "%s, Param not specified: access_latency_cycles - access time for cache.\n", getName().c_str());
+    if (!found) out_->fatal(CALL_INFO, -1, "%s, Param not specified: access_latency_cycles - access time for cache.\n", getName().c_str());
 
     tagLatency_ = params.find<uint64_t>("tag_access_latency_cycles", accessLatency_);
 
 
     // Error check parameter combinations
-    if (accessLatency_ < 1) d_->fatal(CALL_INFO,-1, "%s, Invalid param: access_latency_cycles - must be at least 1. You specified %" PRIu64 "\n", 
+    if (accessLatency_ < 1) out_->fatal(CALL_INFO,-1, "%s, Invalid param: access_latency_cycles - must be at least 1. You specified %" PRIu64 "\n", 
             this->Component::getName().c_str(), accessLatency_);
     
     if (L1_ && type_ != "inclusive") {
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_type - must be 'inclusive' for an L1. You specified '%s'.\n", getName().c_str(), type_.c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_type - must be 'inclusive' for an L1. You specified '%s'.\n", getName().c_str(), type_.c_str());
     } else if (!L1_ && protocol_ == CoherenceProtocol::NONE && type_ != "noninclusive") {
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param combo: cache_type and coherence_protocol - non-coherent caches are noninclusive. You specified: cache_type = '%s', coherence_protocol = '%s'\n", 
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param combo: cache_type and coherence_protocol - non-coherent caches are noninclusive. You specified: cache_type = '%s', coherence_protocol = '%s'\n", 
                 getName().c_str(), type_.c_str(), protStr.c_str()); 
     }
 
@@ -119,7 +122,7 @@ Cache::Cache(ComponentId_t id, Params &params) : Component(id) {
 
     UnitAlgebra packetSize_ua(packetSize);
     if (!packetSize_ua.hasUnits("B")) {
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param: min_packet_size - must have units of bytes (B). Ex: '8B'. SI units are ok. You specified '%s'\n", this->Component::getName().c_str(), packetSize.c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param: min_packet_size - must have units of bytes (B). Ex: '8B'. SI units are ok. You specified '%s'\n", this->Component::getName().c_str(), packetSize.c_str());
     }
 
     if (maxRequestsPerCycle_ == 0) {
@@ -176,7 +179,7 @@ void Cache::createCoherenceManager(Params &params) {
         }
     }
     if (coherenceMgr_ == NULL) {
-        d_->fatal(CALL_INFO, -1, "%s, Failed to load CoherenceController.\n", this->Component::getName().c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Failed to load CoherenceController.\n", this->Component::getName().c_str());
     }
 
     coherenceMgr_->setLinks(linkUp_, linkDown_);
@@ -210,33 +213,33 @@ void Cache::configureLinks(Params &params) {
     /* Check for valid port combos */
     if (highNetExists) {
         if (!lowCacheExists && !lowDirExists && !lowNetExists)
-            d_->fatal(CALL_INFO,-1,"%s, Error: no connected low ports detected. Please connect one of 'cache' or 'directory' or connect N components to 'low_network_n' where n is in the range 0 to N-1\n",
+            out_->fatal(CALL_INFO,-1,"%s, Error: no connected low ports detected. Please connect one of 'cache' or 'directory' or connect N components to 'low_network_n' where n is in the range 0 to N-1\n",
                     getName().c_str());
         if ((lowCacheExists && (lowDirExists || lowNetExists)) || (lowDirExists && lowNetExists))  
-            d_->fatal(CALL_INFO,-1,"%s, Error: multiple connected low port types detected. Please only connect one of 'cache', 'directory', or connect N components to 'low_network_n' where n is in the range 0 to N-1\n",
+            out_->fatal(CALL_INFO,-1,"%s, Error: multiple connected low port types detected. Please only connect one of 'cache', 'directory', or connect N components to 'low_network_n' where n is in the range 0 to N-1\n",
                     getName().c_str());
         if (isPortConnected("high_network_1"))
-            d_->fatal(CALL_INFO,-1,"%s, Error: multiple connected high ports detected. Use the 'Bus' component to connect multiple entities to port 'high_network_0' (e.g., connect 2 L1s to a bus and connect the bus to the L2)\n",
+            out_->fatal(CALL_INFO,-1,"%s, Error: multiple connected high ports detected. Use the 'Bus' component to connect multiple entities to port 'high_network_0' (e.g., connect 2 L1s to a bus and connect the bus to the L2)\n",
                     getName().c_str());
     } else {
         if (!lowDirExists) 
-            d_->fatal(CALL_INFO,-1,"%s, Error: no connected ports detected. Valid ports are high_network_0, cache, directory, and low_network_n\n",
+            out_->fatal(CALL_INFO,-1,"%s, Error: no connected ports detected. Valid ports are high_network_0, cache, directory, and low_network_n\n",
                     getName().c_str());
         if (lowCacheExists || lowNetExists)
-            d_->fatal(CALL_INFO,-1,"%s, Error: no connected high ports detected. Please connect a bus/cache/core on port 'high_network_0'\n",
+            out_->fatal(CALL_INFO,-1,"%s, Error: no connected high ports detected. Please connect a bus/cache/core on port 'high_network_0'\n",
                     getName().c_str());
     }
    
     // Fix up parameters for creating NIC
     bool found;
     if (fixupParam(params, "network_bw", "memNIC.network_bw"))
-        d_->output(CALL_INFO, "Note (%s): Changed 'network_bw' to 'memNIC.network_bw' in params. Change your input file to remove this notice.\n", getName().c_str());
+        out_->output(CALL_INFO, "Note (%s): Changed 'network_bw' to 'memNIC.network_bw' in params. Change your input file to remove this notice.\n", getName().c_str());
     if (fixupParam(params, "network_input_buffer_size", "memNIC.network_input_buffer_size"))
-        d_->output(CALL_INFO, "Note (%s): Changed 'network_input_buffer_size' to 'memNIC.network_input_buffer_size' in params. Change your input file to remove this notice.\n", getName().c_str());
+        out_->output(CALL_INFO, "Note (%s): Changed 'network_input_buffer_size' to 'memNIC.network_input_buffer_size' in params. Change your input file to remove this notice.\n", getName().c_str());
     if (fixupParam(params, "network_output_buffer_size", "memNIC.network_output_buffer_size"))
-        d_->output(CALL_INFO, "Note (%s): Changed 'network_output_buffer_size' to 'memNIC.network_output_buffer_size' in params. Change your input file to remove this notice.\n", getName().c_str());
+        out_->output(CALL_INFO, "Note (%s): Changed 'network_output_buffer_size' to 'memNIC.network_output_buffer_size' in params. Change your input file to remove this notice.\n", getName().c_str());
     if (fixupParam(params, "min_packet_size", "memNIC.min_packet_size"))
-        d_->output(CALL_INFO, "Note (%s): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.\n", getName().c_str());
+        out_->output(CALL_INFO, "Note (%s): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.\n", getName().c_str());
 
     char *node_buffer1 = (char*) malloc(sizeof(char) * 256);
     char *node_buffer2 = (char*) malloc(sizeof(char) * 256);
@@ -327,9 +330,9 @@ void Cache::configureLinks(Params &params) {
         string sliceAllocPolicy     = params.find<std::string>("slice_allocation_policy", "rr");
         if (cacheSliceCount == 1) sliceID = 0;
         else if (cacheSliceCount > 1) {
-            if (sliceID >= cacheSliceCount) d_->fatal(CALL_INFO,-1, "%s, Invalid param: slice_id - should be between 0 and num_cache_slices-1. You specified %d.\n",
+            if (sliceID >= cacheSliceCount) out_->fatal(CALL_INFO,-1, "%s, Invalid param: slice_id - should be between 0 and num_cache_slices-1. You specified %d.\n",
                     getName().c_str(), sliceID);
-            if (sliceAllocPolicy != "rr") d_->fatal(CALL_INFO,-1, "%s, Invalid param: slice_allocation_policy - supported policy is 'rr' (round-robin). You specified '%s'.\n",
+            if (sliceAllocPolicy != "rr") out_->fatal(CALL_INFO,-1, "%s, Invalid param: slice_allocation_policy - supported policy is 'rr' (round-robin). You specified '%s'.\n",
                     getName().c_str(), sliceAllocPolicy.c_str());
         } else {
             d2_->fatal(CALL_INFO, -1, "%s, Invalid param: num_cache_slices - should be 1 or greater. You specified %d.\n", 
@@ -409,7 +412,7 @@ int Cache::createMSHR(Params &params) {
     mshrLatency_ = params.find<uint64_t>("mshr_latency_cycles", 0);
     
     if (mshrSize == -1) mshrSize = HUGE_MSHR; // Set in mshr.h
-    if (mshrSize < 2) d_->fatal(CALL_INFO, -1, "Invalid param: mshr_num_entries - MSHR requires at least 2 entries to avoid deadlock. You specified %d\n", mshrSize);
+    if (mshrSize < 2) out_->fatal(CALL_INFO, -1, "Invalid param: mshr_num_entries - MSHR requires at least 2 entries to avoid deadlock. You specified %d\n", mshrSize);
     
     mshr_ = new MSHR(d_, mshrSize, this->getName(), DEBUG_ADDR);
     
@@ -438,7 +441,7 @@ int Cache::createMSHR(Params &params) {
     for(uint64 idx = 68; idx < N;  idx++) y[idx] = 32;
     
     if (accessLatency_ > N) {
-        d_->fatal(CALL_INFO, -1, "%s, Error: cannot intrapolate MSHR latency if cache latency > 200. Set 'mshr_latency_cycles' or reduce cache latency. Cache latency: %" PRIu64 "\n", getName().c_str(), accessLatency_);
+        out_->fatal(CALL_INFO, -1, "%s, Error: cannot intrapolate MSHR latency if cache latency > 200. Set 'mshr_latency_cycles' or reduce cache latency. Cache latency: %" PRIu64 "\n", getName().c_str(), accessLatency_);
     }
     mshrLatency_ = y[accessLatency_];
 
@@ -453,12 +456,12 @@ CacheArray* Cache::createCacheArray(Params &params) {
     /* Get parameters and error check */
     bool found;
     std::string sizeStr = params.find<std::string>("cache_size", "", found);
-    if (!found) d_->fatal(CALL_INFO, -1, "%s, Param not specified: cache_size\n", getName().c_str());
+    if (!found) out_->fatal(CALL_INFO, -1, "%s, Param not specified: cache_size\n", getName().c_str());
     
     unsigned int lineSize = params.find<uint64_t>("cache_line_size", 64);
     
     uint64_t assoc = params.find<uint64_t>("associativity", -1, found); // uint64_t to match cache size in case we have a fully associative cache
-    if (!found) d_->fatal(CALL_INFO, -1, "%s, Param not specified: associativity\n", getName().c_str());
+    if (!found) out_->fatal(CALL_INFO, -1, "%s, Param not specified: associativity\n", getName().c_str());
 
     std::string replacement = params.find<std::string>("replacement_policy", "lru");
     std::string dReplacement = params.find<std::string>("noninclusive_directory_repl", "lru");
@@ -475,27 +478,27 @@ CacheArray* Cache::createCacheArray(Params &params) {
 
     UnitAlgebra ua(sizeStr);
     if (!ua.hasUnits("B")) {
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_size - must have units of bytes(B). Ex: '32KiB'. SI units are ok. You specified '%s'.", getName().c_str(), sizeStr.c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param: cache_size - must have units of bytes(B). Ex: '32KiB'. SI units are ok. You specified '%s'.", getName().c_str(), sizeStr.c_str());
     }
 
     uint64_t cacheSize = ua.getRoundedValue();
     
     if (lineSize > cacheSize) 
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param combo: cache_line_size cannot be greater than cache_size. You specified: cache_size = '%s', cache_line_size = '%u'\n", getName().c_str(), sizeStr.c_str(), lineSize);
-    if (!isPowerOfTwo(lineSize)) d_->fatal(CALL_INFO, -1, "%s, cache_line_size - must be a power of 2. You specified '%u'.\n", getName().c_str(), lineSize);
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param combo: cache_line_size cannot be greater than cache_size. You specified: cache_size = '%s', cache_line_size = '%u'\n", getName().c_str(), sizeStr.c_str(), lineSize);
+    if (!isPowerOfTwo(lineSize)) out_->fatal(CALL_INFO, -1, "%s, cache_line_size - must be a power of 2. You specified '%u'.\n", getName().c_str(), lineSize);
 
     uint64_t lines = cacheSize / lineSize;
     
     if (assoc < 1 || assoc > lines) 
-        d_->fatal(CALL_INFO, -1, "%s, Invalid param: associativity - must be at least 1 (direct mapped) and less than or equal to the number of cache lines (cache_size / cache_line_size). You specified '%" PRIu64 "'\n", 
+        out_->fatal(CALL_INFO, -1, "%s, Invalid param: associativity - must be at least 1 (direct mapped) and less than or equal to the number of cache lines (cache_size / cache_line_size). You specified '%" PRIu64 "'\n", 
                 getName().c_str(), assoc);
 
     if (type_ == "noninclusive_with_directory") { /* Error check dir params */
         if (dAssoc < 1 || dAssoc > dEntries) 
-            d_->fatal(CALL_INFO, -1, "%s, Invalid param: noninclusive_directory_associativity - must be at least 1 (direct mapped) and less than or equal to noninclusive_directory_entries. You specified '%" PRIu64 "'\n", 
+            out_->fatal(CALL_INFO, -1, "%s, Invalid param: noninclusive_directory_associativity - must be at least 1 (direct mapped) and less than or equal to noninclusive_directory_entries. You specified '%" PRIu64 "'\n", 
                     getName().c_str(), dAssoc);
         if (dEntries < 1)
-            d_->fatal(CALL_INFO, -1, "%s, Invalid param: noninclusive_directory_entries - must be at least 1 if cache_type is noninclusive_with_directory. You specified '%" PRIu64 "'.\n", getName().c_str(), dEntries);
+            out_->fatal(CALL_INFO, -1, "%s, Invalid param: noninclusive_directory_entries - must be at least 1 if cache_type is noninclusive_with_directory. You specified '%" PRIu64 "'.\n", getName().c_str(), dEntries);
     }
 
     /* Build cache array */
@@ -532,7 +535,7 @@ ReplacementMgr* Cache::constructReplacementManager(std::string policy, uint64_t 
     if (SST::strcasecmp(policy, "nmru"))   
         return new NMRUReplacementMgr(d_, lines, associativity);
     
-    d_->fatal(CALL_INFO, -1, "%s, Invalid param: (directory_)replacement_policy - supported policies are 'lru', 'lfu', 'random', 'mru', and 'nmru'. You specified '%s'.\n",
+    out_->fatal(CALL_INFO, -1, "%s, Invalid param: (directory_)replacement_policy - supported policies are 'lru', 'lfu', 'random', 'mru', and 'nmru'. You specified '%s'.\n",
             getName().c_str(), policy.c_str());
     
     return nullptr;
@@ -543,7 +546,7 @@ void Cache::createClock(Params &params) {
     bool found;
     std::string frequency = params.find<std::string>("cache_frequency", "", found);
     if (!found)
-        d_->fatal(CALL_INFO, -1, "%s, Param not specified: frequency - cache frequency.\n", getName().c_str());
+        out_->fatal(CALL_INFO, -1, "%s, Param not specified: frequency - cache frequency.\n", getName().c_str());
     
     clockHandler_       = new Clock::Handler<Cache>(this, &Cache::clockTick);
     defaultTimeBase_    = registerClock(frequency, clockHandler_);

--- a/src/sst/elements/memHierarchy/directoryController.h
+++ b/src/sst/elements/memHierarchy/directoryController.h
@@ -115,6 +115,7 @@ public:
 
 /* Begin class definition */
 private:
+    Output out;
     Output dbg;
     std::set<Addr> DEBUG_ADDR;
     struct DirEntry;
@@ -368,6 +369,24 @@ private:
             owner        = -1;
         }
 
+        std::string getString() {
+            std::ostringstream str;
+            str << "State: " << StateString[state];
+            str << " Sharers: [";
+            bool first = true;
+            for (int i = 0; i < sharers.size(); i++) {
+                if (sharers[i]) {
+                    if (!first) str << ",";
+                    str << i;
+                    first = false;
+                }
+            }
+            str << "] Owner: " << owner;
+            str << " Cached: " << (cached ? "y" : "n");
+            str << " Acks: " << waitingAcks;
+            return str.str();
+        }
+
         bool isCached() {
             return cached;
         }
@@ -452,8 +471,9 @@ public:
     void init(unsigned int phase);
     void finish(void);
     
-    /** Print status of entries/work queue */
-    void printStatus(Output &out);
+    /** Debug - triggered by output.fatal() or SIGUSR2 */
+    virtual void printStatus(Output &out);
+    virtual void emergencyShutdown();
     
     /** Function handles responses from Main Memory.  
         "Advances" the state of the directory entry */

--- a/src/sst/elements/memHierarchy/memLink.h
+++ b/src/sst/elements/memHierarchy/memLink.h
@@ -100,6 +100,11 @@ public:
     virtual void send(MemEventBase * ev);
     virtual MemEventBase * recv();
 
+    /* Debug */
+    virtual void printStatus(Output &out) {
+        out.output("  MemHierarchy::MemLink: No status given\n");
+    }
+
 protected:
     
     // Link

--- a/src/sst/elements/memHierarchy/memLinkBase.h
+++ b/src/sst/elements/memHierarchy/memLinkBase.h
@@ -142,6 +142,11 @@ public:
 #endif
     }
 
+    /* Debug - triggered by output.fatal() or SIGUSR2 */
+    virtual void printStatus(Output &out) {
+        out.output("  MemHierarchy::MemLinkBase: No status given\n");
+    }
+
     /* Send and receive functions for MemLink */
     virtual void sendInitData(MemEventInit * ev) =0;
     virtual MemEventInit* recvInitData() =0;

--- a/src/sst/elements/memHierarchy/memNIC.h
+++ b/src/sst/elements/memHierarchy/memNIC.h
@@ -27,12 +27,119 @@
 #include <sst/core/interfaces/simpleNetwork.h>
 
 #include "sst/elements/memHierarchy/memEventBase.h"
-#include "sst/elements/memHierarchy/memEvent.h"
 #include "sst/elements/memHierarchy/util.h"
 #include "sst/elements/memHierarchy/memLinkBase.h"
 
 namespace SST {
 namespace MemHierarchy {
+
+/* MemNIC Base class
+ *  Base class to handle initialization and endpoint management for different NICs
+ */
+class MemNICBase : public MemLinkBase {
+    public:
+
+#define MEMNICBASE_ELI_PARAMS MEMLINKBASE_ELI_PARAMS, \
+        { "group",                       "(int) Group ID. See params 'sources' and 'destinations'. If not specified, the parent component will guess.", "1"},\
+        { "sources",                     "(comma-separated list of ints) List of group IDs that serve as sources for this component. If not specified, defaults to 'group - 1'.", "group-1"},\
+        { "destinations",                "(comma-separated list of ints) List of group IDs that serve as destinations for this component. If not specified, defaults to 'group + 1'.", "group+1"}
+
+        MemNICBase(Component * comp, Params &params);
+        ~MemNICBase() { }
+
+        uint64_t lookupNetworkAddress(const std::string &dst) const;
+
+        // Router events 
+        class MemRtrEvent : public SST::Event {
+            public:
+                MemEventBase * event;
+                MemRtrEvent() : Event(), event(nullptr) { }
+                MemRtrEvent(MemEventBase * ev) : Event(), event(ev) { }
+            
+                virtual Event* clone(void) override {
+                    MemRtrEvent *mre = new MemRtrEvent(*this);
+                    if (this->event != nullptr)
+                        mre->event = this->event->clone();
+                    else
+                        mre->event = nullptr;
+                    return mre;
+                }
+
+                virtual bool hasClientData() const { return true; }
+    
+                void serialize_order(SST::Core::Serialization::serializer &ser) override {
+                    Event::serialize_order(ser);
+                    ser & event;
+                }
+    
+                ImplementSerializable(SST::MemHierarchy::MemNICBase::MemRtrEvent);
+        };
+
+        class InitMemRtrEvent : public MemRtrEvent {
+            public:
+                EndpointInfo info;
+
+                InitMemRtrEvent() {}
+                InitMemRtrEvent(EndpointInfo info) : MemRtrEvent(), info(info) { }
+
+                virtual Event* clone(void) override {
+                    InitMemRtrEvent * imre = new InitMemRtrEvent(*this);
+                    if (this->event != nullptr)
+                        imre->event = this->event->clone();
+                    else
+                        imre->event = nullptr;
+                    return imre;
+                }
+
+                virtual bool hasClientData() const override { return false; }
+
+                void serialize_order(SST::Core::Serialization::serializer & ser) override {
+                    MemRtrEvent::serialize_order(ser);
+                    ser & info.name;
+                    ser & info.addr;
+                    ser & info.id;
+                    ser & info.node;
+                    ser & info.region.start;
+                    ser & info.region.end;
+                    ser & info.region.interleaveSize;
+                    ser & info.region.interleaveStep;
+                }
+    
+                ImplementSerializable(SST::MemHierarchy::MemNICBase::InitMemRtrEvent);
+        };
+
+        // Init functions
+        void sendInitData(MemEventInit * ev);
+        MemEventInit* recvInitData();
+
+        bool isSource(std::string str) { /* Note this is only used during init so doesn't need to be fast */
+            for (std::set<EndpointInfo>::iterator it = sourceEndpointInfo.begin(); it != sourceEndpointInfo.end(); it++) {
+                if (it->name == str) return true;   
+            }
+            return false;
+        }
+
+        bool isDest(std::string str) { /* Note this is only used during init so doesn't need to be fast */
+            for (std::set<EndpointInfo>::iterator it = destEndpointInfo.begin(); it != destEndpointInfo.end(); it++) {
+                if (it->name == str) return true;   
+            }
+            return false;
+        }
+
+    protected:
+        void nicInit(SST::Interfaces::SimpleNetwork * linkcontrol, unsigned int phase);
+        bool initMsgSent;
+
+        // Data structures
+        std::unordered_map<std::string,uint64_t> networkAddressMap; // Map of name -> address for each network endpoint
+        
+        // Init queues
+        std::queue<MemRtrEvent*> initQueue; // Queue for received init events
+        std::queue<SST::Interfaces::SimpleNetwork::Request*> initSendQueue; // Queue of events waiting to be sent after network (linkcontrol) initializes
+};
+/***** End MemHierarchy::MemNICBase *****/
+
+
 
 /*
  *  MemNIC provides a simpleNetwork (from SST core) network interface for memory components
@@ -42,15 +149,14 @@ namespace MemHierarchy {
  *  each endpoint communicates with a subset of endpoints on the network as defined by "sources"
  *  and "destinations".
  *
+ *  MemNICBase handles init and managing the endpoint information/address lookup
+ *
  */
-class MemNIC : public MemLinkBase {
+class MemNIC : public MemNICBase {
 
 public:
 /* Element Library Info */
-#define MEMNIC_ELI_PARAMS MEMLINKBASE_ELI_PARAMS, \
-        { "group",                       "(int) Group ID. See params 'sources' and 'destinations'. If not specified, the parent component will guess.", "1"},\
-        { "sources",                     "(comma-separated list of ints) List of group IDs that serve as sources for this component. If not specified, defaults to 'group - 1'.", "group-1"},\
-        { "destinations",                "(comma-separated list of ints) List of group IDs that serve as destinations for this component. If not specified, defaults to 'group + 1'.", "group+1"},\
+#define MEMNIC_ELI_PARAMS MEMNICBASE_ELI_PARAMS, \
         { "network_bw",                  "(string) Network bandwidth", "80GiB/s" },\
         { "network_input_buffer_size",   "(string) Size of input buffer", "1KiB"},\
         { "network_output_buffer_size",  "(string) Size of output buffer", "1KiB"},\
@@ -62,6 +168,8 @@ public:
             "Memory-oriented network interface", "SST::MemLinkBase")
 
     SST_ELI_DOCUMENT_PARAMS( MEMNIC_ELI_PARAMS )
+
+    SST_ELI_DOCUMENT_PORTS( {"port", "Link to network", { "memHierarchy.MemRtrEvent" } } )
 
 /* Begin class definition */    
     /* Constructor */
@@ -80,94 +188,24 @@ public:
 
     /* Helper functions */
     size_t getSizeInBits(MemEventBase * ev);
-    uint64_t lookupNetworkAddress(const std::string &dst) const;
 
     /* Initialization and finish */
     void init(unsigned int phase);
-    void sendInitData(MemEventInit * ev);
-    MemEventInit* recvInitData();
     void finish() { link_control->finish(); }
     void setup() { link_control->setup(); MemLinkBase::setup(); }
 
-    // Router events
-    class MemRtrEvent : public SST::Event {
-        public:
-            MemEventBase * event;
-            MemRtrEvent() : Event(), event(nullptr) { }
-            MemRtrEvent(MemEventBase * ev) : Event(), event(ev) { }
-
-            virtual Event* clone(void) override {
-                MemRtrEvent *mre = new MemRtrEvent(*this);
-                mre->event = this->event->clone();
-                return mre;
-            }
-
-            virtual bool hasClientData() const { return true; }
-
-            void serialize_order(SST::Core::Serialization::serializer &ser) override {
-                Event::serialize_order(ser);
-                ser & event;
-            }
-
-            ImplementSerializable(SST::MemHierarchy::MemNIC::MemRtrEvent);
-    };
-
-    class InitMemRtrEvent : public MemRtrEvent {
-        public:
-        EndpointInfo info;
-
-        InitMemRtrEvent() {}
-        InitMemRtrEvent(EndpointInfo info) : MemRtrEvent(), info(info) { }
-        
-        virtual Event* clone(void) override {
-            return new InitMemRtrEvent(*this);
-        }
-
-        virtual bool hasClientData() const override { return false; }
-
-        void serialize_order(SST::Core::Serialization::serializer & ser) override {
-            MemRtrEvent::serialize_order(ser);
-            ser & info.name;
-            ser & info.addr;
-            ser & info.id;
-            ser & info.node;
-            ser & info.region.start;
-            ser & info.region.end;
-            ser & info.region.interleaveSize;
-            ser & info.region.interleaveStep;
-        }
-
-        ImplementSerializable(SST::MemHierarchy::MemNIC::InitMemRtrEvent);
-    };
-    
-    bool isSource(std::string str) { /* Note this is only used during init so doesn't need to be fast */
-        for (std::set<EndpointInfo>::iterator it = sourceEndpointInfo.begin(); it != sourceEndpointInfo.end(); it++) {
-            if (it->name == str) return true;   
-        }
-        return false;
-    }
-    bool isDest(std::string str) { /* Note this is only used during init so doesn't need to be fast */
-        for (std::set<EndpointInfo>::iterator it = destEndpointInfo.begin(); it != destEndpointInfo.end(); it++) {
-            if (it->name == str) return true;   
-        }
-        return false;
-    }
+    /* Debug */
+    void printStatus(Output &out);
 
 private:
 
     // Other parameters
     size_t packetHeaderBytes;
-    bool initMsgSent;
 
     // Handlers and network
     SST::Interfaces::SimpleNetwork *link_control;
 
-    // Data structures
-    std::unordered_map<std::string,uint64_t> networkAddressMap;         // Map of name -> address for each network endpoint
-
     // Event queues
-    std::queue<MemRtrEvent*> initQueue; // Queue for received init events
-    std::queue<SST::Interfaces::SimpleNetwork::Request*> initSendQueue; // Queue of events waiting to be sent. Sent after merlin initializes
     std::queue<SST::Interfaces::SimpleNetwork::Request*> sendQueue; // Queue of events waiting to be sent (sent on clock)
 };
 

--- a/src/sst/elements/memHierarchy/memoryController.h
+++ b/src/sst/elements/memHierarchy/memoryController.h
@@ -123,6 +123,7 @@ protected:
 
     virtual bool clock( SST::Cycle_t );
 
+    Output out;
     Output dbg;
     std::set<Addr> DEBUG_ADDR;
 
@@ -154,6 +155,10 @@ protected:
     TimeConverter* clockTimeBase_;
     
     CustomCmdMemHandler * customCommandHandler_;
+
+    /* Debug -triggered by output.fatal() and/or SIGUSR2 */
+    virtual void printStatus(Output &out);
+    virtual void emergencyShutdown();
 
 private:
     

--- a/src/sst/elements/memHierarchy/mshr.cc
+++ b/src/sst/elements/memHierarchy/mshr.cc
@@ -508,6 +508,23 @@ void MSHR::printTable() {
     }
 }*/
 
+void MSHR::printStatus(Output &out) {
+    out.output("    MSHR Status for %s. Size: %u. Prefetches: %u\n", ownerName_.c_str(), size_, prefetchCount_);
+    for (mshrTable::iterator it = map_.begin(); it != map_.end(); it++) {
+        vector<mshrType> entries = (it->second).mshrQueue;
+        out.output("      Entry: Addr = 0x%" PRIx64 " Acks needed: %d\n", (it->first), it->second.acksNeeded);
+        for (vector<mshrType>::iterator it2 = entries.begin(); it2 != entries.end(); it2++) {
+            if (it2->elem.isAddr()) {
+                Addr ptr = (it2->elem).getAddr();
+                out.output("        0x%" PRIx64 "\n", ptr);
+            } else {
+                MemEvent * ev = (it2->elem).getEvent();
+                out.output("        %s\n", ev->getVerboseString().c_str());
+            }
+        }
+    }
+    out.output("    End MSHR Status for %s\n", ownerName_.c_str());
+}
 
 
 

--- a/src/sst/elements/memHierarchy/mshr.h
+++ b/src/sst/elements/memHierarchy/mshr.h
@@ -122,7 +122,9 @@ public:
     bool insert(Addr keyAddr, Addr ptrAddr);         // internal
     bool insertInv(Addr baseAddr, mshrType entry, bool inProgress);         // internal
     bool removeElement(Addr baseAddr, mshrType entry);  // internal
-    
+
+    // debug
+    void printStatus(Output& out);
 
     // unimplemented or unused functions
     void printEntry(Addr baseAddr);                         // not implemented

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendChaining.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendChaining.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 523675; SumSQ.u64 = 5191023; Count.u64 = 53328; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 523675; SumSQ.u64 = 5191023; Count.u64 = 53792; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 694; SumSQ.u64 = 694; Count.u64 = 694; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 500373; SumSQ.u64 = 4949833; Count.u64 = 52587; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 500373; SumSQ.u64 = 4949833; Count.u64 = 53792; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 688; SumSQ.u64 = 688; Count.u64 = 688; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 48; SumSQ.u64 = 48; Count.u64 = 48; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 49; SumSQ.u64 = 49; Count.u64 = 49; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 739945; SumSQ.u64 = 10626863; Count.u64 = 53330; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 739945; SumSQ.u64 = 10626863; Count.u64 = 53792; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 408; SumSQ.u64 = 408; Count.u64 = 408; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 517351; SumSQ.u64 = 5123867; Count.u64 = 52857; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 517351; SumSQ.u64 = 5123867; Count.u64 = 53792; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 687; SumSQ.u64 = 687; Count.u64 = 687; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 42; SumSQ.u64 = 42; Count.u64 = 42; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 52; SumSQ.u64 = 52; Count.u64 = 52; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 736888; SumSQ.u64 = 10429102; Count.u64 = 53791; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 736888; SumSQ.u64 = 10429102; Count.u64 = 53792; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 375; SumSQ.u64 = 375; Count.u64 = 375; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (57928 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1402764; SumSQ.u64 = 37771622; Count.u64 = 53789; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1402764; SumSQ.u64 = 37771622; Count.u64 = 53792; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2465; SumSQ.u64 = 2465; Count.u64 = 2465; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendChaining_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendChaining_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 523675; SumSQ.u64 = 5191023; Count.u64 = 53328; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 523675; SumSQ.u64 = 5191023; Count.u64 = 53792; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 694; SumSQ.u64 = 694; Count.u64 = 694; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 500373; SumSQ.u64 = 4949833; Count.u64 = 52587; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 500373; SumSQ.u64 = 4949833; Count.u64 = 53792; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 688; SumSQ.u64 = 688; Count.u64 = 688; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 48; SumSQ.u64 = 48; Count.u64 = 48; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 49; SumSQ.u64 = 49; Count.u64 = 49; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 739945; SumSQ.u64 = 10626863; Count.u64 = 53330; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 739945; SumSQ.u64 = 10626863; Count.u64 = 53792; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 408; SumSQ.u64 = 408; Count.u64 = 408; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 517351; SumSQ.u64 = 5123867; Count.u64 = 52857; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 517351; SumSQ.u64 = 5123867; Count.u64 = 53792; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 687; SumSQ.u64 = 687; Count.u64 = 687; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 42; SumSQ.u64 = 42; Count.u64 = 42; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 52; SumSQ.u64 = 52; Count.u64 = 52; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 736888; SumSQ.u64 = 10429102; Count.u64 = 53791; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 736888; SumSQ.u64 = 10429102; Count.u64 = 53792; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 375; SumSQ.u64 = 375; Count.u64 = 375; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (58367 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1402764; SumSQ.u64 = 37771622; Count.u64 = 53789; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1402764; SumSQ.u64 = 37771622; Count.u64 = 53792; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2465; SumSQ.u64 = 2465; Count.u64 = 2465; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendDelayBuffer.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendDelayBuffer.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9000814; SumSQ.u64 = 87576740; Count.u64 = 940849; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9000814; SumSQ.u64 = 87576740; Count.u64 = 945120; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 711; SumSQ.u64 = 711; Count.u64 = 711; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9136255; SumSQ.u64 = 88897325; Count.u64 = 945117; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9136255; SumSQ.u64 = 88897325; Count.u64 = 945120; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 676; SumSQ.u64 = 676; Count.u64 = 676; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 36; SumSQ.u64 = 36; Count.u64 = 36; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 39; SumSQ.u64 = 39; Count.u64 = 39; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13689120; SumSQ.u64 = 202359498; Count.u64 = 945112; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13689120; SumSQ.u64 = 202359498; Count.u64 = 945120; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 372; SumSQ.u64 = 372; Count.u64 = 372; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9068908; SumSQ.u64 = 88382876; Count.u64 = 937341; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9068908; SumSQ.u64 = 88382876; Count.u64 = 945120; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 711; SumSQ.u64 = 711; Count.u64 = 711; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8879428; SumSQ.u64 = 86245380; Count.u64 = 923968; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8879428; SumSQ.u64 = 86245380; Count.u64 = 945120; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 705; SumSQ.u64 = 705; Count.u64 = 705; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 39; SumSQ.u64 = 39; Count.u64 = 39; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 42; SumSQ.u64 = 42; Count.u64 = 42; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13829626; SumSQ.u64 = 208324490; Count.u64 = 943477; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13829626; SumSQ.u64 = 208324490; Count.u64 = 945120; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 361; SumSQ.u64 = 361; Count.u64 = 361; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (460608 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 27320842; SumSQ.u64 = 803238220; Count.u64 = 945106; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 27320842; SumSQ.u64 = 803238220; Count.u64 = 945120; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2487; SumSQ.u64 = 2487; Count.u64 = 2487; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendDelayBuffer_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendDelayBuffer_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9000814; SumSQ.u64 = 87576740; Count.u64 = 940849; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9000814; SumSQ.u64 = 87576740; Count.u64 = 945120; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 711; SumSQ.u64 = 711; Count.u64 = 711; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9136255; SumSQ.u64 = 88897325; Count.u64 = 945117; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9136255; SumSQ.u64 = 88897325; Count.u64 = 945120; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 676; SumSQ.u64 = 676; Count.u64 = 676; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 36; SumSQ.u64 = 36; Count.u64 = 36; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 39; SumSQ.u64 = 39; Count.u64 = 39; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13689120; SumSQ.u64 = 202359498; Count.u64 = 945112; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13689120; SumSQ.u64 = 202359498; Count.u64 = 945120; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 372; SumSQ.u64 = 372; Count.u64 = 372; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9068908; SumSQ.u64 = 88382876; Count.u64 = 937341; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9068908; SumSQ.u64 = 88382876; Count.u64 = 945120; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 711; SumSQ.u64 = 711; Count.u64 = 711; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8879428; SumSQ.u64 = 86245380; Count.u64 = 923968; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8879428; SumSQ.u64 = 86245380; Count.u64 = 945120; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 705; SumSQ.u64 = 705; Count.u64 = 705; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 39; SumSQ.u64 = 39; Count.u64 = 39; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 42; SumSQ.u64 = 42; Count.u64 = 42; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13829626; SumSQ.u64 = 208324490; Count.u64 = 943477; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13829626; SumSQ.u64 = 208324490; Count.u64 = 945120; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 361; SumSQ.u64 = 361; Count.u64 = 361; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (466656 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 27320842; SumSQ.u64 = 803238220; Count.u64 = 945106; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 27320842; SumSQ.u64 = 803238220; Count.u64 = 945120; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2487; SumSQ.u64 = 2487; Count.u64 = 2487; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendGoblinHMC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendGoblinHMC.out
@@ -35,7 +35,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9235684; SumSQ.u64 = 90358004; Count.u64 = 948048; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9235684; SumSQ.u64 = 90358004; Count.u64 = 948052; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -160,7 +160,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9171887; SumSQ.u64 = 89571485; Count.u64 = 944304; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9171887; SumSQ.u64 = 89571485; Count.u64 = 948052; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -285,7 +285,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18226050; SumSQ.u64 = 352211328; Count.u64 = 948006; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18226050; SumSQ.u64 = 352211328; Count.u64 = 948052; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -475,7 +475,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9104119; SumSQ.u64 = 88712123; Count.u64 = 939984; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9104119; SumSQ.u64 = 88712123; Count.u64 = 948052; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -600,7 +600,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9194767; SumSQ.u64 = 89748557; Count.u64 = 947184; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9194767; SumSQ.u64 = 89748557; Count.u64 = 948052; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -725,7 +725,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18095223; SumSQ.u64 = 348118327; Count.u64 = 947142; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18095223; SumSQ.u64 = 348118327; Count.u64 = 948052; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -919,7 +919,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35885303; SumSQ.u64 = 1365861541; Count.u64 = 947962; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35885303; SumSQ.u64 = 1365861541; Count.u64 = 948052; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendGoblinHMC_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendGoblinHMC_MC.out
@@ -2,10 +2,10 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (474026 clocks)
-TrivialCPU cpu1 Finished after 1000 issued reads, 1000 returned (472154 clocks)
-TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (469994 clocks)
 TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
+TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (469994 clocks)
+TrivialCPU cpu1 Finished after 1000 issued reads, 1000 returned (472154 clocks)
+TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (474026 clocks)
  c0.l1cache.TotalEventsReceived : Accumulator : Sum.u64 = 1999; SumSQ.u64 = 1999; Count.u64 = 1999; 
  c0.l1cache.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -35,7 +35,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9235684; SumSQ.u64 = 90358004; Count.u64 = 948048; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9235684; SumSQ.u64 = 90358004; Count.u64 = 948052; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -160,7 +160,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9171887; SumSQ.u64 = 89571485; Count.u64 = 944304; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9171887; SumSQ.u64 = 89571485; Count.u64 = 948052; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -285,7 +285,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18226050; SumSQ.u64 = 352211328; Count.u64 = 948006; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18226050; SumSQ.u64 = 352211328; Count.u64 = 948052; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -475,7 +475,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9104119; SumSQ.u64 = 88712123; Count.u64 = 939984; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9104119; SumSQ.u64 = 88712123; Count.u64 = 948052; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -600,7 +600,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9194767; SumSQ.u64 = 89748557; Count.u64 = 947184; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9194767; SumSQ.u64 = 89748557; Count.u64 = 948052; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -725,7 +725,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18095223; SumSQ.u64 = 348118327; Count.u64 = 947142; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18095223; SumSQ.u64 = 348118327; Count.u64 = 948052; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -919,7 +919,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (473594 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35885303; SumSQ.u64 = 1365861541; Count.u64 = 947962; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35885303; SumSQ.u64 = 1365861541; Count.u64 = 948052; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendPagedMulti.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendPagedMulti.out
@@ -39,7 +39,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 29862394; SumSQ.u64 = 270498868; Count.u64 = 3379842; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 29862394; SumSQ.u64 = 270498868; Count.u64 = 3379844; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 8370; SumSQ.u64 = 8370; Count.u64 = 8370; 
@@ -171,7 +171,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 11; SumSQ.u64 = 11; Count.u64 = 11; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9186046; SumSQ.u64 = 89307300; Count.u64 = 1777460; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9186046; SumSQ.u64 = 89307300; Count.u64 = 3379844; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 701; SumSQ.u64 = 701; Count.u64 = 701; 
@@ -303,7 +303,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 71; SumSQ.u64 = 71; Count.u64 = 71; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 29899741; SumSQ.u64 = 319335217; Count.u64 = 3379837; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 29899741; SumSQ.u64 = 319335217; Count.u64 = 3379844; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 5050; SumSQ.u64 = 5050; Count.u64 = 5050; 
@@ -540,7 +540,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9146379; SumSQ.u64 = 88973675; Count.u64 = 2505645; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9146379; SumSQ.u64 = 88973675; Count.u64 = 3379844; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 702; SumSQ.u64 = 702; Count.u64 = 702; 
@@ -672,7 +672,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 19; SumSQ.u64 = 19; Count.u64 = 19; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9179841; SumSQ.u64 = 89284149; Count.u64 = 2374921; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9179841; SumSQ.u64 = 89284149; Count.u64 = 3379844; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 688; SumSQ.u64 = 688; Count.u64 = 688; 
@@ -804,7 +804,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 65; SumSQ.u64 = 65; Count.u64 = 65; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 84; SumSQ.u64 = 84; Count.u64 = 84; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13953981; SumSQ.u64 = 207857759; Count.u64 = 2523077; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13953981; SumSQ.u64 = 207857759; Count.u64 = 3379844; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 363; SumSQ.u64 = 363; Count.u64 = 363; 
@@ -1045,7 +1045,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (476218 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 43580868; SumSQ.u64 = 934050688; Count.u64 = 3379831; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 43580868; SumSQ.u64 = 934050688; Count.u64 = 3379844; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 10026; SumSQ.u64 = 10026; Count.u64 = 10026; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendPagedMulti_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendPagedMulti_MC.out
@@ -39,7 +39,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 29862394; SumSQ.u64 = 270498868; Count.u64 = 3379842; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 29862394; SumSQ.u64 = 270498868; Count.u64 = 3379844; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 8370; SumSQ.u64 = 8370; Count.u64 = 8370; 
@@ -171,7 +171,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 11; SumSQ.u64 = 11; Count.u64 = 11; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9186046; SumSQ.u64 = 89307300; Count.u64 = 1777460; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9186046; SumSQ.u64 = 89307300; Count.u64 = 3379844; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 701; SumSQ.u64 = 701; Count.u64 = 701; 
@@ -303,7 +303,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 71; SumSQ.u64 = 71; Count.u64 = 71; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 29899741; SumSQ.u64 = 319335217; Count.u64 = 3379837; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 29899741; SumSQ.u64 = 319335217; Count.u64 = 3379844; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 5050; SumSQ.u64 = 5050; Count.u64 = 5050; 
@@ -540,7 +540,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9146379; SumSQ.u64 = 88973675; Count.u64 = 2505645; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9146379; SumSQ.u64 = 88973675; Count.u64 = 3379844; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 702; SumSQ.u64 = 702; Count.u64 = 702; 
@@ -672,7 +672,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 19; SumSQ.u64 = 19; Count.u64 = 19; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9179841; SumSQ.u64 = 89284149; Count.u64 = 2374921; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9179841; SumSQ.u64 = 89284149; Count.u64 = 3379844; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 688; SumSQ.u64 = 688; Count.u64 = 688; 
@@ -804,7 +804,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 65; SumSQ.u64 = 65; Count.u64 = 65; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 84; SumSQ.u64 = 84; Count.u64 = 84; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13953981; SumSQ.u64 = 207857759; Count.u64 = 2523077; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13953981; SumSQ.u64 = 207857759; Count.u64 = 3379844; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 363; SumSQ.u64 = 363; Count.u64 = 363; 
@@ -1045,7 +1045,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (1689922 clock
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 43580868; SumSQ.u64 = 934050688; Count.u64 = 3379831; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 43580868; SumSQ.u64 = 934050688; Count.u64 = 3379844; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 10026; SumSQ.u64 = 10026; Count.u64 = 10026; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderRow.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderRow.out
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487777; SumSQ.u64 = 4828061; Count.u64 = 50527; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487777; SumSQ.u64 = 4828061; Count.u64 = 51685; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 677; SumSQ.u64 = 677; Count.u64 = 677; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 713479; SumSQ.u64 = 10167863; Count.u64 = 51684; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 713479; SumSQ.u64 = 10167863; Count.u64 = 51685; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 359; SumSQ.u64 = 359; Count.u64 = 359; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 508390; SumSQ.u64 = 5036800; Count.u64 = 51514; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 508390; SumSQ.u64 = 5036800; Count.u64 = 51685; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 689; SumSQ.u64 = 689; Count.u64 = 689; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487885; SumSQ.u64 = 4826743; Count.u64 = 51180; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487885; SumSQ.u64 = 4826743; Count.u64 = 51685; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 691; SumSQ.u64 = 691; Count.u64 = 691; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 34; SumSQ.u64 = 34; Count.u64 = 34; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 708291; SumSQ.u64 = 10048565; Count.u64 = 51547; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 708291; SumSQ.u64 = 10048565; Count.u64 = 51685; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 385; SumSQ.u64 = 385; Count.u64 = 385; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (54850 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1347119; SumSQ.u64 = 36167103; Count.u64 = 51682; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1347119; SumSQ.u64 = 36167103; Count.u64 = 51685; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2476; SumSQ.u64 = 2476; Count.u64 = 2476; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderRow_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderRow_MC.out
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487777; SumSQ.u64 = 4828061; Count.u64 = 50527; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487777; SumSQ.u64 = 4828061; Count.u64 = 51685; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 677; SumSQ.u64 = 677; Count.u64 = 677; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 713479; SumSQ.u64 = 10167863; Count.u64 = 51684; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 713479; SumSQ.u64 = 10167863; Count.u64 = 51685; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 359; SumSQ.u64 = 359; Count.u64 = 359; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 508390; SumSQ.u64 = 5036800; Count.u64 = 51514; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 508390; SumSQ.u64 = 5036800; Count.u64 = 51685; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 689; SumSQ.u64 = 689; Count.u64 = 689; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487885; SumSQ.u64 = 4826743; Count.u64 = 51180; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 487885; SumSQ.u64 = 4826743; Count.u64 = 51685; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 691; SumSQ.u64 = 691; Count.u64 = 691; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 34; SumSQ.u64 = 34; Count.u64 = 34; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 45; SumSQ.u64 = 45; Count.u64 = 45; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 708291; SumSQ.u64 = 10048565; Count.u64 = 51547; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 708291; SumSQ.u64 = 10048565; Count.u64 = 51685; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 385; SumSQ.u64 = 385; Count.u64 = 385; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (56797 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1347119; SumSQ.u64 = 36167103; Count.u64 = 51682; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 1347119; SumSQ.u64 = 36167103; Count.u64 = 51685; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 2476; SumSQ.u64 = 2476; Count.u64 = 2476; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderSimple.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderSimple.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 16570301; SumSQ.u64 = 158502847; Count.u64 = 1746298; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 16570301; SumSQ.u64 = 158502847; Count.u64 = 1746300; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 3224; SumSQ.u64 = 3224; Count.u64 = 3224; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9170219; SumSQ.u64 = 89300699; Count.u64 = 1682406; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9170219; SumSQ.u64 = 89300699; Count.u64 = 1746300; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 684; SumSQ.u64 = 684; Count.u64 = 684; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 57; SumSQ.u64 = 57; Count.u64 = 57; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 85; SumSQ.u64 = 85; Count.u64 = 85; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 19392191; SumSQ.u64 = 245478939; Count.u64 = 1746295; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 19392191; SumSQ.u64 = 245478939; Count.u64 = 1746300; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 1830; SumSQ.u64 = 1830; Count.u64 = 1830; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8841327; SumSQ.u64 = 85885469; Count.u64 = 1717829; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8841327; SumSQ.u64 = 85885469; Count.u64 = 1746300; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 697; SumSQ.u64 = 697; Count.u64 = 697; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8877426; SumSQ.u64 = 86191408; Count.u64 = 1666475; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8877426; SumSQ.u64 = 86191408; Count.u64 = 1746300; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 691; SumSQ.u64 = 691; Count.u64 = 691; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 74; SumSQ.u64 = 74; Count.u64 = 74; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13736480; SumSQ.u64 = 207935768; Count.u64 = 1735152; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13736480; SumSQ.u64 = 207935768; Count.u64 = 1746300; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 370; SumSQ.u64 = 370; Count.u64 = 370; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (461526 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 32994349; SumSQ.u64 = 851428461; Count.u64 = 1746291; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 32994349; SumSQ.u64 = 851428461; Count.u64 = 1746300; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 4974; SumSQ.u64 = 4974; Count.u64 = 4974; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderSimple_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendReorderSimple_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 16570301; SumSQ.u64 = 158502847; Count.u64 = 1746298; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 16570301; SumSQ.u64 = 158502847; Count.u64 = 1746300; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 3224; SumSQ.u64 = 3224; Count.u64 = 3224; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9170219; SumSQ.u64 = 89300699; Count.u64 = 1682406; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9170219; SumSQ.u64 = 89300699; Count.u64 = 1746300; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 684; SumSQ.u64 = 684; Count.u64 = 684; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 57; SumSQ.u64 = 57; Count.u64 = 57; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 85; SumSQ.u64 = 85; Count.u64 = 85; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 19392191; SumSQ.u64 = 245478939; Count.u64 = 1746295; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 19392191; SumSQ.u64 = 245478939; Count.u64 = 1746300; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 1830; SumSQ.u64 = 1830; Count.u64 = 1830; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8841327; SumSQ.u64 = 85885469; Count.u64 = 1717829; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8841327; SumSQ.u64 = 85885469; Count.u64 = 1746300; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 697; SumSQ.u64 = 697; Count.u64 = 697; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8877426; SumSQ.u64 = 86191408; Count.u64 = 1666475; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 8877426; SumSQ.u64 = 86191408; Count.u64 = 1746300; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 691; SumSQ.u64 = 691; Count.u64 = 691; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 74; SumSQ.u64 = 74; Count.u64 = 74; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13736480; SumSQ.u64 = 207935768; Count.u64 = 1735152; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 13736480; SumSQ.u64 = 207935768; Count.u64 = 1746300; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 370; SumSQ.u64 = 370; Count.u64 = 370; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 4000 issued reads, 4000 returned (873150 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 32994349; SumSQ.u64 = 851428461; Count.u64 = 1746291; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 32994349; SumSQ.u64 = 851428461; Count.u64 = 1746300; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 4974; SumSQ.u64 = 4974; Count.u64 = 4974; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_1.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 30; SumSQ.u64 = 30; Count.u64 = 30; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20228771; SumSQ.u64 = 201925921; Count.u64 = 2029066; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20228771; SumSQ.u64 = 201925921; Count.u64 = 2029069; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1665; SumSQ.u64 = 1665; Count.u64 = 1665; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 23; SumSQ.u64 = 23; Count.u64 = 23; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20241020; SumSQ.u64 = 202092480; Count.u64 = 2028490; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20241020; SumSQ.u64 = 202092480; Count.u64 = 2029069; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1669; SumSQ.u64 = 1669; Count.u64 = 1669; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 101; SumSQ.u64 = 101; Count.u64 = 101; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 40094326; SumSQ.u64 = 793355424; Count.u64 = 2029025; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 40094326; SumSQ.u64 = 793355424; Count.u64 = 2029069; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 2861; SumSQ.u64 = 2861; Count.u64 = 2861; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20182903; SumSQ.u64 = 201569295; Count.u64 = 2022445; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20182903; SumSQ.u64 = 201569295; Count.u64 = 2029069; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1645; SumSQ.u64 = 1645; Count.u64 = 1645; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 19932407; SumSQ.u64 = 198637781; Count.u64 = 2010171; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 19932407; SumSQ.u64 = 198637781; Count.u64 = 2029069; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1646; SumSQ.u64 = 1646; Count.u64 = 1646; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39746086; SumSQ.u64 = 784309920; Count.u64 = 2022404; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39746086; SumSQ.u64 = 784309920; Count.u64 = 2029069; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 2826; SumSQ.u64 = 2826; Count.u64 = 2826; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1703850 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 78939195; SumSQ.u64 = 3079908801; Count.u64 = 2028983; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 78939195; SumSQ.u64 = 3079908801; Count.u64 = 2029069; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 5812; SumSQ.u64 = 5812; Count.u64 = 5812; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_1_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 30; SumSQ.u64 = 30; Count.u64 = 30; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20228771; SumSQ.u64 = 201925921; Count.u64 = 2029066; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20228771; SumSQ.u64 = 201925921; Count.u64 = 2029069; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1665; SumSQ.u64 = 1665; Count.u64 = 1665; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 23; SumSQ.u64 = 23; Count.u64 = 23; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20241020; SumSQ.u64 = 202092480; Count.u64 = 2028490; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20241020; SumSQ.u64 = 202092480; Count.u64 = 2029069; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1669; SumSQ.u64 = 1669; Count.u64 = 1669; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 101; SumSQ.u64 = 101; Count.u64 = 101; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 40094326; SumSQ.u64 = 793355424; Count.u64 = 2029025; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 40094326; SumSQ.u64 = 793355424; Count.u64 = 2029069; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 2861; SumSQ.u64 = 2861; Count.u64 = 2861; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20182903; SumSQ.u64 = 201569295; Count.u64 = 2022445; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 20182903; SumSQ.u64 = 201569295; Count.u64 = 2029069; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1645; SumSQ.u64 = 1645; Count.u64 = 1645; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 19932407; SumSQ.u64 = 198637781; Count.u64 = 2010171; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 19932407; SumSQ.u64 = 198637781; Count.u64 = 2029069; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1646; SumSQ.u64 = 1646; Count.u64 = 1646; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39746086; SumSQ.u64 = 784309920; Count.u64 = 2022404; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39746086; SumSQ.u64 = 784309920; Count.u64 = 2029069; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 2826; SumSQ.u64 = 2826; Count.u64 = 2826; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (2029069 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 78939195; SumSQ.u64 = 3079908801; Count.u64 = 2028983; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 78939195; SumSQ.u64 = 3079908801; Count.u64 = 2029069; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 5812; SumSQ.u64 = 5812; Count.u64 = 5812; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_2.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 20; SumSQ.u64 = 20; Count.u64 = 20; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31470241; SumSQ.u64 = 310675965; Count.u64 = 3193610; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31470241; SumSQ.u64 = 310675965; Count.u64 = 3193614; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1675; SumSQ.u64 = 1675; Count.u64 = 1675; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 23; SumSQ.u64 = 23; Count.u64 = 23; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31374963; SumSQ.u64 = 309751459; Count.u64 = 3184682; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31374963; SumSQ.u64 = 309751459; Count.u64 = 3193614; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1666; SumSQ.u64 = 1666; Count.u64 = 1666; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62414452; SumSQ.u64 = 1222602480; Count.u64 = 3193569; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62414452; SumSQ.u64 = 1222602480; Count.u64 = 3193614; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 2853; SumSQ.u64 = 2853; Count.u64 = 2853; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31349872; SumSQ.u64 = 309460984; Count.u64 = 3182378; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31349872; SumSQ.u64 = 309460984; Count.u64 = 3193614; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1658; SumSQ.u64 = 1658; Count.u64 = 1658; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 24; SumSQ.u64 = 24; Count.u64 = 24; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31223396; SumSQ.u64 = 308118204; Count.u64 = 3172874; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31223396; SumSQ.u64 = 308118204; Count.u64 = 3193614; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1652; SumSQ.u64 = 1652; Count.u64 = 1652; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 93; SumSQ.u64 = 93; Count.u64 = 93; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62180147; SumSQ.u64 = 1218218059; Count.u64 = 3182337; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62180147; SumSQ.u64 = 1218218059; Count.u64 = 3193614; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 2824; SumSQ.u64 = 2824; Count.u64 = 2824; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 2000 issued reads, 2000 returned (1586439 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 123520552; SumSQ.u64 = 4793299104; Count.u64 = 3193524; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 123520552; SumSQ.u64 = 4793299104; Count.u64 = 3193614; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 5823; SumSQ.u64 = 5823; Count.u64 = 5823; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_2_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendSimpleDRAM_2_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 20; SumSQ.u64 = 20; Count.u64 = 20; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31470241; SumSQ.u64 = 310675965; Count.u64 = 3193610; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31470241; SumSQ.u64 = 310675965; Count.u64 = 3193614; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1675; SumSQ.u64 = 1675; Count.u64 = 1675; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 23; SumSQ.u64 = 23; Count.u64 = 23; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31374963; SumSQ.u64 = 309751459; Count.u64 = 3184682; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31374963; SumSQ.u64 = 309751459; Count.u64 = 3193614; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1666; SumSQ.u64 = 1666; Count.u64 = 1666; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62414452; SumSQ.u64 = 1222602480; Count.u64 = 3193569; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62414452; SumSQ.u64 = 1222602480; Count.u64 = 3193614; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 2853; SumSQ.u64 = 2853; Count.u64 = 2853; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31349872; SumSQ.u64 = 309460984; Count.u64 = 3182378; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31349872; SumSQ.u64 = 309460984; Count.u64 = 3193614; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1658; SumSQ.u64 = 1658; Count.u64 = 1658; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 24; SumSQ.u64 = 24; Count.u64 = 24; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31223396; SumSQ.u64 = 308118204; Count.u64 = 3172874; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 31223396; SumSQ.u64 = 308118204; Count.u64 = 3193614; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1652; SumSQ.u64 = 1652; Count.u64 = 1652; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 93; SumSQ.u64 = 93; Count.u64 = 93; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62180147; SumSQ.u64 = 1218218059; Count.u64 = 3182337; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 62180147; SumSQ.u64 = 1218218059; Count.u64 = 3193614; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 2824; SumSQ.u64 = 2824; Count.u64 = 2824; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 2000 issued reads, 2000 returned (1596807 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 123520552; SumSQ.u64 = 4793299104; Count.u64 = 3193524; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 123520552; SumSQ.u64 = 4793299104; Count.u64 = 3193614; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 5823; SumSQ.u64 = 5823; Count.u64 = 5823; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_1.out
@@ -59,7 +59,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657591; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657599; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 32688; SumSQ.u64 = 32688; Count.u64 = 32688; 
@@ -296,7 +296,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10656446; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10657599; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1985; SumSQ.u64 = 1985; Count.u64 = 1985; 
@@ -428,7 +428,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  c0.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10656444; 
+ c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10657599; 
  c0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -665,7 +665,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10646434; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10657599; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1961; SumSQ.u64 = 1961; Count.u64 = 1961; 
@@ -797,7 +797,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 112; SumSQ.u64 = 112; Count.u64 = 112; 
  c1.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10646437; 
+ c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10657599; 
  c1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1034,7 +1034,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657598; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657599; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1927; SumSQ.u64 = 1927; Count.u64 = 1927; 
@@ -1166,7 +1166,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  c2.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c2.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657596; 
+ c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657599; 
  c2.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1403,7 +1403,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10651011; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10657599; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1975; SumSQ.u64 = 1975; Count.u64 = 1975; 
@@ -1535,7 +1535,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
  c3.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c3.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10651014; 
+ c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10657599; 
  c3.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1772,7 +1772,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 80; SumSQ.u64 = 80; Count.u64 = 80; 
  c4.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c4.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10650810; 
+ c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10657599; 
  c4.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_E : Accumulator : Sum.u64 = 1965; SumSQ.u64 = 1965; Count.u64 = 1965; 
@@ -1904,7 +1904,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  c4.l2cache.Inv_recv : Accumulator : Sum.u64 = 38; SumSQ.u64 = 38; Count.u64 = 38; 
  c4.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10650813; 
+ c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10657599; 
  c4.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2141,7 +2141,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c5.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10646115; 
+ c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10657599; 
  c5.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_E : Accumulator : Sum.u64 = 2070; SumSQ.u64 = 2070; Count.u64 = 2070; 
@@ -2273,7 +2273,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 118; SumSQ.u64 = 118; Count.u64 = 118; 
  c5.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c5.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10646118; 
+ c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10657599; 
  c5.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2510,7 +2510,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c6.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10631744; 
+ c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10657599; 
  c6.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_E : Accumulator : Sum.u64 = 2026; SumSQ.u64 = 2026; Count.u64 = 2026; 
@@ -2642,7 +2642,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 113; SumSQ.u64 = 113; Count.u64 = 113; 
  c6.l2cache.Inv_recv : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
  c6.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10631747; 
+ c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10657599; 
  c6.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2879,7 +2879,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  c7.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c7.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10656195; 
+ c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10657599; 
  c7.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_E : Accumulator : Sum.u64 = 2014; SumSQ.u64 = 2014; Count.u64 = 2014; 
@@ -3011,7 +3011,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 116; SumSQ.u64 = 116; Count.u64 = 116; 
  c7.l2cache.Inv_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
  c7.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10656198; 
+ c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10657599; 
  c7.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_2.out
@@ -59,7 +59,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657591; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657599; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 32688; SumSQ.u64 = 32688; Count.u64 = 32688; 
@@ -296,7 +296,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10656446; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10657599; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1985; SumSQ.u64 = 1985; Count.u64 = 1985; 
@@ -428,7 +428,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  c0.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10656444; 
+ c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10657599; 
  c0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -665,7 +665,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10646434; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10657599; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1961; SumSQ.u64 = 1961; Count.u64 = 1961; 
@@ -797,7 +797,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 112; SumSQ.u64 = 112; Count.u64 = 112; 
  c1.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10646437; 
+ c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10657599; 
  c1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1034,7 +1034,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657598; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657599; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1927; SumSQ.u64 = 1927; Count.u64 = 1927; 
@@ -1166,7 +1166,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  c2.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c2.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657596; 
+ c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657599; 
  c2.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1403,7 +1403,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10651011; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10657599; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1975; SumSQ.u64 = 1975; Count.u64 = 1975; 
@@ -1535,7 +1535,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
  c3.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c3.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10651014; 
+ c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10657599; 
  c3.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1772,7 +1772,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 80; SumSQ.u64 = 80; Count.u64 = 80; 
  c4.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c4.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10650810; 
+ c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10657599; 
  c4.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_E : Accumulator : Sum.u64 = 1965; SumSQ.u64 = 1965; Count.u64 = 1965; 
@@ -1904,7 +1904,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  c4.l2cache.Inv_recv : Accumulator : Sum.u64 = 38; SumSQ.u64 = 38; Count.u64 = 38; 
  c4.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10650813; 
+ c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10657599; 
  c4.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2141,7 +2141,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c5.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10646115; 
+ c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10657599; 
  c5.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_E : Accumulator : Sum.u64 = 2070; SumSQ.u64 = 2070; Count.u64 = 2070; 
@@ -2273,7 +2273,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 118; SumSQ.u64 = 118; Count.u64 = 118; 
  c5.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c5.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10646118; 
+ c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10657599; 
  c5.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2510,7 +2510,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c6.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10631744; 
+ c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10657599; 
  c6.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_E : Accumulator : Sum.u64 = 2026; SumSQ.u64 = 2026; Count.u64 = 2026; 
@@ -2642,7 +2642,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 113; SumSQ.u64 = 113; Count.u64 = 113; 
  c6.l2cache.Inv_recv : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
  c6.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10631747; 
+ c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10657599; 
  c6.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2879,7 +2879,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  c7.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c7.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10656195; 
+ c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10657599; 
  c7.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_E : Accumulator : Sum.u64 = 2014; SumSQ.u64 = 2014; Count.u64 = 2014; 
@@ -3011,7 +3011,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 116; SumSQ.u64 = 116; Count.u64 = 116; 
  c7.l2cache.Inv_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
  c7.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10656198; 
+ c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10657599; 
  c7.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_3.out
@@ -59,7 +59,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657591; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657599; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 32688; SumSQ.u64 = 32688; Count.u64 = 32688; 
@@ -296,7 +296,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10656446; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10657599; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1985; SumSQ.u64 = 1985; Count.u64 = 1985; 
@@ -428,7 +428,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  c0.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10656444; 
+ c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10657599; 
  c0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -665,7 +665,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10646434; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10657599; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1961; SumSQ.u64 = 1961; Count.u64 = 1961; 
@@ -797,7 +797,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 112; SumSQ.u64 = 112; Count.u64 = 112; 
  c1.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10646437; 
+ c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10657599; 
  c1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1034,7 +1034,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657598; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657599; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1927; SumSQ.u64 = 1927; Count.u64 = 1927; 
@@ -1166,7 +1166,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  c2.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c2.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657596; 
+ c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657599; 
  c2.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1403,7 +1403,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10651011; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10657599; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1975; SumSQ.u64 = 1975; Count.u64 = 1975; 
@@ -1535,7 +1535,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
  c3.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c3.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10651014; 
+ c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10657599; 
  c3.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1772,7 +1772,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 80; SumSQ.u64 = 80; Count.u64 = 80; 
  c4.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c4.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10650810; 
+ c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10657599; 
  c4.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_E : Accumulator : Sum.u64 = 1965; SumSQ.u64 = 1965; Count.u64 = 1965; 
@@ -1904,7 +1904,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  c4.l2cache.Inv_recv : Accumulator : Sum.u64 = 38; SumSQ.u64 = 38; Count.u64 = 38; 
  c4.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10650813; 
+ c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10657599; 
  c4.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2141,7 +2141,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c5.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10646115; 
+ c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10657599; 
  c5.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_E : Accumulator : Sum.u64 = 2070; SumSQ.u64 = 2070; Count.u64 = 2070; 
@@ -2273,7 +2273,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 118; SumSQ.u64 = 118; Count.u64 = 118; 
  c5.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c5.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10646118; 
+ c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10657599; 
  c5.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2510,7 +2510,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c6.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10631744; 
+ c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10657599; 
  c6.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_E : Accumulator : Sum.u64 = 2026; SumSQ.u64 = 2026; Count.u64 = 2026; 
@@ -2642,7 +2642,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 113; SumSQ.u64 = 113; Count.u64 = 113; 
  c6.l2cache.Inv_recv : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
  c6.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10631747; 
+ c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10657599; 
  c6.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2879,7 +2879,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  c7.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c7.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10656195; 
+ c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10657599; 
  c7.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_E : Accumulator : Sum.u64 = 2014; SumSQ.u64 = 2014; Count.u64 = 2014; 
@@ -3011,7 +3011,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 116; SumSQ.u64 = 116; Count.u64 = 116; 
  c7.l2cache.Inv_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
  c7.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10656198; 
+ c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10657599; 
  c7.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_4.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_4.out
@@ -59,7 +59,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657591; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 843460167; SumSQ.u64 = 66895021953; Count.u64 = 10657599; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 32688; SumSQ.u64 = 32688; Count.u64 = 32688; 
@@ -296,7 +296,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10656446; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106514840; SumSQ.u64 = 1064913560; Count.u64 = 10657599; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 1985; SumSQ.u64 = 1985; Count.u64 = 1985; 
@@ -428,7 +428,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  c0.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10656444; 
+ c0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105678960; SumSQ.u64 = 1049488994; Count.u64 = 10657599; 
  c0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -665,7 +665,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10646434; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106281404; SumSQ.u64 = 1062330238; Count.u64 = 10657599; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 1961; SumSQ.u64 = 1961; Count.u64 = 1961; 
@@ -797,7 +797,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 112; SumSQ.u64 = 112; Count.u64 = 112; 
  c1.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10646437; 
+ c1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105995611; SumSQ.u64 = 1057017429; Count.u64 = 10657599; 
  c1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1034,7 +1034,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657598; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106536195; SumSQ.u64 = 1065082713; Count.u64 = 10657599; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 1927; SumSQ.u64 = 1927; Count.u64 = 1927; 
@@ -1166,7 +1166,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c2.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  c2.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c2.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657596; 
+ c2.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105974622; SumSQ.u64 = 1054785010; Count.u64 = 10657599; 
  c2.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1403,7 +1403,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10651011; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105988092; SumSQ.u64 = 1059375888; Count.u64 = 10657599; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 1975; SumSQ.u64 = 1975; Count.u64 = 1975; 
@@ -1535,7 +1535,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c3.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
  c3.l2cache.Inv_recv : Accumulator : Sum.u64 = 29; SumSQ.u64 = 29; Count.u64 = 29; 
  c3.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10651014; 
+ c3.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105373169; SumSQ.u64 = 1048413415; Count.u64 = 10657599; 
  c3.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1772,7 +1772,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 80; SumSQ.u64 = 80; Count.u64 = 80; 
  c4.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c4.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10650810; 
+ c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105920663; SumSQ.u64 = 1058341997; Count.u64 = 10657599; 
  c4.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_E : Accumulator : Sum.u64 = 1965; SumSQ.u64 = 1965; Count.u64 = 1965; 
@@ -1904,7 +1904,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c4.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  c4.l2cache.Inv_recv : Accumulator : Sum.u64 = 38; SumSQ.u64 = 38; Count.u64 = 38; 
  c4.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10650813; 
+ c4.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105415955; SumSQ.u64 = 1048917501; Count.u64 = 10657599; 
  c4.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2141,7 +2141,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  c5.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10646115; 
+ c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106042927; SumSQ.u64 = 1059769673; Count.u64 = 10657599; 
  c5.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_E : Accumulator : Sum.u64 = 2070; SumSQ.u64 = 2070; Count.u64 = 2070; 
@@ -2273,7 +2273,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c5.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 118; SumSQ.u64 = 118; Count.u64 = 118; 
  c5.l2cache.Inv_recv : Accumulator : Sum.u64 = 31; SumSQ.u64 = 31; Count.u64 = 31; 
  c5.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10646118; 
+ c5.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105335448; SumSQ.u64 = 1046781042; Count.u64 = 10657599; 
  c5.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2510,7 +2510,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c6.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10631744; 
+ c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105399501; SumSQ.u64 = 1053225519; Count.u64 = 10657599; 
  c6.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_E : Accumulator : Sum.u64 = 2026; SumSQ.u64 = 2026; Count.u64 = 2026; 
@@ -2642,7 +2642,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c6.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 113; SumSQ.u64 = 113; Count.u64 = 113; 
  c6.l2cache.Inv_recv : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
  c6.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10631747; 
+ c6.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 104762636; SumSQ.u64 = 1041282042; Count.u64 = 10657599; 
  c6.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2879,7 +2879,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  c7.l1cache.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c7.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10656195; 
+ c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106429882; SumSQ.u64 = 1063992886; Count.u64 = 10657599; 
  c7.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_E : Accumulator : Sum.u64 = 2014; SumSQ.u64 = 2014; Count.u64 = 2014; 
@@ -3011,7 +3011,7 @@ TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15870077 clocks
  c7.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 116; SumSQ.u64 = 116; Count.u64 = 116; 
  c7.l2cache.Inv_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
  c7.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10656198; 
+ c7.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 105952900; SumSQ.u64 = 1055086860; Count.u64 = 10657599; 
  c7.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim.out
@@ -39,7 +39,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9124288; SumSQ.u64 = 89117462; Count.u64 = 937850; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9124288; SumSQ.u64 = 89117462; Count.u64 = 937854; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -164,7 +164,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9037809; SumSQ.u64 = 88124721; Count.u64 = 932522; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9037809; SumSQ.u64 = 88124721; Count.u64 = 937854; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -289,7 +289,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17972174; SumSQ.u64 = 346252478; Count.u64 = 937809; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17972174; SumSQ.u64 = 346252478; Count.u64 = 937854; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -479,7 +479,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9075040; SumSQ.u64 = 88619570; Count.u64 = 935114; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9075040; SumSQ.u64 = 88619570; Count.u64 = 937854; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -604,7 +604,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9086557; SumSQ.u64 = 88722191; Count.u64 = 936842; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9086557; SumSQ.u64 = 88722191; Count.u64 = 937854; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -729,7 +729,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17976144; SumSQ.u64 = 347081838; Count.u64 = 936801; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17976144; SumSQ.u64 = 347081838; Count.u64 = 937854; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -923,7 +923,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (468927 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35408497; SumSQ.u64 = 1344265195; Count.u64 = 937764; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35408497; SumSQ.u64 = 1344265195; Count.u64 = 937854; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim_MC.out
@@ -39,7 +39,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9124288; SumSQ.u64 = 89117462; Count.u64 = 937850; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9124288; SumSQ.u64 = 89117462; Count.u64 = 937854; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -164,7 +164,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9037809; SumSQ.u64 = 88124721; Count.u64 = 932522; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9037809; SumSQ.u64 = 88124721; Count.u64 = 937854; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -289,7 +289,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17972174; SumSQ.u64 = 346252478; Count.u64 = 937809; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17972174; SumSQ.u64 = 346252478; Count.u64 = 937854; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -479,7 +479,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9075040; SumSQ.u64 = 88619570; Count.u64 = 935114; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9075040; SumSQ.u64 = 88619570; Count.u64 = 937854; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -604,7 +604,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9086557; SumSQ.u64 = 88722191; Count.u64 = 936842; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9086557; SumSQ.u64 = 88722191; Count.u64 = 937854; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -729,7 +729,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17976144; SumSQ.u64 = 347081838; Count.u64 = 936801; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 17976144; SumSQ.u64 = 347081838; Count.u64 = 937854; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -923,7 +923,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (468423 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35408497; SumSQ.u64 = 1344265195; Count.u64 = 937764; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35408497; SumSQ.u64 = 1344265195; Count.u64 = 937854; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
@@ -51,7 +51,7 @@
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 26065; SumSQ.u64 = 69857; Count.u64 = 21617; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 26065; SumSQ.u64 = 69857; Count.u64 = 21620; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 2470; SumSQ.u64 = 2470; Count.u64 = 2470; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
@@ -51,7 +51,7 @@
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 26065; SumSQ.u64 = 69857; Count.u64 = 21617; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 26065; SumSQ.u64 = 69857; Count.u64 = 21620; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 2470; SumSQ.u64 = 2470; Count.u64 = 2470; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_2.out
@@ -51,7 +51,7 @@
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 37539; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 37542; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_2_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_2_MC.out
@@ -51,7 +51,7 @@
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 37539; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 37542; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3.out
@@ -187,7 +187,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_0.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l1cache_0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.NACK_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
- l1cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 173546; SumSQ.u64 = 3064098; Count.u64 = 11361; 
+ l1cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 173546; SumSQ.u64 = 3064098; Count.u64 = 11681; 
  l1cache_0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -300,7 +300,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.packet_latency : Accumulator : Sum.u64 = 460; SumSQ.u64 = 460; Count.u64 = 637; 
  l2cache_0.send_bit_count : Accumulator : Sum.u64 = 42816; SumSQ.u64 = 3919872; Count.u64 = 637; 
  l2cache_0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_0.idle_time : Accumulator : Sum.u64 = 2502830; SumSQ.u64 = 175829351346; Count.u64 = 474; 
+ l2cache_0.idle_time : Accumulator : Sum.u64 = 2621568; SumSQ.u64 = 189928063990; Count.u64 = 475; 
  l2cache_0.TotalEventsReceived : Accumulator : Sum.u64 = 859; SumSQ.u64 = 859; Count.u64 = 859; 
  l2cache_0.TotalEventsReplayed : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  l2cache_0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -330,7 +330,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l2cache_0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 130658; SumSQ.u64 = 1713768; Count.u64 = 11364; 
+ l2cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 130658; SumSQ.u64 = 1713768; Count.u64 = 11681; 
  l2cache_0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -591,7 +591,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_1.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 169673; SumSQ.u64 = 2778873; Count.u64 = 11668; 
+ l1cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 169673; SumSQ.u64 = 2778873; Count.u64 = 11681; 
  l1cache_1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -734,7 +734,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_1.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 110758; SumSQ.u64 = 1175960; Count.u64 = 11667; 
+ l2cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 110758; SumSQ.u64 = 1175960; Count.u64 = 11681; 
  l2cache_1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -995,7 +995,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_2.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  l1cache_2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.NACK_recv : Accumulator : Sum.u64 = 119; SumSQ.u64 = 119; Count.u64 = 119; 
- l1cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 179553; SumSQ.u64 = 3265693; Count.u64 = 11611; 
+ l1cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 179553; SumSQ.u64 = 3265693; Count.u64 = 11681; 
  l1cache_2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1108,7 +1108,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.packet_latency : Accumulator : Sum.u64 = 495; SumSQ.u64 = 495; Count.u64 = 641; 
  l2cache_2.send_bit_count : Accumulator : Sum.u64 = 44096; SumSQ.u64 = 4591616; Count.u64 = 641; 
  l2cache_2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_2.idle_time : Accumulator : Sum.u64 = 2631178; SumSQ.u64 = 118122196686; Count.u64 = 466; 
+ l2cache_2.idle_time : Accumulator : Sum.u64 = 2655926; SumSQ.u64 = 118734660190; Count.u64 = 467; 
  l2cache_2.TotalEventsReceived : Accumulator : Sum.u64 = 910; SumSQ.u64 = 910; Count.u64 = 910; 
  l2cache_2.TotalEventsReplayed : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  l2cache_2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -1138,7 +1138,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_2.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 131071; SumSQ.u64 = 1736745; Count.u64 = 11614; 
+ l2cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 131071; SumSQ.u64 = 1736745; Count.u64 = 11681; 
  l2cache_2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1399,7 +1399,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_3.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 179489; SumSQ.u64 = 3150549; Count.u64 = 11646; 
+ l1cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 179489; SumSQ.u64 = 3150549; Count.u64 = 11681; 
  l1cache_3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1542,7 +1542,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_3.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 112876; SumSQ.u64 = 1196932; Count.u64 = 11645; 
+ l2cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 112876; SumSQ.u64 = 1196932; Count.u64 = 11681; 
  l2cache_3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1803,7 +1803,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_4.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.NACK_recv : Accumulator : Sum.u64 = 90; SumSQ.u64 = 90; Count.u64 = 90; 
- l1cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 179218; SumSQ.u64 = 3291994; Count.u64 = 11612; 
+ l1cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 179218; SumSQ.u64 = 3291994; Count.u64 = 11681; 
  l1cache_4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1916,7 +1916,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.packet_latency : Accumulator : Sum.u64 = 436; SumSQ.u64 = 436; Count.u64 = 639; 
  l2cache_4.send_bit_count : Accumulator : Sum.u64 = 44992; SumSQ.u64 = 5238784; Count.u64 = 639; 
  l2cache_4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_4.idle_time : Accumulator : Sum.u64 = 2617527; SumSQ.u64 = 112101891847; Count.u64 = 465; 
+ l2cache_4.idle_time : Accumulator : Sum.u64 = 2641889; SumSQ.u64 = 112695398891; Count.u64 = 466; 
  l2cache_4.TotalEventsReceived : Accumulator : Sum.u64 = 875; SumSQ.u64 = 875; Count.u64 = 875; 
  l2cache_4.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache_4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -1946,7 +1946,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_4.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 129756; SumSQ.u64 = 1709426; Count.u64 = 11615; 
+ l2cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 129756; SumSQ.u64 = 1709426; Count.u64 = 11681; 
  l2cache_4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2207,7 +2207,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_5.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l1cache_5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.NACK_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
- l1cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 172744; SumSQ.u64 = 2817886; Count.u64 = 11619; 
+ l1cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 172744; SumSQ.u64 = 2817886; Count.u64 = 11681; 
  l1cache_5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2350,7 +2350,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_5.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l2cache_5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 114000; SumSQ.u64 = 1246986; Count.u64 = 11618; 
+ l2cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 114000; SumSQ.u64 = 1246986; Count.u64 = 11681; 
  l2cache_5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2611,7 +2611,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_6.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.NACK_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
- l1cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 178133; SumSQ.u64 = 3180975; Count.u64 = 11392; 
+ l1cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 178133; SumSQ.u64 = 3180975; Count.u64 = 11681; 
  l1cache_6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2724,7 +2724,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.packet_latency : Accumulator : Sum.u64 = 460; SumSQ.u64 = 460; Count.u64 = 645; 
  l2cache_6.send_bit_count : Accumulator : Sum.u64 = 45888; SumSQ.u64 = 5591040; Count.u64 = 645; 
  l2cache_6.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_6.idle_time : Accumulator : Sum.u64 = 2605561; SumSQ.u64 = 169255925065; Count.u64 = 484; 
+ l2cache_6.idle_time : Accumulator : Sum.u64 = 2711896; SumSQ.u64 = 180563057290; Count.u64 = 485; 
  l2cache_6.TotalEventsReceived : Accumulator : Sum.u64 = 904; SumSQ.u64 = 904; Count.u64 = 904; 
  l2cache_6.TotalEventsReplayed : Accumulator : Sum.u64 = 20; SumSQ.u64 = 20; Count.u64 = 20; 
  l2cache_6.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -2754,7 +2754,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_6.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_6.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 132998; SumSQ.u64 = 1772778; Count.u64 = 11395; 
+ l2cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 132998; SumSQ.u64 = 1772778; Count.u64 = 11681; 
  l2cache_6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_6.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3015,7 +3015,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_7.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l1cache_7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 167780; SumSQ.u64 = 2658516; Count.u64 = 11590; 
+ l1cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 167780; SumSQ.u64 = 2658516; Count.u64 = 11681; 
  l1cache_7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3158,7 +3158,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_7.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l2cache_7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 113845; SumSQ.u64 = 1213823; Count.u64 = 11589; 
+ l2cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 113845; SumSQ.u64 = 1213823; Count.u64 = 11681; 
  l2cache_7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3419,7 +3419,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_8.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_8.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.NACK_recv : Accumulator : Sum.u64 = 101; SumSQ.u64 = 101; Count.u64 = 101; 
- l1cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 176882; SumSQ.u64 = 3162464; Count.u64 = 11473; 
+ l1cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 176882; SumSQ.u64 = 3162464; Count.u64 = 11681; 
  l1cache_8.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3532,7 +3532,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.packet_latency : Accumulator : Sum.u64 = 466; SumSQ.u64 = 466; Count.u64 = 639; 
  l2cache_8.send_bit_count : Accumulator : Sum.u64 = 44992; SumSQ.u64 = 5238784; Count.u64 = 639; 
  l2cache_8.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_8.idle_time : Accumulator : Sum.u64 = 2402869; SumSQ.u64 = 82102894593; Count.u64 = 444; 
+ l2cache_8.idle_time : Accumulator : Sum.u64 = 2479495; SumSQ.u64 = 87974438469; Count.u64 = 445; 
  l2cache_8.TotalEventsReceived : Accumulator : Sum.u64 = 887; SumSQ.u64 = 887; Count.u64 = 887; 
  l2cache_8.TotalEventsReplayed : Accumulator : Sum.u64 = 25; SumSQ.u64 = 25; Count.u64 = 25; 
  l2cache_8.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -3562,7 +3562,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_8.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 129770; SumSQ.u64 = 1689922; Count.u64 = 11476; 
+ l2cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 129770; SumSQ.u64 = 1689922; Count.u64 = 11681; 
  l2cache_8.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3823,7 +3823,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_9.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l1cache_9.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 175933; SumSQ.u64 = 2991319; Count.u64 = 11661; 
+ l1cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 175933; SumSQ.u64 = 2991319; Count.u64 = 11681; 
  l1cache_9.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3966,7 +3966,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_9.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache_9.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 112652; SumSQ.u64 = 1180196; Count.u64 = 11660; 
+ l2cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 112652; SumSQ.u64 = 1180196; Count.u64 = 11681; 
  l2cache_9.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4227,7 +4227,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_10.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_10.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.NACK_recv : Accumulator : Sum.u64 = 67; SumSQ.u64 = 67; Count.u64 = 67; 
- l1cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 170237; SumSQ.u64 = 2995669; Count.u64 = 11599; 
+ l1cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 170237; SumSQ.u64 = 2995669; Count.u64 = 11681; 
  l1cache_10.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4340,7 +4340,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.packet_latency : Accumulator : Sum.u64 = 493; SumSQ.u64 = 493; Count.u64 = 639; 
  l2cache_10.send_bit_count : Accumulator : Sum.u64 = 45504; SumSQ.u64 = 5566464; Count.u64 = 639; 
  l2cache_10.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_10.idle_time : Accumulator : Sum.u64 = 2534520; SumSQ.u64 = 110676644170; Count.u64 = 470; 
+ l2cache_10.idle_time : Accumulator : Sum.u64 = 2563780; SumSQ.u64 = 111532791770; Count.u64 = 471; 
  l2cache_10.TotalEventsReceived : Accumulator : Sum.u64 = 864; SumSQ.u64 = 864; Count.u64 = 864; 
  l2cache_10.TotalEventsReplayed : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  l2cache_10.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -4370,7 +4370,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_10.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 129856; SumSQ.u64 = 1718946; Count.u64 = 11602; 
+ l2cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 129856; SumSQ.u64 = 1718946; Count.u64 = 11681; 
  l2cache_10.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4631,7 +4631,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_11.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l1cache_11.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 176183; SumSQ.u64 = 2922863; Count.u64 = 11660; 
+ l1cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 176183; SumSQ.u64 = 2922863; Count.u64 = 11681; 
  l1cache_11.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4774,7 +4774,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_11.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_11.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_11.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 115849; SumSQ.u64 = 1226717; Count.u64 = 11659; 
+ l2cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 115849; SumSQ.u64 = 1226717; Count.u64 = 11681; 
  l2cache_11.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_11.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_11.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5035,7 +5035,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_12.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_12.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.NACK_recv : Accumulator : Sum.u64 = 78; SumSQ.u64 = 78; Count.u64 = 78; 
- l1cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 177661; SumSQ.u64 = 3244171; Count.u64 = 11628; 
+ l1cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 177661; SumSQ.u64 = 3244171; Count.u64 = 11681; 
  l1cache_12.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5148,7 +5148,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.packet_latency : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 639; 
  l2cache_12.send_bit_count : Accumulator : Sum.u64 = 45504; SumSQ.u64 = 5566464; Count.u64 = 639; 
  l2cache_12.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_12.idle_time : Accumulator : Sum.u64 = 2429981; SumSQ.u64 = 82920467759; Count.u64 = 465; 
+ l2cache_12.idle_time : Accumulator : Sum.u64 = 2448327; SumSQ.u64 = 83257043475; Count.u64 = 466; 
  l2cache_12.TotalEventsReceived : Accumulator : Sum.u64 = 865; SumSQ.u64 = 865; Count.u64 = 865; 
  l2cache_12.TotalEventsReplayed : Accumulator : Sum.u64 = 24; SumSQ.u64 = 24; Count.u64 = 24; 
  l2cache_12.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -5178,7 +5178,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_12.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 130170; SumSQ.u64 = 1717510; Count.u64 = 11631; 
+ l2cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 130170; SumSQ.u64 = 1717510; Count.u64 = 11681; 
  l2cache_12.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5439,7 +5439,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_13.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l1cache_13.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 182027; SumSQ.u64 = 3131263; Count.u64 = 11680; 
+ l1cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 182028; SumSQ.u64 = 3131264; Count.u64 = 11681; 
  l1cache_13.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5582,7 +5582,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_13.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_13.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_13.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 111554; SumSQ.u64 = 1190162; Count.u64 = 11679; 
+ l2cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 111556; SumSQ.u64 = 1190164; Count.u64 = 11681; 
  l2cache_13.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_13.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_13.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5843,7 +5843,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_14.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_14.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.NACK_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
- l1cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 179492; SumSQ.u64 = 3259680; Count.u64 = 11642; 
+ l1cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 179492; SumSQ.u64 = 3259680; Count.u64 = 11681; 
  l1cache_14.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5956,7 +5956,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.packet_latency : Accumulator : Sum.u64 = 490; SumSQ.u64 = 490; Count.u64 = 641; 
  l2cache_14.send_bit_count : Accumulator : Sum.u64 = 45632; SumSQ.u64 = 5574656; Count.u64 = 641; 
  l2cache_14.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_14.idle_time : Accumulator : Sum.u64 = 2481378; SumSQ.u64 = 126987350696; Count.u64 = 471; 
+ l2cache_14.idle_time : Accumulator : Sum.u64 = 2494460; SumSQ.u64 = 127158489420; Count.u64 = 472; 
  l2cache_14.TotalEventsReceived : Accumulator : Sum.u64 = 908; SumSQ.u64 = 908; Count.u64 = 908; 
  l2cache_14.TotalEventsReplayed : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  l2cache_14.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -5986,7 +5986,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_14.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 131666; SumSQ.u64 = 1735262; Count.u64 = 11645; 
+ l2cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 131666; SumSQ.u64 = 1735262; Count.u64 = 11681; 
  l2cache_14.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -6247,7 +6247,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_15.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_15.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 181690; SumSQ.u64 = 3045220; Count.u64 = 11622; 
+ l1cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 181690; SumSQ.u64 = 3045220; Count.u64 = 11681; 
  l1cache_15.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -6390,7 +6390,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_15.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_15.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 113991; SumSQ.u64 = 1185613; Count.u64 = 11621; 
+ l2cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 113991; SumSQ.u64 = 1185613; Count.u64 = 11681; 
  l2cache_15.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3_MC.out
@@ -187,7 +187,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_0.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l1cache_0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.NACK_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
- l1cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 173546; SumSQ.u64 = 3064098; Count.u64 = 11361; 
+ l1cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 173546; SumSQ.u64 = 3064098; Count.u64 = 11681; 
  l1cache_0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -300,7 +300,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.packet_latency : Accumulator : Sum.u64 = 460; SumSQ.u64 = 460; Count.u64 = 637; 
  l2cache_0.send_bit_count : Accumulator : Sum.u64 = 42816; SumSQ.u64 = 3919872; Count.u64 = 637; 
  l2cache_0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_0.idle_time : Accumulator : Sum.u64 = 2502830; SumSQ.u64 = 175829351346; Count.u64 = 474; 
+ l2cache_0.idle_time : Accumulator : Sum.u64 = 2621568; SumSQ.u64 = 189928063990; Count.u64 = 475; 
  l2cache_0.TotalEventsReceived : Accumulator : Sum.u64 = 859; SumSQ.u64 = 859; Count.u64 = 859; 
  l2cache_0.TotalEventsReplayed : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  l2cache_0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -330,7 +330,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l2cache_0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 130658; SumSQ.u64 = 1713768; Count.u64 = 11364; 
+ l2cache_0.MSHR_occupancy : Accumulator : Sum.u64 = 130658; SumSQ.u64 = 1713768; Count.u64 = 11681; 
  l2cache_0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -591,7 +591,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_1.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 169673; SumSQ.u64 = 2778873; Count.u64 = 11668; 
+ l1cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 169673; SumSQ.u64 = 2778873; Count.u64 = 11681; 
  l1cache_1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -734,7 +734,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_1.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 110758; SumSQ.u64 = 1175960; Count.u64 = 11667; 
+ l2cache_1.MSHR_occupancy : Accumulator : Sum.u64 = 110758; SumSQ.u64 = 1175960; Count.u64 = 11681; 
  l2cache_1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -995,7 +995,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_2.FetchInvX_recv : Accumulator : Sum.u64 = 5; SumSQ.u64 = 5; Count.u64 = 5; 
  l1cache_2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.NACK_recv : Accumulator : Sum.u64 = 119; SumSQ.u64 = 119; Count.u64 = 119; 
- l1cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 179553; SumSQ.u64 = 3265693; Count.u64 = 11611; 
+ l1cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 179553; SumSQ.u64 = 3265693; Count.u64 = 11681; 
  l1cache_2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1108,7 +1108,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.packet_latency : Accumulator : Sum.u64 = 495; SumSQ.u64 = 495; Count.u64 = 641; 
  l2cache_2.send_bit_count : Accumulator : Sum.u64 = 44096; SumSQ.u64 = 4591616; Count.u64 = 641; 
  l2cache_2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_2.idle_time : Accumulator : Sum.u64 = 2631178; SumSQ.u64 = 118122196686; Count.u64 = 466; 
+ l2cache_2.idle_time : Accumulator : Sum.u64 = 2655926; SumSQ.u64 = 118734660190; Count.u64 = 467; 
  l2cache_2.TotalEventsReceived : Accumulator : Sum.u64 = 910; SumSQ.u64 = 910; Count.u64 = 910; 
  l2cache_2.TotalEventsReplayed : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  l2cache_2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -1138,7 +1138,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_2.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 131071; SumSQ.u64 = 1736745; Count.u64 = 11614; 
+ l2cache_2.MSHR_occupancy : Accumulator : Sum.u64 = 131071; SumSQ.u64 = 1736745; Count.u64 = 11681; 
  l2cache_2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1399,7 +1399,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_3.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 179489; SumSQ.u64 = 3150549; Count.u64 = 11646; 
+ l1cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 179489; SumSQ.u64 = 3150549; Count.u64 = 11681; 
  l1cache_3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1542,7 +1542,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_3.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 112876; SumSQ.u64 = 1196932; Count.u64 = 11645; 
+ l2cache_3.MSHR_occupancy : Accumulator : Sum.u64 = 112876; SumSQ.u64 = 1196932; Count.u64 = 11681; 
  l2cache_3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1803,7 +1803,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_4.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.NACK_recv : Accumulator : Sum.u64 = 90; SumSQ.u64 = 90; Count.u64 = 90; 
- l1cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 179218; SumSQ.u64 = 3291994; Count.u64 = 11612; 
+ l1cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 179218; SumSQ.u64 = 3291994; Count.u64 = 11681; 
  l1cache_4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1916,7 +1916,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.packet_latency : Accumulator : Sum.u64 = 436; SumSQ.u64 = 436; Count.u64 = 639; 
  l2cache_4.send_bit_count : Accumulator : Sum.u64 = 44992; SumSQ.u64 = 5238784; Count.u64 = 639; 
  l2cache_4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_4.idle_time : Accumulator : Sum.u64 = 2617527; SumSQ.u64 = 112101891847; Count.u64 = 465; 
+ l2cache_4.idle_time : Accumulator : Sum.u64 = 2641889; SumSQ.u64 = 112695398891; Count.u64 = 466; 
  l2cache_4.TotalEventsReceived : Accumulator : Sum.u64 = 875; SumSQ.u64 = 875; Count.u64 = 875; 
  l2cache_4.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache_4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -1946,7 +1946,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_4.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 129756; SumSQ.u64 = 1709426; Count.u64 = 11615; 
+ l2cache_4.MSHR_occupancy : Accumulator : Sum.u64 = 129756; SumSQ.u64 = 1709426; Count.u64 = 11681; 
  l2cache_4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2207,7 +2207,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_5.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l1cache_5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.NACK_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
- l1cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 172744; SumSQ.u64 = 2817886; Count.u64 = 11619; 
+ l1cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 172744; SumSQ.u64 = 2817886; Count.u64 = 11681; 
  l1cache_5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2350,7 +2350,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_5.FetchInvX_recv : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; 
  l2cache_5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 114000; SumSQ.u64 = 1246986; Count.u64 = 11618; 
+ l2cache_5.MSHR_occupancy : Accumulator : Sum.u64 = 114000; SumSQ.u64 = 1246986; Count.u64 = 11681; 
  l2cache_5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2611,7 +2611,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_6.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.NACK_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
- l1cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 178133; SumSQ.u64 = 3180975; Count.u64 = 11392; 
+ l1cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 178133; SumSQ.u64 = 3180975; Count.u64 = 11681; 
  l1cache_6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_6.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2724,7 +2724,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.packet_latency : Accumulator : Sum.u64 = 460; SumSQ.u64 = 460; Count.u64 = 645; 
  l2cache_6.send_bit_count : Accumulator : Sum.u64 = 45888; SumSQ.u64 = 5591040; Count.u64 = 645; 
  l2cache_6.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_6.idle_time : Accumulator : Sum.u64 = 2605561; SumSQ.u64 = 169255925065; Count.u64 = 484; 
+ l2cache_6.idle_time : Accumulator : Sum.u64 = 2711896; SumSQ.u64 = 180563057290; Count.u64 = 485; 
  l2cache_6.TotalEventsReceived : Accumulator : Sum.u64 = 904; SumSQ.u64 = 904; Count.u64 = 904; 
  l2cache_6.TotalEventsReplayed : Accumulator : Sum.u64 = 20; SumSQ.u64 = 20; Count.u64 = 20; 
  l2cache_6.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -2754,7 +2754,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_6.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_6.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 132998; SumSQ.u64 = 1772778; Count.u64 = 11395; 
+ l2cache_6.MSHR_occupancy : Accumulator : Sum.u64 = 132998; SumSQ.u64 = 1772778; Count.u64 = 11681; 
  l2cache_6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_6.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3015,7 +3015,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_7.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l1cache_7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 167780; SumSQ.u64 = 2658516; Count.u64 = 11590; 
+ l1cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 167780; SumSQ.u64 = 2658516; Count.u64 = 11681; 
  l1cache_7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_7.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3158,7 +3158,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_7.FetchInvX_recv : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l2cache_7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 113845; SumSQ.u64 = 1213823; Count.u64 = 11589; 
+ l2cache_7.MSHR_occupancy : Accumulator : Sum.u64 = 113845; SumSQ.u64 = 1213823; Count.u64 = 11681; 
  l2cache_7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_7.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3419,7 +3419,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_8.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_8.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.NACK_recv : Accumulator : Sum.u64 = 101; SumSQ.u64 = 101; Count.u64 = 101; 
- l1cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 176882; SumSQ.u64 = 3162464; Count.u64 = 11473; 
+ l1cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 176882; SumSQ.u64 = 3162464; Count.u64 = 11681; 
  l1cache_8.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_8.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3532,7 +3532,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.packet_latency : Accumulator : Sum.u64 = 466; SumSQ.u64 = 466; Count.u64 = 639; 
  l2cache_8.send_bit_count : Accumulator : Sum.u64 = 44992; SumSQ.u64 = 5238784; Count.u64 = 639; 
  l2cache_8.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_8.idle_time : Accumulator : Sum.u64 = 2402869; SumSQ.u64 = 82102894593; Count.u64 = 444; 
+ l2cache_8.idle_time : Accumulator : Sum.u64 = 2479495; SumSQ.u64 = 87974438469; Count.u64 = 445; 
  l2cache_8.TotalEventsReceived : Accumulator : Sum.u64 = 887; SumSQ.u64 = 887; Count.u64 = 887; 
  l2cache_8.TotalEventsReplayed : Accumulator : Sum.u64 = 25; SumSQ.u64 = 25; Count.u64 = 25; 
  l2cache_8.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -3562,7 +3562,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache_8.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 129770; SumSQ.u64 = 1689922; Count.u64 = 11476; 
+ l2cache_8.MSHR_occupancy : Accumulator : Sum.u64 = 129770; SumSQ.u64 = 1689922; Count.u64 = 11681; 
  l2cache_8.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_8.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3823,7 +3823,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_9.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l1cache_9.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 175933; SumSQ.u64 = 2991319; Count.u64 = 11661; 
+ l1cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 175933; SumSQ.u64 = 2991319; Count.u64 = 11681; 
  l1cache_9.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_9.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3966,7 +3966,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_9.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache_9.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 112652; SumSQ.u64 = 1180196; Count.u64 = 11660; 
+ l2cache_9.MSHR_occupancy : Accumulator : Sum.u64 = 112652; SumSQ.u64 = 1180196; Count.u64 = 11681; 
  l2cache_9.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_9.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4227,7 +4227,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_10.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_10.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.NACK_recv : Accumulator : Sum.u64 = 67; SumSQ.u64 = 67; Count.u64 = 67; 
- l1cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 170237; SumSQ.u64 = 2995669; Count.u64 = 11599; 
+ l1cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 170237; SumSQ.u64 = 2995669; Count.u64 = 11681; 
  l1cache_10.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_10.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4340,7 +4340,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.packet_latency : Accumulator : Sum.u64 = 493; SumSQ.u64 = 493; Count.u64 = 639; 
  l2cache_10.send_bit_count : Accumulator : Sum.u64 = 45504; SumSQ.u64 = 5566464; Count.u64 = 639; 
  l2cache_10.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_10.idle_time : Accumulator : Sum.u64 = 2534520; SumSQ.u64 = 110676644170; Count.u64 = 470; 
+ l2cache_10.idle_time : Accumulator : Sum.u64 = 2563780; SumSQ.u64 = 111532791770; Count.u64 = 471; 
  l2cache_10.TotalEventsReceived : Accumulator : Sum.u64 = 864; SumSQ.u64 = 864; Count.u64 = 864; 
  l2cache_10.TotalEventsReplayed : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
  l2cache_10.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -4370,7 +4370,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_10.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 129856; SumSQ.u64 = 1718946; Count.u64 = 11602; 
+ l2cache_10.MSHR_occupancy : Accumulator : Sum.u64 = 129856; SumSQ.u64 = 1718946; Count.u64 = 11681; 
  l2cache_10.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_10.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4631,7 +4631,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_11.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l1cache_11.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 176183; SumSQ.u64 = 2922863; Count.u64 = 11660; 
+ l1cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 176183; SumSQ.u64 = 2922863; Count.u64 = 11681; 
  l1cache_11.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_11.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -4774,7 +4774,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_11.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_11.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_11.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 115849; SumSQ.u64 = 1226717; Count.u64 = 11659; 
+ l2cache_11.MSHR_occupancy : Accumulator : Sum.u64 = 115849; SumSQ.u64 = 1226717; Count.u64 = 11681; 
  l2cache_11.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_11.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_11.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5035,7 +5035,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_12.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_12.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.NACK_recv : Accumulator : Sum.u64 = 78; SumSQ.u64 = 78; Count.u64 = 78; 
- l1cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 177661; SumSQ.u64 = 3244171; Count.u64 = 11628; 
+ l1cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 177661; SumSQ.u64 = 3244171; Count.u64 = 11681; 
  l1cache_12.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_12.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5148,7 +5148,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.packet_latency : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 639; 
  l2cache_12.send_bit_count : Accumulator : Sum.u64 = 45504; SumSQ.u64 = 5566464; Count.u64 = 639; 
  l2cache_12.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_12.idle_time : Accumulator : Sum.u64 = 2429981; SumSQ.u64 = 82920467759; Count.u64 = 465; 
+ l2cache_12.idle_time : Accumulator : Sum.u64 = 2448327; SumSQ.u64 = 83257043475; Count.u64 = 466; 
  l2cache_12.TotalEventsReceived : Accumulator : Sum.u64 = 865; SumSQ.u64 = 865; Count.u64 = 865; 
  l2cache_12.TotalEventsReplayed : Accumulator : Sum.u64 = 24; SumSQ.u64 = 24; Count.u64 = 24; 
  l2cache_12.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -5178,7 +5178,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_12.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 130170; SumSQ.u64 = 1717510; Count.u64 = 11631; 
+ l2cache_12.MSHR_occupancy : Accumulator : Sum.u64 = 130170; SumSQ.u64 = 1717510; Count.u64 = 11681; 
  l2cache_12.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_12.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5439,7 +5439,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_13.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l1cache_13.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 182027; SumSQ.u64 = 3131263; Count.u64 = 11680; 
+ l1cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 182028; SumSQ.u64 = 3131264; Count.u64 = 11681; 
  l1cache_13.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_13.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5582,7 +5582,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_13.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  l2cache_13.Inv_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache_13.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 111554; SumSQ.u64 = 1190162; Count.u64 = 11679; 
+ l2cache_13.MSHR_occupancy : Accumulator : Sum.u64 = 111556; SumSQ.u64 = 1190164; Count.u64 = 11681; 
  l2cache_13.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_13.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_13.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5843,7 +5843,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_14.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l1cache_14.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.NACK_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
- l1cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 179492; SumSQ.u64 = 3259680; Count.u64 = 11642; 
+ l1cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 179492; SumSQ.u64 = 3259680; Count.u64 = 11681; 
  l1cache_14.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_14.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -5956,7 +5956,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.packet_latency : Accumulator : Sum.u64 = 490; SumSQ.u64 = 490; Count.u64 = 641; 
  l2cache_14.send_bit_count : Accumulator : Sum.u64 = 45632; SumSQ.u64 = 5574656; Count.u64 = 641; 
  l2cache_14.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_14.idle_time : Accumulator : Sum.u64 = 2481378; SumSQ.u64 = 126987350696; Count.u64 = 471; 
+ l2cache_14.idle_time : Accumulator : Sum.u64 = 2494460; SumSQ.u64 = 127158489420; Count.u64 = 472; 
  l2cache_14.TotalEventsReceived : Accumulator : Sum.u64 = 908; SumSQ.u64 = 908; Count.u64 = 908; 
  l2cache_14.TotalEventsReplayed : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  l2cache_14.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 624; SumSQ.u64 = 624; Count.u64 = 624; 
@@ -5986,7 +5986,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_14.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 131666; SumSQ.u64 = 1735262; Count.u64 = 11645; 
+ l2cache_14.MSHR_occupancy : Accumulator : Sum.u64 = 131666; SumSQ.u64 = 1735262; Count.u64 = 11681; 
  l2cache_14.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_14.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -6247,7 +6247,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_15.FetchInvX_recv : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l1cache_15.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 181690; SumSQ.u64 = 3045220; Count.u64 = 11622; 
+ l1cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 181690; SumSQ.u64 = 3045220; Count.u64 = 11681; 
  l1cache_15.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache_15.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -6390,7 +6390,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_15.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache_15.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 113991; SumSQ.u64 = 1185613; Count.u64 = 11621; 
+ l2cache_15.MSHR_occupancy : Accumulator : Sum.u64 = 113991; SumSQ.u64 = 1185613; Count.u64 = 11681; 
  l2cache_15.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache_15.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches.out
@@ -148,7 +148,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 912693; SumSQ.u64 = 9025025; Count.u64 = 92943; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 912693; SumSQ.u64 = 9025025; Count.u64 = 93439; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1054; SumSQ.u64 = 1054; Count.u64 = 1054; 
@@ -285,7 +285,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 918573; SumSQ.u64 = 9093129; Count.u64 = 93330; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 918573; SumSQ.u64 = 9093129; Count.u64 = 93439; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1037; SumSQ.u64 = 1037; Count.u64 = 1037; 
@@ -422,7 +422,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 916865; SumSQ.u64 = 9067373; Count.u64 = 93219; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 916865; SumSQ.u64 = 9067373; Count.u64 = 93439; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1049; SumSQ.u64 = 1049; Count.u64 = 1049; 
@@ -559,7 +559,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 923709; SumSQ.u64 = 9152193; Count.u64 = 93437; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 923709; SumSQ.u64 = 9152193; Count.u64 = 93439; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1046; SumSQ.u64 = 1046; Count.u64 = 1046; 
@@ -696,7 +696,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 910960; SumSQ.u64 = 9005716; Count.u64 = 92996; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 910960; SumSQ.u64 = 9005716; Count.u64 = 93439; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1045; SumSQ.u64 = 1045; Count.u64 = 1045; 
@@ -833,7 +833,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 921794; SumSQ.u64 = 9130406; Count.u64 = 93378; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 921794; SumSQ.u64 = 9130406; Count.u64 = 93439; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1039; SumSQ.u64 = 1039; Count.u64 = 1039; 
@@ -970,7 +970,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 896115; SumSQ.u64 = 8857393; Count.u64 = 91330; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 896115; SumSQ.u64 = 8857393; Count.u64 = 93439; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1042; SumSQ.u64 = 1042; Count.u64 = 1042; 
@@ -1107,7 +1107,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 919840; SumSQ.u64 = 9108022; Count.u64 = 93273; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 919840; SumSQ.u64 = 9108022; Count.u64 = 93439; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1039; SumSQ.u64 = 1039; Count.u64 = 1039; 
@@ -1213,7 +1213,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 8071; SumSQ.u64 = 11869; Count.u64 = 7088; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 1525760; SumSQ.u64 = 800718848; Count.u64 = 4768; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 25022932; SumSQ.u64 = 421211153048; Count.u64 = 3773; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 25025071; SumSQ.u64 = 421215728369; Count.u64 = 3774; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 7088; SumSQ.u64 = 7088; Count.u64 = 7088; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1243,7 +1243,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1077820; SumSQ.u64 = 23822760; Count.u64 = 54567; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1077820; SumSQ.u64 = 23822760; Count.u64 = 54571; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1454,7 +1454,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 8102; SumSQ.u64 = 11808; Count.u64 = 7177; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 1544896; SumSQ.u64 = 810790912; Count.u64 = 4827; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 24874050; SumSQ.u64 = 395599157140; Count.u64 = 3778; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 25058973; SumSQ.u64 = 429795673069; Count.u64 = 3779; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 7177; SumSQ.u64 = 7177; Count.u64 = 7177; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1484,7 +1484,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 882723; SumSQ.u64 = 17597773; Count.u64 = 54311; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 882723; SumSQ.u64 = 17597773; Count.u64 = 54571; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1695,7 +1695,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 8379; SumSQ.u64 = 12305; Count.u64 = 7372; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 1586496; SumSQ.u64 = 832622592; Count.u64 = 4957; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 24824066; SumSQ.u64 = 386027429964; Count.u64 = 3869; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 24826433; SumSQ.u64 = 386033032653; Count.u64 = 3870; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 7372; SumSQ.u64 = 7372; Count.u64 = 7372; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1725,7 +1725,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1133850; SumSQ.u64 = 26847608; Count.u64 = 54567; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1133850; SumSQ.u64 = 26847608; Count.u64 = 54571; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1936,7 +1936,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 7834; SumSQ.u64 = 11336; Count.u64 = 6905; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 1486720; SumSQ.u64 = 780230656; Count.u64 = 4646; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 25400484; SumSQ.u64 = 435135939520; Count.u64 = 3675; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 25513293; SumSQ.u64 = 447861810001; Count.u64 = 3676; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 6905; SumSQ.u64 = 6905; Count.u64 = 6905; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1966,7 +1966,7 @@ TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 864992; SumSQ.u64 = 17306630; Count.u64 = 54412; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 864992; SumSQ.u64 = 17306630; Count.u64 = 54571; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches_MC.out
@@ -10,11 +10,11 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu6 Finished after 1200 issued reads, 1200 returned (91332 clocks)
 TrivialCPU cpu5 Finished after 1200 issued reads, 1200 returned (93380 clocks)
-TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
+TrivialCPU cpu6 Finished after 1200 issued reads, 1200 returned (91332 clocks)
 TrivialCPU cpu0 Finished after 1200 issued reads, 1200 returned (92945 clocks)
 TrivialCPU cpu1 Finished after 1200 issued reads, 1200 returned (93332 clocks)
+TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (93275 clocks)
 TrivialCPU cpu2 Finished after 1200 issued reads, 1200 returned (93221 clocks)
 TrivialCPU cpu3 Finished after 1200 issued reads, 1200 returned (93439 clocks)
 TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
@@ -148,7 +148,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 912693; SumSQ.u64 = 9025025; Count.u64 = 92943; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 912693; SumSQ.u64 = 9025025; Count.u64 = 93439; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1054; SumSQ.u64 = 1054; Count.u64 = 1054; 
@@ -285,7 +285,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 918573; SumSQ.u64 = 9093129; Count.u64 = 93330; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 918573; SumSQ.u64 = 9093129; Count.u64 = 93439; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1037; SumSQ.u64 = 1037; Count.u64 = 1037; 
@@ -422,7 +422,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 916865; SumSQ.u64 = 9067373; Count.u64 = 93219; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 916865; SumSQ.u64 = 9067373; Count.u64 = 93439; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1049; SumSQ.u64 = 1049; Count.u64 = 1049; 
@@ -559,7 +559,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 923709; SumSQ.u64 = 9152193; Count.u64 = 93437; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 923709; SumSQ.u64 = 9152193; Count.u64 = 93439; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1046; SumSQ.u64 = 1046; Count.u64 = 1046; 
@@ -696,7 +696,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 910960; SumSQ.u64 = 9005716; Count.u64 = 92996; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 910960; SumSQ.u64 = 9005716; Count.u64 = 93439; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1045; SumSQ.u64 = 1045; Count.u64 = 1045; 
@@ -833,7 +833,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 921794; SumSQ.u64 = 9130406; Count.u64 = 93378; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 921794; SumSQ.u64 = 9130406; Count.u64 = 93439; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1039; SumSQ.u64 = 1039; Count.u64 = 1039; 
@@ -970,7 +970,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 896115; SumSQ.u64 = 8857393; Count.u64 = 91330; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 896115; SumSQ.u64 = 8857393; Count.u64 = 93439; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1042; SumSQ.u64 = 1042; Count.u64 = 1042; 
@@ -1107,7 +1107,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 919840; SumSQ.u64 = 9108022; Count.u64 = 93273; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 919840; SumSQ.u64 = 9108022; Count.u64 = 93439; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1039; SumSQ.u64 = 1039; Count.u64 = 1039; 
@@ -1213,7 +1213,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 8071; SumSQ.u64 = 11869; Count.u64 = 7088; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 1525760; SumSQ.u64 = 800718848; Count.u64 = 4768; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 25022932; SumSQ.u64 = 421211153048; Count.u64 = 3773; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 25025071; SumSQ.u64 = 421215728369; Count.u64 = 3774; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 7088; SumSQ.u64 = 7088; Count.u64 = 7088; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1243,7 +1243,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1077820; SumSQ.u64 = 23822760; Count.u64 = 54567; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1077820; SumSQ.u64 = 23822760; Count.u64 = 54571; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1454,7 +1454,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 8102; SumSQ.u64 = 11808; Count.u64 = 7177; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 1544896; SumSQ.u64 = 810790912; Count.u64 = 4827; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 24874050; SumSQ.u64 = 395599157140; Count.u64 = 3778; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 25058973; SumSQ.u64 = 429795673069; Count.u64 = 3779; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 7177; SumSQ.u64 = 7177; Count.u64 = 7177; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1484,7 +1484,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 882723; SumSQ.u64 = 17597773; Count.u64 = 54311; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 882723; SumSQ.u64 = 17597773; Count.u64 = 54571; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1695,7 +1695,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 8379; SumSQ.u64 = 12305; Count.u64 = 7372; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 1586496; SumSQ.u64 = 832622592; Count.u64 = 4957; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 24824066; SumSQ.u64 = 386027429964; Count.u64 = 3869; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 24826433; SumSQ.u64 = 386033032653; Count.u64 = 3870; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 7372; SumSQ.u64 = 7372; Count.u64 = 7372; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1725,7 +1725,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1133850; SumSQ.u64 = 26847608; Count.u64 = 54567; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1133850; SumSQ.u64 = 26847608; Count.u64 = 54571; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1936,7 +1936,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 7834; SumSQ.u64 = 11336; Count.u64 = 6905; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 1486720; SumSQ.u64 = 780230656; Count.u64 = 4646; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 25400484; SumSQ.u64 = 435135939520; Count.u64 = 3675; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 25513293; SumSQ.u64 = 447861810001; Count.u64 = 3676; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 6905; SumSQ.u64 = 6905; Count.u64 = 6905; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1966,7 +1966,7 @@ TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92998 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 864992; SumSQ.u64 = 17306630; Count.u64 = 54412; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 864992; SumSQ.u64 = 17306630; Count.u64 = 54571; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes.out
@@ -106,7 +106,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 144; SumSQ.u64 = 144; Count.u64 = 144; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 319; SumSQ.u64 = 319; Count.u64 = 319; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 1166; SumSQ.u64 = 1166; Count.u64 = 1166; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 214292; SumSQ.u64 = 3227610; Count.u64 = 15296; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 214292; SumSQ.u64 = 3227610; Count.u64 = 15458; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -212,7 +212,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 2936; SumSQ.u64 = 7030; Count.u64 = 1875; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 316736; SumSQ.u64 = 133812224; Count.u64 = 1869; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 2927928; SumSQ.u64 = 22830492754; Count.u64 = 1472; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 2993448; SumSQ.u64 = 27123363154; Count.u64 = 1473; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4881; SumSQ.u64 = 4881; Count.u64 = 4881; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -242,7 +242,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 183; SumSQ.u64 = 183; Count.u64 = 183; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 518; SumSQ.u64 = 518; Count.u64 = 518; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 319; SumSQ.u64 = 319; Count.u64 = 319; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 84223; SumSQ.u64 = 519383; Count.u64 = 15299; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 84223; SumSQ.u64 = 519383; Count.u64 = 15458; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -480,7 +480,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 134; SumSQ.u64 = 134; Count.u64 = 134; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 305; SumSQ.u64 = 305; Count.u64 = 305; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 1474; SumSQ.u64 = 1474; Count.u64 = 1474; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 204419; SumSQ.u64 = 3062321; Count.u64 = 14899; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 204419; SumSQ.u64 = 3062321; Count.u64 = 15458; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
@@ -586,7 +586,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 3044; SumSQ.u64 = 7788; Count.u64 = 1847; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 305792; SumSQ.u64 = 127803392; Count.u64 = 1842; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 2879178; SumSQ.u64 = 24796953504; Count.u64 = 1432; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 3110247; SumSQ.u64 = 78189836265; Count.u64 = 1433; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 5193; SumSQ.u64 = 5193; Count.u64 = 5193; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -616,7 +616,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 171; SumSQ.u64 = 171; Count.u64 = 171; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 508; SumSQ.u64 = 508; Count.u64 = 508; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 341; SumSQ.u64 = 341; Count.u64 = 341; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 85971; SumSQ.u64 = 552775; Count.u64 = 14902; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 85971; SumSQ.u64 = 552775; Count.u64 = 15458; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -854,7 +854,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 139; SumSQ.u64 = 139; Count.u64 = 139; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 308; SumSQ.u64 = 308; Count.u64 = 308; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 1507; SumSQ.u64 = 1507; Count.u64 = 1507; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 220155; SumSQ.u64 = 3292995; Count.u64 = 15102; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 220155; SumSQ.u64 = 3292995; Count.u64 = 15458; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
@@ -960,7 +960,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 3027; SumSQ.u64 = 7965; Count.u64 = 1804; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 308160; SumSQ.u64 = 130904064; Count.u64 = 1799; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 2918071; SumSQ.u64 = 16917683217; Count.u64 = 1405; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 3011347; SumSQ.u64 = 25618095393; Count.u64 = 1406; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 5173; SumSQ.u64 = 5173; Count.u64 = 5173; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -990,7 +990,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 176; SumSQ.u64 = 176; Count.u64 = 176; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 499; SumSQ.u64 = 499; Count.u64 = 499; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 87261; SumSQ.u64 = 550429; Count.u64 = 15231; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 87261; SumSQ.u64 = 550429; Count.u64 = 15458; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1228,7 +1228,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 303; SumSQ.u64 = 303; Count.u64 = 303; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 1356; SumSQ.u64 = 1356; Count.u64 = 1356; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 228530; SumSQ.u64 = 3443472; Count.u64 = 15456; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 228530; SumSQ.u64 = 3443472; Count.u64 = 15458; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
@@ -1364,7 +1364,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 469; SumSQ.u64 = 469; Count.u64 = 469; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 283; SumSQ.u64 = 283; Count.u64 = 283; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 86349; SumSQ.u64 = 521361; Count.u64 = 15454; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 86349; SumSQ.u64 = 521361; Count.u64 = 15458; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1602,7 +1602,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 294; SumSQ.u64 = 294; Count.u64 = 294; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 1657; SumSQ.u64 = 1657; Count.u64 = 1657; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 205119; SumSQ.u64 = 3067625; Count.u64 = 15103; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 205119; SumSQ.u64 = 3067625; Count.u64 = 15458; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
@@ -1708,7 +1708,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 3088; SumSQ.u64 = 8070; Count.u64 = 1840; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 306752; SumSQ.u64 = 128749568; Count.u64 = 1833; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 2985291; SumSQ.u64 = 33575032941; Count.u64 = 1408; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 3131292; SumSQ.u64 = 54891324942; Count.u64 = 1409; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 5371; SumSQ.u64 = 5371; Count.u64 = 5371; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1738,7 +1738,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 187; SumSQ.u64 = 187; Count.u64 = 187; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 528; SumSQ.u64 = 528; Count.u64 = 528; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 304; SumSQ.u64 = 304; Count.u64 = 304; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 86509; SumSQ.u64 = 557563; Count.u64 = 15106; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 86509; SumSQ.u64 = 557563; Count.u64 = 15458; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1976,7 +1976,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 131; SumSQ.u64 = 131; Count.u64 = 131; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 296; SumSQ.u64 = 296; Count.u64 = 296; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 1385; SumSQ.u64 = 1385; Count.u64 = 1385; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 212865; SumSQ.u64 = 3201263; Count.u64 = 15105; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 212865; SumSQ.u64 = 3201263; Count.u64 = 15458; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
@@ -2082,7 +2082,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 3100; SumSQ.u64 = 8036; Count.u64 = 1775; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 302976; SumSQ.u64 = 128507904; Count.u64 = 1774; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 3048776; SumSQ.u64 = 21108370448; Count.u64 = 1372; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 3193943; SumSQ.u64 = 42181828337; Count.u64 = 1373; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4975; SumSQ.u64 = 4975; Count.u64 = 4975; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2112,7 +2112,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 469; SumSQ.u64 = 469; Count.u64 = 469; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 315; SumSQ.u64 = 315; Count.u64 = 315; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 82618; SumSQ.u64 = 514196; Count.u64 = 15108; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 82618; SumSQ.u64 = 514196; Count.u64 = 15458; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2323,7 +2323,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 6413; SumSQ.u64 = 17397; Count.u64 = 4107; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 1263360; SumSQ.u64 = 656818176; Count.u64 = 4116; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1247368; SumSQ.u64 = 3013632072; Count.u64 = 1211; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1296256; SumSQ.u64 = 5403668616; Count.u64 = 1212; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4107; SumSQ.u64 = 4107; Count.u64 = 4107; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 285; SumSQ.u64 = 285; Count.u64 = 285; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2353,7 +2353,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 41672; SumSQ.u64 = 227988; Count.u64 = 8958; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 41672; SumSQ.u64 = 227988; Count.u64 = 9027; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2564,7 +2564,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 6424; SumSQ.u64 = 17688; Count.u64 = 4165; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 1254848; SumSQ.u64 = 649195520; Count.u64 = 4175; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1244180; SumSQ.u64 = 3314395072; Count.u64 = 1230; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1247372; SumSQ.u64 = 3324583936; Count.u64 = 1231; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4165; SumSQ.u64 = 4165; Count.u64 = 4165; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 276; SumSQ.u64 = 276; Count.u64 = 276; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2594,7 +2594,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 63; SumSQ.u64 = 63; Count.u64 = 63; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 41268; SumSQ.u64 = 224010; Count.u64 = 9022; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 41268; SumSQ.u64 = 224010; Count.u64 = 9027; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2805,7 +2805,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 6387; SumSQ.u64 = 17189; Count.u64 = 4117; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 1243008; SumSQ.u64 = 643424256; Count.u64 = 4126; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1228560; SumSQ.u64 = 3254843472; Count.u64 = 1217; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1333140; SumSQ.u64 = 14191819872; Count.u64 = 1218; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4117; SumSQ.u64 = 4117; Count.u64 = 4117; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 278; SumSQ.u64 = 278; Count.u64 = 278; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2835,7 +2835,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 68; SumSQ.u64 = 68; Count.u64 = 68; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 41056; SumSQ.u64 = 228476; Count.u64 = 8880; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 41056; SumSQ.u64 = 228476; Count.u64 = 9027; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2.out
@@ -118,7 +118,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 111; SumSQ.u64 = 111; Count.u64 = 111; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 300; SumSQ.u64 = 300; Count.u64 = 300; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 1020; SumSQ.u64 = 1020; Count.u64 = 1020; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 262255; SumSQ.u64 = 3867881; Count.u64 = 18055; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 262255; SumSQ.u64 = 3867881; Count.u64 = 18057; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
@@ -254,7 +254,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 142; SumSQ.u64 = 142; Count.u64 = 142; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 449; SumSQ.u64 = 449; Count.u64 = 449; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 379; SumSQ.u64 = 379; Count.u64 = 379; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 101196; SumSQ.u64 = 603842; Count.u64 = 18053; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 101196; SumSQ.u64 = 603842; Count.u64 = 18057; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -492,7 +492,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 297; SumSQ.u64 = 297; Count.u64 = 297; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 1227; SumSQ.u64 = 1227; Count.u64 = 1227; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 247658; SumSQ.u64 = 3601194; Count.u64 = 17935; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 247658; SumSQ.u64 = 3601194; Count.u64 = 18057; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -598,7 +598,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 2837; SumSQ.u64 = 6083; Count.u64 = 1954; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 315424; SumSQ.u64 = 129915904; Count.u64 = 1949; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 3506613; SumSQ.u64 = 24532418729; Count.u64 = 1538; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 3549615; SumSQ.u64 = 26381590733; Count.u64 = 1539; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4800; SumSQ.u64 = 4800; Count.u64 = 4800; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 216; SumSQ.u64 = 216; Count.u64 = 216; 
@@ -628,7 +628,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 176; SumSQ.u64 = 176; Count.u64 = 176; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 470; SumSQ.u64 = 470; Count.u64 = 470; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 410; SumSQ.u64 = 410; Count.u64 = 410; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 103024; SumSQ.u64 = 647412; Count.u64 = 17952; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 103024; SumSQ.u64 = 647412; Count.u64 = 18057; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -866,7 +866,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 298; SumSQ.u64 = 298; Count.u64 = 298; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 1343; SumSQ.u64 = 1343; Count.u64 = 1343; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 221250; SumSQ.u64 = 3151162; Count.u64 = 17954; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 221250; SumSQ.u64 = 3151162; Count.u64 = 18057; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
@@ -972,7 +972,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 2823; SumSQ.u64 = 6285; Count.u64 = 1896; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 312384; SumSQ.u64 = 130037760; Count.u64 = 1890; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 3875681; SumSQ.u64 = 166267969895; Count.u64 = 1444; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 3916598; SumSQ.u64 = 167942170784; Count.u64 = 1445; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4788; SumSQ.u64 = 4788; Count.u64 = 4788; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 252; SumSQ.u64 = 252; Count.u64 = 252; 
@@ -1002,7 +1002,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 154; SumSQ.u64 = 154; Count.u64 = 154; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 458; SumSQ.u64 = 458; Count.u64 = 458; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 400; SumSQ.u64 = 400; Count.u64 = 400; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 92953; SumSQ.u64 = 584597; Count.u64 = 17957; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 92953; SumSQ.u64 = 584597; Count.u64 = 18057; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1240,7 +1240,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 1357; SumSQ.u64 = 1357; Count.u64 = 1357; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 249884; SumSQ.u64 = 3616314; Count.u64 = 17955; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 249884; SumSQ.u64 = 3616314; Count.u64 = 18057; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
@@ -1346,7 +1346,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 2820; SumSQ.u64 = 6146; Count.u64 = 1910; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 313888; SumSQ.u64 = 130413568; Count.u64 = 1908; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 3621094; SumSQ.u64 = 42345935268; Count.u64 = 1525; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 3661594; SumSQ.u64 = 43986185268; Count.u64 = 1526; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 4832; SumSQ.u64 = 4832; Count.u64 = 4832; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 214; SumSQ.u64 = 214; Count.u64 = 214; 
@@ -1376,7 +1376,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 155; SumSQ.u64 = 155; Count.u64 = 155; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 457; SumSQ.u64 = 457; Count.u64 = 457; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 391; SumSQ.u64 = 391; Count.u64 = 391; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 101284; SumSQ.u64 = 630248; Count.u64 = 17958; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 101284; SumSQ.u64 = 630248; Count.u64 = 18057; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1614,7 +1614,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 138; SumSQ.u64 = 138; Count.u64 = 138; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 311; SumSQ.u64 = 311; Count.u64 = 311; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 1291; SumSQ.u64 = 1291; Count.u64 = 1291; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 254815; SumSQ.u64 = 3735157; Count.u64 = 17944; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 254815; SumSQ.u64 = 3735157; Count.u64 = 18057; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
@@ -1720,7 +1720,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 2891; SumSQ.u64 = 6439; Count.u64 = 1949; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 311008; SumSQ.u64 = 127273984; Count.u64 = 1944; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 3376631; SumSQ.u64 = 18634578563; Count.u64 = 1521; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 3417548; SumSQ.u64 = 20308779452; Count.u64 = 1522; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 4919; SumSQ.u64 = 4919; Count.u64 = 4919; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 186; SumSQ.u64 = 186; Count.u64 = 186; 
@@ -1750,7 +1750,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 175; SumSQ.u64 = 175; Count.u64 = 175; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 465; SumSQ.u64 = 465; Count.u64 = 465; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 386; SumSQ.u64 = 386; Count.u64 = 386; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 98218; SumSQ.u64 = 595626; Count.u64 = 17957; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 98218; SumSQ.u64 = 595626; Count.u64 = 18057; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1988,7 +1988,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 126; SumSQ.u64 = 126; Count.u64 = 126; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 269; SumSQ.u64 = 269; Count.u64 = 269; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 1352; SumSQ.u64 = 1352; Count.u64 = 1352; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 209380; SumSQ.u64 = 3009110; Count.u64 = 16745; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 209380; SumSQ.u64 = 3009110; Count.u64 = 18057; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -2094,7 +2094,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 2837; SumSQ.u64 = 6379; Count.u64 = 1856; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 318400; SumSQ.u64 = 135430144; Count.u64 = 1849; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 3419790; SumSQ.u64 = 46974174632; Count.u64 = 1446; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 3964860; SumSQ.u64 = 344075479532; Count.u64 = 1447; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4830; SumSQ.u64 = 4830; Count.u64 = 4830; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 180; SumSQ.u64 = 180; Count.u64 = 180; 
@@ -2124,7 +2124,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 174; SumSQ.u64 = 174; Count.u64 = 174; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 461; SumSQ.u64 = 461; Count.u64 = 461; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 388; SumSQ.u64 = 388; Count.u64 = 388; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90327; SumSQ.u64 = 576909; Count.u64 = 16748; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90327; SumSQ.u64 = 576909; Count.u64 = 18057; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2335,7 +2335,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 6618; SumSQ.u64 = 16940; Count.u64 = 4471; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 1214784; SumSQ.u64 = 607739904; Count.u64 = 4479; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1855598; SumSQ.u64 = 6216358284; Count.u64 = 1539; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1885139; SumSQ.u64 = 7089028965; Count.u64 = 1540; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 3843; SumSQ.u64 = 3843; Count.u64 = 3843; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 277; SumSQ.u64 = 277; Count.u64 = 277; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 628; SumSQ.u64 = 628; Count.u64 = 628; 
@@ -2365,7 +2365,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49222; SumSQ.u64 = 274800; Count.u64 = 10503; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49222; SumSQ.u64 = 274800; Count.u64 = 10545; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2576,7 +2576,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 6686; SumSQ.u64 = 16694; Count.u64 = 4534; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 1263072; SumSQ.u64 = 638407680; Count.u64 = 4545; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1684588; SumSQ.u64 = 8533332168; Count.u64 = 1476; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1687711; SumSQ.u64 = 8543085297; Count.u64 = 1477; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4226; SumSQ.u64 = 4226; Count.u64 = 4226; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 308; SumSQ.u64 = 308; Count.u64 = 308; 
@@ -2606,7 +2606,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52148; SumSQ.u64 = 297874; Count.u64 = 10540; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52148; SumSQ.u64 = 297874; Count.u64 = 10545; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2817,7 +2817,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 6736; SumSQ.u64 = 17812; Count.u64 = 4476; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 1271968; SumSQ.u64 = 646319104; Count.u64 = 4489; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1697972; SumSQ.u64 = 4896058056; Count.u64 = 1486; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1757387; SumSQ.u64 = 8426200281; Count.u64 = 1487; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4188; SumSQ.u64 = 4188; Count.u64 = 4188; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 306; SumSQ.u64 = 306; Count.u64 = 306; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 288; SumSQ.u64 = 288; Count.u64 = 288; 
@@ -2847,7 +2847,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 50825; SumSQ.u64 = 290297; Count.u64 = 10462; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 50825; SumSQ.u64 = 290297; Count.u64 = 10545; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2_MC.out
@@ -7,12 +7,12 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (17649 clocks)
 	76 Noncacheable Reads
 	7 Noncacheable Writes
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (17609 clocks)
-	86 Noncacheable Reads
-	9 Noncacheable Writes
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14807 clocks)
 	66 Noncacheable Reads
 	12 Noncacheable Writes
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (17609 clocks)
+	86 Noncacheable Reads
+	9 Noncacheable Writes
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (18057 clocks)
 	67 Noncacheable Reads
 	11 Noncacheable Writes
@@ -118,7 +118,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 111; SumSQ.u64 = 111; Count.u64 = 111; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 300; SumSQ.u64 = 300; Count.u64 = 300; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 1020; SumSQ.u64 = 1020; Count.u64 = 1020; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 262255; SumSQ.u64 = 3867881; Count.u64 = 18055; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 262255; SumSQ.u64 = 3867881; Count.u64 = 18057; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
@@ -254,7 +254,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 142; SumSQ.u64 = 142; Count.u64 = 142; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 449; SumSQ.u64 = 449; Count.u64 = 449; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 379; SumSQ.u64 = 379; Count.u64 = 379; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 101196; SumSQ.u64 = 603842; Count.u64 = 18053; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 101196; SumSQ.u64 = 603842; Count.u64 = 18057; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -492,7 +492,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 297; SumSQ.u64 = 297; Count.u64 = 297; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 1227; SumSQ.u64 = 1227; Count.u64 = 1227; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 247658; SumSQ.u64 = 3601194; Count.u64 = 17935; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 247658; SumSQ.u64 = 3601194; Count.u64 = 18057; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -598,7 +598,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 2837; SumSQ.u64 = 6083; Count.u64 = 1954; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 315424; SumSQ.u64 = 129915904; Count.u64 = 1949; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 3506613; SumSQ.u64 = 24532418729; Count.u64 = 1538; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 3549615; SumSQ.u64 = 26381590733; Count.u64 = 1539; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4800; SumSQ.u64 = 4800; Count.u64 = 4800; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 216; SumSQ.u64 = 216; Count.u64 = 216; 
@@ -628,7 +628,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 176; SumSQ.u64 = 176; Count.u64 = 176; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 470; SumSQ.u64 = 470; Count.u64 = 470; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 410; SumSQ.u64 = 410; Count.u64 = 410; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 103024; SumSQ.u64 = 647412; Count.u64 = 17952; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 103024; SumSQ.u64 = 647412; Count.u64 = 18057; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -866,7 +866,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 298; SumSQ.u64 = 298; Count.u64 = 298; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 1343; SumSQ.u64 = 1343; Count.u64 = 1343; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 221250; SumSQ.u64 = 3151162; Count.u64 = 17954; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 221250; SumSQ.u64 = 3151162; Count.u64 = 18057; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
@@ -972,7 +972,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 2823; SumSQ.u64 = 6285; Count.u64 = 1896; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 312384; SumSQ.u64 = 130037760; Count.u64 = 1890; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 3875681; SumSQ.u64 = 166267969895; Count.u64 = 1444; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 3916598; SumSQ.u64 = 167942170784; Count.u64 = 1445; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4788; SumSQ.u64 = 4788; Count.u64 = 4788; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 252; SumSQ.u64 = 252; Count.u64 = 252; 
@@ -1002,7 +1002,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 154; SumSQ.u64 = 154; Count.u64 = 154; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 458; SumSQ.u64 = 458; Count.u64 = 458; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 400; SumSQ.u64 = 400; Count.u64 = 400; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 92953; SumSQ.u64 = 584597; Count.u64 = 17957; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 92953; SumSQ.u64 = 584597; Count.u64 = 18057; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1240,7 +1240,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 127; SumSQ.u64 = 127; Count.u64 = 127; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 1357; SumSQ.u64 = 1357; Count.u64 = 1357; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 249884; SumSQ.u64 = 3616314; Count.u64 = 17955; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 249884; SumSQ.u64 = 3616314; Count.u64 = 18057; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
@@ -1346,7 +1346,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 2820; SumSQ.u64 = 6146; Count.u64 = 1910; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 313888; SumSQ.u64 = 130413568; Count.u64 = 1908; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 3621094; SumSQ.u64 = 42345935268; Count.u64 = 1525; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 3661594; SumSQ.u64 = 43986185268; Count.u64 = 1526; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 4832; SumSQ.u64 = 4832; Count.u64 = 4832; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 214; SumSQ.u64 = 214; Count.u64 = 214; 
@@ -1376,7 +1376,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 155; SumSQ.u64 = 155; Count.u64 = 155; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 457; SumSQ.u64 = 457; Count.u64 = 457; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 391; SumSQ.u64 = 391; Count.u64 = 391; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 101284; SumSQ.u64 = 630248; Count.u64 = 17958; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 101284; SumSQ.u64 = 630248; Count.u64 = 18057; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1614,7 +1614,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 138; SumSQ.u64 = 138; Count.u64 = 138; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 311; SumSQ.u64 = 311; Count.u64 = 311; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 1291; SumSQ.u64 = 1291; Count.u64 = 1291; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 254815; SumSQ.u64 = 3735157; Count.u64 = 17944; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 254815; SumSQ.u64 = 3735157; Count.u64 = 18057; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
@@ -1720,7 +1720,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 2891; SumSQ.u64 = 6439; Count.u64 = 1949; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 311008; SumSQ.u64 = 127273984; Count.u64 = 1944; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 3376631; SumSQ.u64 = 18634578563; Count.u64 = 1521; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 3417548; SumSQ.u64 = 20308779452; Count.u64 = 1522; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 4919; SumSQ.u64 = 4919; Count.u64 = 4919; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 186; SumSQ.u64 = 186; Count.u64 = 186; 
@@ -1750,7 +1750,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 175; SumSQ.u64 = 175; Count.u64 = 175; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 465; SumSQ.u64 = 465; Count.u64 = 465; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 386; SumSQ.u64 = 386; Count.u64 = 386; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 98218; SumSQ.u64 = 595626; Count.u64 = 17957; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 98218; SumSQ.u64 = 595626; Count.u64 = 18057; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1988,7 +1988,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 126; SumSQ.u64 = 126; Count.u64 = 126; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 269; SumSQ.u64 = 269; Count.u64 = 269; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 1352; SumSQ.u64 = 1352; Count.u64 = 1352; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 209380; SumSQ.u64 = 3009110; Count.u64 = 16745; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 209380; SumSQ.u64 = 3009110; Count.u64 = 18057; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -2094,7 +2094,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 2837; SumSQ.u64 = 6379; Count.u64 = 1856; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 318400; SumSQ.u64 = 135430144; Count.u64 = 1849; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 3419790; SumSQ.u64 = 46974174632; Count.u64 = 1446; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 3964860; SumSQ.u64 = 344075479532; Count.u64 = 1447; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4830; SumSQ.u64 = 4830; Count.u64 = 4830; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 180; SumSQ.u64 = 180; Count.u64 = 180; 
@@ -2124,7 +2124,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 174; SumSQ.u64 = 174; Count.u64 = 174; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 461; SumSQ.u64 = 461; Count.u64 = 461; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 388; SumSQ.u64 = 388; Count.u64 = 388; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90327; SumSQ.u64 = 576909; Count.u64 = 16748; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90327; SumSQ.u64 = 576909; Count.u64 = 18057; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2335,7 +2335,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 6618; SumSQ.u64 = 16940; Count.u64 = 4471; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 1214784; SumSQ.u64 = 607739904; Count.u64 = 4479; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1855598; SumSQ.u64 = 6216358284; Count.u64 = 1539; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1885139; SumSQ.u64 = 7089028965; Count.u64 = 1540; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 3843; SumSQ.u64 = 3843; Count.u64 = 3843; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 277; SumSQ.u64 = 277; Count.u64 = 277; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 628; SumSQ.u64 = 628; Count.u64 = 628; 
@@ -2365,7 +2365,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49222; SumSQ.u64 = 274800; Count.u64 = 10503; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49222; SumSQ.u64 = 274800; Count.u64 = 10545; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2576,7 +2576,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 6686; SumSQ.u64 = 16694; Count.u64 = 4534; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 1263072; SumSQ.u64 = 638407680; Count.u64 = 4545; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1684588; SumSQ.u64 = 8533332168; Count.u64 = 1476; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1687711; SumSQ.u64 = 8543085297; Count.u64 = 1477; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4226; SumSQ.u64 = 4226; Count.u64 = 4226; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 308; SumSQ.u64 = 308; Count.u64 = 308; 
@@ -2606,7 +2606,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52148; SumSQ.u64 = 297874; Count.u64 = 10540; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52148; SumSQ.u64 = 297874; Count.u64 = 10545; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2817,7 +2817,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 6736; SumSQ.u64 = 17812; Count.u64 = 4476; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 1271968; SumSQ.u64 = 646319104; Count.u64 = 4489; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1697972; SumSQ.u64 = 4896058056; Count.u64 = 1486; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1757387; SumSQ.u64 = 8426200281; Count.u64 = 1487; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4188; SumSQ.u64 = 4188; Count.u64 = 4188; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 306; SumSQ.u64 = 306; Count.u64 = 306; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 288; SumSQ.u64 = 288; Count.u64 = 288; 
@@ -2847,7 +2847,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (15837 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 50825; SumSQ.u64 = 290297; Count.u64 = 10462; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 50825; SumSQ.u64 = 290297; Count.u64 = 10545; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_MC.out
@@ -4,11 +4,11 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (13967 clocks)
 TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (15458 clocks)
-TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (13967 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (14367 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (13878 clocks)
+TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (14373 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 557248; SumSQ.u64 = 287518720; Count.u64 = 1875; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 1875; SumSQ.u64 = 1875; Count.u64 = 1875; 
@@ -106,7 +106,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 144; SumSQ.u64 = 144; Count.u64 = 144; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 319; SumSQ.u64 = 319; Count.u64 = 319; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 1166; SumSQ.u64 = 1166; Count.u64 = 1166; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 214292; SumSQ.u64 = 3227610; Count.u64 = 15296; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 214292; SumSQ.u64 = 3227610; Count.u64 = 15458; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; 
@@ -212,7 +212,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 2936; SumSQ.u64 = 7030; Count.u64 = 1875; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 316736; SumSQ.u64 = 133812224; Count.u64 = 1869; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 2927928; SumSQ.u64 = 22830492754; Count.u64 = 1472; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 2993448; SumSQ.u64 = 27123363154; Count.u64 = 1473; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4881; SumSQ.u64 = 4881; Count.u64 = 4881; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -242,7 +242,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 183; SumSQ.u64 = 183; Count.u64 = 183; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 518; SumSQ.u64 = 518; Count.u64 = 518; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 319; SumSQ.u64 = 319; Count.u64 = 319; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 84223; SumSQ.u64 = 519383; Count.u64 = 15299; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 84223; SumSQ.u64 = 519383; Count.u64 = 15458; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -480,7 +480,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 134; SumSQ.u64 = 134; Count.u64 = 134; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 305; SumSQ.u64 = 305; Count.u64 = 305; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 1474; SumSQ.u64 = 1474; Count.u64 = 1474; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 204419; SumSQ.u64 = 3062321; Count.u64 = 14899; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 204419; SumSQ.u64 = 3062321; Count.u64 = 15458; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 16; SumSQ.u64 = 16; Count.u64 = 16; 
@@ -586,7 +586,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache1.packet_latency : Accumulator : Sum.u64 = 3044; SumSQ.u64 = 7788; Count.u64 = 1847; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 305792; SumSQ.u64 = 127803392; Count.u64 = 1842; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 2879178; SumSQ.u64 = 24796953504; Count.u64 = 1432; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 3110247; SumSQ.u64 = 78189836265; Count.u64 = 1433; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 5193; SumSQ.u64 = 5193; Count.u64 = 5193; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -616,7 +616,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 171; SumSQ.u64 = 171; Count.u64 = 171; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 508; SumSQ.u64 = 508; Count.u64 = 508; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 341; SumSQ.u64 = 341; Count.u64 = 341; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 85971; SumSQ.u64 = 552775; Count.u64 = 14902; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 85971; SumSQ.u64 = 552775; Count.u64 = 15458; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -854,7 +854,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 139; SumSQ.u64 = 139; Count.u64 = 139; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 308; SumSQ.u64 = 308; Count.u64 = 308; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 1507; SumSQ.u64 = 1507; Count.u64 = 1507; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 220155; SumSQ.u64 = 3292995; Count.u64 = 15102; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 220155; SumSQ.u64 = 3292995; Count.u64 = 15458; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; 
@@ -960,7 +960,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 3027; SumSQ.u64 = 7965; Count.u64 = 1804; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 308160; SumSQ.u64 = 130904064; Count.u64 = 1799; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 2918071; SumSQ.u64 = 16917683217; Count.u64 = 1405; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 3011347; SumSQ.u64 = 25618095393; Count.u64 = 1406; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 5173; SumSQ.u64 = 5173; Count.u64 = 5173; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -990,7 +990,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 176; SumSQ.u64 = 176; Count.u64 = 176; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 499; SumSQ.u64 = 499; Count.u64 = 499; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 307; SumSQ.u64 = 307; Count.u64 = 307; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 87261; SumSQ.u64 = 550429; Count.u64 = 15231; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 87261; SumSQ.u64 = 550429; Count.u64 = 15458; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1228,7 +1228,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 114; SumSQ.u64 = 114; Count.u64 = 114; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 303; SumSQ.u64 = 303; Count.u64 = 303; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 1356; SumSQ.u64 = 1356; Count.u64 = 1356; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 228530; SumSQ.u64 = 3443472; Count.u64 = 15456; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 228530; SumSQ.u64 = 3443472; Count.u64 = 15458; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
@@ -1364,7 +1364,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 469; SumSQ.u64 = 469; Count.u64 = 469; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 283; SumSQ.u64 = 283; Count.u64 = 283; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 86349; SumSQ.u64 = 521361; Count.u64 = 15454; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 86349; SumSQ.u64 = 521361; Count.u64 = 15458; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1602,7 +1602,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 133; SumSQ.u64 = 133; Count.u64 = 133; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 294; SumSQ.u64 = 294; Count.u64 = 294; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 1657; SumSQ.u64 = 1657; Count.u64 = 1657; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 205119; SumSQ.u64 = 3067625; Count.u64 = 15103; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 205119; SumSQ.u64 = 3067625; Count.u64 = 15458; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 22; SumSQ.u64 = 22; Count.u64 = 22; 
@@ -1708,7 +1708,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 3088; SumSQ.u64 = 8070; Count.u64 = 1840; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 306752; SumSQ.u64 = 128749568; Count.u64 = 1833; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 2985291; SumSQ.u64 = 33575032941; Count.u64 = 1408; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 3131292; SumSQ.u64 = 54891324942; Count.u64 = 1409; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 5371; SumSQ.u64 = 5371; Count.u64 = 5371; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1738,7 +1738,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 187; SumSQ.u64 = 187; Count.u64 = 187; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 528; SumSQ.u64 = 528; Count.u64 = 528; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 304; SumSQ.u64 = 304; Count.u64 = 304; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 86509; SumSQ.u64 = 557563; Count.u64 = 15106; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 86509; SumSQ.u64 = 557563; Count.u64 = 15458; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1976,7 +1976,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 131; SumSQ.u64 = 131; Count.u64 = 131; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 296; SumSQ.u64 = 296; Count.u64 = 296; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 1385; SumSQ.u64 = 1385; Count.u64 = 1385; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 212865; SumSQ.u64 = 3201263; Count.u64 = 15105; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 212865; SumSQ.u64 = 3201263; Count.u64 = 15458; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; 
@@ -2082,7 +2082,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 3100; SumSQ.u64 = 8036; Count.u64 = 1775; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 302976; SumSQ.u64 = 128507904; Count.u64 = 1774; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 3048776; SumSQ.u64 = 21108370448; Count.u64 = 1372; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 3193943; SumSQ.u64 = 42181828337; Count.u64 = 1373; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4975; SumSQ.u64 = 4975; Count.u64 = 4975; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2112,7 +2112,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 469; SumSQ.u64 = 469; Count.u64 = 469; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 315; SumSQ.u64 = 315; Count.u64 = 315; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 82618; SumSQ.u64 = 514196; Count.u64 = 15108; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 82618; SumSQ.u64 = 514196; Count.u64 = 15458; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2323,7 +2323,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 6413; SumSQ.u64 = 17397; Count.u64 = 4107; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 1263360; SumSQ.u64 = 656818176; Count.u64 = 4116; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1247368; SumSQ.u64 = 3013632072; Count.u64 = 1211; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1296256; SumSQ.u64 = 5403668616; Count.u64 = 1212; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4107; SumSQ.u64 = 4107; Count.u64 = 4107; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 285; SumSQ.u64 = 285; Count.u64 = 285; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2353,7 +2353,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 54; SumSQ.u64 = 54; Count.u64 = 54; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 41672; SumSQ.u64 = 227988; Count.u64 = 8958; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 41672; SumSQ.u64 = 227988; Count.u64 = 9027; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2564,7 +2564,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 6424; SumSQ.u64 = 17688; Count.u64 = 4165; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 1254848; SumSQ.u64 = 649195520; Count.u64 = 4175; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1244180; SumSQ.u64 = 3314395072; Count.u64 = 1230; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1247372; SumSQ.u64 = 3324583936; Count.u64 = 1231; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 4165; SumSQ.u64 = 4165; Count.u64 = 4165; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 276; SumSQ.u64 = 276; Count.u64 = 276; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2594,7 +2594,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 63; SumSQ.u64 = 63; Count.u64 = 63; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 41268; SumSQ.u64 = 224010; Count.u64 = 9022; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 41268; SumSQ.u64 = 224010; Count.u64 = 9027; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2805,7 +2805,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 6387; SumSQ.u64 = 17189; Count.u64 = 4117; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 1243008; SumSQ.u64 = 643424256; Count.u64 = 4126; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1228560; SumSQ.u64 = 3254843472; Count.u64 = 1217; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1333140; SumSQ.u64 = 14191819872; Count.u64 = 1218; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4117; SumSQ.u64 = 4117; Count.u64 = 4117; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 278; SumSQ.u64 = 278; Count.u64 = 278; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2835,7 +2835,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (14975 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 68; SumSQ.u64 = 68; Count.u64 = 68; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 41056; SumSQ.u64 = 228476; Count.u64 = 8880; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 41056; SumSQ.u64 = 228476; Count.u64 = 9027; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_HashXor.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_HashXor.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113422278; SumSQ.u64 = 1131898480; Count.u64 = 11368958; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113422278; SumSQ.u64 = 1131898480; Count.u64 = 11372130; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 8993; SumSQ.u64 = 8993; Count.u64 = 8993; 
@@ -170,7 +170,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113408310; SumSQ.u64 = 1131699832; Count.u64 = 11371838; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113408310; SumSQ.u64 = 1131699832; Count.u64 = 11372130; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 8928; SumSQ.u64 = 8928; Count.u64 = 8928; 
@@ -302,7 +302,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226528346; SumSQ.u64 = 4514849210; Count.u64 = 11371833; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226528346; SumSQ.u64 = 4514849210; Count.u64 = 11372130; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 17586; SumSQ.u64 = 17586; Count.u64 = 17586; 
@@ -539,7 +539,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113430815; SumSQ.u64 = 1131859831; Count.u64 = 11371550; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113430815; SumSQ.u64 = 1131859831; Count.u64 = 11372130; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 8942; SumSQ.u64 = 8942; Count.u64 = 8942; 
@@ -671,7 +671,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113399688; SumSQ.u64 = 1131561590; Count.u64 = 11372126; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113399688; SumSQ.u64 = 1131561590; Count.u64 = 11372130; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 8919; SumSQ.u64 = 8919; Count.u64 = 8919; 
@@ -803,7 +803,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226470549; SumSQ.u64 = 4512229149; Count.u64 = 11372121; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226470549; SumSQ.u64 = 4512229149; Count.u64 = 11372130; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 17517; SumSQ.u64 = 17517; Count.u64 = 17517; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu3 Finished after 10000 issued reads, 10000 returned (5686065 clock
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 452199919; SumSQ.u64 = 17989232419; Count.u64 = 11372115; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 452199919; SumSQ.u64 = 17989232419; Count.u64 = 11372130; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 35105; SumSQ.u64 = 35105; Count.u64 = 35105; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_HashXor_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_HashXor_MC.out
@@ -38,7 +38,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113422278; SumSQ.u64 = 1131898480; Count.u64 = 11368958; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113422278; SumSQ.u64 = 1131898480; Count.u64 = 11372130; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 8993; SumSQ.u64 = 8993; Count.u64 = 8993; 
@@ -170,7 +170,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113408310; SumSQ.u64 = 1131699832; Count.u64 = 11371838; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113408310; SumSQ.u64 = 1131699832; Count.u64 = 11372130; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 8928; SumSQ.u64 = 8928; Count.u64 = 8928; 
@@ -302,7 +302,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226528346; SumSQ.u64 = 4514849210; Count.u64 = 11371833; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226528346; SumSQ.u64 = 4514849210; Count.u64 = 11372130; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 17586; SumSQ.u64 = 17586; Count.u64 = 17586; 
@@ -539,7 +539,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113430815; SumSQ.u64 = 1131859831; Count.u64 = 11371550; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113430815; SumSQ.u64 = 1131859831; Count.u64 = 11372130; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 8942; SumSQ.u64 = 8942; Count.u64 = 8942; 
@@ -671,7 +671,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113399688; SumSQ.u64 = 1131561590; Count.u64 = 11372126; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 113399688; SumSQ.u64 = 1131561590; Count.u64 = 11372130; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 8919; SumSQ.u64 = 8919; Count.u64 = 8919; 
@@ -803,7 +803,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226470549; SumSQ.u64 = 4512229149; Count.u64 = 11372121; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 226470549; SumSQ.u64 = 4512229149; Count.u64 = 11372130; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 17517; SumSQ.u64 = 17517; Count.u64 = 17517; 
@@ -1044,7 +1044,7 @@ TrivialCPU cpu0 Finished after 10000 issued reads, 10000 returned (5684481 clock
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 452199919; SumSQ.u64 = 17989232419; Count.u64 = 11372115; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 452199919; SumSQ.u64 = 17989232419; Count.u64 = 11372130; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 35105; SumSQ.u64 = 35105; Count.u64 = 35105; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Incoherent.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Incoherent.out
@@ -30,7 +30,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 34272; SumSQ.u64 = 48332; Count.u64 = 208104; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 34272; SumSQ.u64 = 48332; Count.u64 = 208108; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 392; SumSQ.u64 = 392; Count.u64 = 392; 
@@ -116,7 +116,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 207770; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 208108; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Incoherent_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Incoherent_MC.out
@@ -30,7 +30,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 34272; SumSQ.u64 = 48332; Count.u64 = 208104; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 34272; SumSQ.u64 = 48332; Count.u64 = 208108; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 392; SumSQ.u64 = 392; Count.u64 = 392; 
@@ -116,7 +116,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 207770; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 208108; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1.out
@@ -132,7 +132,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 3262; SumSQ.u64 = 3262; Count.u64 = 3262; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1127998; SumSQ.u64 = 11152540; Count.u64 = 114492; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1127998; SumSQ.u64 = 11152540; Count.u64 = 114494; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1331; SumSQ.u64 = 1331; Count.u64 = 1331; 
@@ -268,7 +268,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 501; SumSQ.u64 = 501; Count.u64 = 501; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 298520; SumSQ.u64 = 825942; Count.u64 = 114490; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 298520; SumSQ.u64 = 825942; Count.u64 = 114494; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 1273; SumSQ.u64 = 1273; Count.u64 = 1273; 
@@ -507,7 +507,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 2967; SumSQ.u64 = 2967; Count.u64 = 2967; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1068320; SumSQ.u64 = 10548160; Count.u64 = 108698; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1068320; SumSQ.u64 = 10548160; Count.u64 = 114494; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1312; SumSQ.u64 = 1312; Count.u64 = 1312; 
@@ -643,7 +643,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 485; SumSQ.u64 = 485; Count.u64 = 485; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 287359; SumSQ.u64 = 797593; Count.u64 = 108696; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 287359; SumSQ.u64 = 797593; Count.u64 = 114494; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 1255; SumSQ.u64 = 1255; Count.u64 = 1255; 
@@ -882,7 +882,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 3178; SumSQ.u64 = 3178; Count.u64 = 3178; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1102060; SumSQ.u64 = 10896940; Count.u64 = 111840; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1102060; SumSQ.u64 = 10896940; Count.u64 = 114494; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1319; SumSQ.u64 = 1319; Count.u64 = 1319; 
@@ -1018,7 +1018,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 482; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 287499; SumSQ.u64 = 789841; Count.u64 = 111838; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 287499; SumSQ.u64 = 789841; Count.u64 = 114494; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 1261; SumSQ.u64 = 1261; Count.u64 = 1261; 
@@ -1257,7 +1257,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 3253; SumSQ.u64 = 3253; Count.u64 = 3253; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1111956; SumSQ.u64 = 10985272; Count.u64 = 113135; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1111956; SumSQ.u64 = 10985272; Count.u64 = 114494; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 1315; Count.u64 = 1315; 
@@ -1393,7 +1393,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 638; SumSQ.u64 = 638; Count.u64 = 638; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 292504; SumSQ.u64 = 809066; Count.u64 = 113133; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 292504; SumSQ.u64 = 809066; Count.u64 = 114494; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 1257; SumSQ.u64 = 1257; Count.u64 = 1257; 
@@ -1632,7 +1632,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 3295; SumSQ.u64 = 3295; Count.u64 = 3295; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1100178; SumSQ.u64 = 10872716; Count.u64 = 111768; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1100178; SumSQ.u64 = 10872716; Count.u64 = 114494; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1336; SumSQ.u64 = 1336; Count.u64 = 1336; 
@@ -1768,7 +1768,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 522; SumSQ.u64 = 522; Count.u64 = 522; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 293036; SumSQ.u64 = 811154; Count.u64 = 111766; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 293036; SumSQ.u64 = 811154; Count.u64 = 114494; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 1272; SumSQ.u64 = 1272; Count.u64 = 1272; 
@@ -2007,7 +2007,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 2935; SumSQ.u64 = 2935; Count.u64 = 2935; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1104468; SumSQ.u64 = 10929142; Count.u64 = 111951; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1104468; SumSQ.u64 = 10929142; Count.u64 = 114494; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1322; SumSQ.u64 = 1322; Count.u64 = 1322; 
@@ -2143,7 +2143,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 528; SumSQ.u64 = 528; Count.u64 = 528; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 290804; SumSQ.u64 = 798304; Count.u64 = 111949; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 290804; SumSQ.u64 = 798304; Count.u64 = 114494; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 1266; SumSQ.u64 = 1266; Count.u64 = 1266; 
@@ -2382,7 +2382,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 2904; SumSQ.u64 = 2904; Count.u64 = 2904; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1074192; SumSQ.u64 = 10621360; Count.u64 = 109013; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1074192; SumSQ.u64 = 10621360; Count.u64 = 114494; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1311; SumSQ.u64 = 1311; Count.u64 = 1311; 
@@ -2518,7 +2518,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.NACK_recv : Accumulator : Sum.u64 = 500; SumSQ.u64 = 500; Count.u64 = 500; 
- l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 287356; SumSQ.u64 = 800488; Count.u64 = 109011; 
+ l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 287356; SumSQ.u64 = 800488; Count.u64 = 114494; 
  l2cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_E : Accumulator : Sum.u64 = 1251; SumSQ.u64 = 1251; Count.u64 = 1251; 
@@ -2757,7 +2757,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 2776; SumSQ.u64 = 2776; Count.u64 = 2776; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1121132; SumSQ.u64 = 11075210; Count.u64 = 114056; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1121132; SumSQ.u64 = 11075210; Count.u64 = 114494; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1328; SumSQ.u64 = 1328; Count.u64 = 1328; 
@@ -2893,7 +2893,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.NACK_recv : Accumulator : Sum.u64 = 544; SumSQ.u64 = 544; Count.u64 = 544; 
- l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 290907; SumSQ.u64 = 795151; Count.u64 = 114054; 
+ l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 290907; SumSQ.u64 = 795151; Count.u64 = 114494; 
  l2cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_E : Accumulator : Sum.u64 = 1268; SumSQ.u64 = 1268; Count.u64 = 1268; 
@@ -3105,7 +3105,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 11880; SumSQ.u64 = 21214; Count.u64 = 9458; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 2357504; SumSQ.u64 = 1261518848; Count.u64 = 6708; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 27393334; SumSQ.u64 = 483548659564; Count.u64 = 5112; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 27396064; SumSQ.u64 = 483556112464; Count.u64 = 5113; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 9458; SumSQ.u64 = 9458; Count.u64 = 9458; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3135,7 +3135,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 256302; SumSQ.u64 = 1297334; Count.u64 = 66863; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 256302; SumSQ.u64 = 1297334; Count.u64 = 66868; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3346,7 +3346,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 12614; SumSQ.u64 = 22452; Count.u64 = 10104; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 2592512; SumSQ.u64 = 1392754688; Count.u64 = 7228; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 26665626; SumSQ.u64 = 415329112380; Count.u64 = 5426; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 26850426; SumSQ.u64 = 449480152380; Count.u64 = 5427; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 10104; SumSQ.u64 = 10104; Count.u64 = 10104; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3376,7 +3376,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 263229; SumSQ.u64 = 1358321; Count.u64 = 66608; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 263229; SumSQ.u64 = 1358321; Count.u64 = 66868; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3587,7 +3587,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 12626; SumSQ.u64 = 22836; Count.u64 = 9954; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 2608896; SumSQ.u64 = 1405304832; Count.u64 = 7172; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 26028880; SumSQ.u64 = 348833596792; Count.u64 = 5416; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 26409316; SumSQ.u64 = 493565146888; Count.u64 = 5417; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 9954; SumSQ.u64 = 9954; Count.u64 = 9954; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3617,7 +3617,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 259672; SumSQ.u64 = 1340968; Count.u64 = 66334; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 259672; SumSQ.u64 = 1340968; Count.u64 = 66868; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3828,7 +3828,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache3.packet_latency : Accumulator : Sum.u64 = 12398; SumSQ.u64 = 22098; Count.u64 = 9915; 
  l3cache3.send_bit_count : Accumulator : Sum.u64 = 2540224; SumSQ.u64 = 1364340736; Count.u64 = 7091; 
  l3cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.idle_time : Accumulator : Sum.u64 = 26245810; SumSQ.u64 = 366774844972; Count.u64 = 5341; 
+ l3cache3.idle_time : Accumulator : Sum.u64 = 26680510; SumSQ.u64 = 555738934972; Count.u64 = 5342; 
  l3cache3.TotalEventsReceived : Accumulator : Sum.u64 = 9915; SumSQ.u64 = 9915; Count.u64 = 9915; 
  l3cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3858,7 +3858,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l3cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 259968; SumSQ.u64 = 1326644; Count.u64 = 66258; 
+ l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 259968; SumSQ.u64 = 1326644; Count.u64 = 66868; 
  l3cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1_MC.out
@@ -12,9 +12,11 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (111953 clocks)
 TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (111770 clocks)
+TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
 TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (113137 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (114494 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (108700 clocks)
+TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 1152576; SumSQ.u64 = 663883776; Count.u64 = 2001; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 2001; SumSQ.u64 = 2001; Count.u64 = 2001; 
@@ -130,7 +132,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 3262; SumSQ.u64 = 3262; Count.u64 = 3262; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1127998; SumSQ.u64 = 11152540; Count.u64 = 114492; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1127998; SumSQ.u64 = 11152540; Count.u64 = 114494; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1331; SumSQ.u64 = 1331; Count.u64 = 1331; 
@@ -266,7 +268,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 501; SumSQ.u64 = 501; Count.u64 = 501; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 298520; SumSQ.u64 = 825942; Count.u64 = 114490; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 298520; SumSQ.u64 = 825942; Count.u64 = 114494; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 1273; SumSQ.u64 = 1273; Count.u64 = 1273; 
@@ -505,7 +507,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 2967; SumSQ.u64 = 2967; Count.u64 = 2967; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1068320; SumSQ.u64 = 10548160; Count.u64 = 108698; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1068320; SumSQ.u64 = 10548160; Count.u64 = 114494; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1312; SumSQ.u64 = 1312; Count.u64 = 1312; 
@@ -641,7 +643,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 485; SumSQ.u64 = 485; Count.u64 = 485; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 287359; SumSQ.u64 = 797593; Count.u64 = 108696; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 287359; SumSQ.u64 = 797593; Count.u64 = 114494; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 1255; SumSQ.u64 = 1255; Count.u64 = 1255; 
@@ -880,7 +882,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 3178; SumSQ.u64 = 3178; Count.u64 = 3178; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1102060; SumSQ.u64 = 10896940; Count.u64 = 111840; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1102060; SumSQ.u64 = 10896940; Count.u64 = 114494; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1319; SumSQ.u64 = 1319; Count.u64 = 1319; 
@@ -1016,7 +1018,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 482; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 287499; SumSQ.u64 = 789841; Count.u64 = 111838; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 287499; SumSQ.u64 = 789841; Count.u64 = 114494; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 1261; SumSQ.u64 = 1261; Count.u64 = 1261; 
@@ -1255,7 +1257,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 3253; SumSQ.u64 = 3253; Count.u64 = 3253; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1111956; SumSQ.u64 = 10985272; Count.u64 = 113135; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1111956; SumSQ.u64 = 10985272; Count.u64 = 114494; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 1315; Count.u64 = 1315; 
@@ -1391,7 +1393,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 638; SumSQ.u64 = 638; Count.u64 = 638; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 292504; SumSQ.u64 = 809066; Count.u64 = 113133; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 292504; SumSQ.u64 = 809066; Count.u64 = 114494; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 1257; SumSQ.u64 = 1257; Count.u64 = 1257; 
@@ -1536,12 +1538,10 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (111842 clocks)
  l2cache3.eventSent_GetX : Accumulator : Sum.u64 = 214; SumSQ.u64 = 214; Count.u64 = 214; 
  l2cache3.eventSent_GetSX : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.eventSent_PutS : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
-TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (109015 clocks)
  l2cache3.eventSent_PutM : Accumulator : Sum.u64 = 147; SumSQ.u64 = 147; Count.u64 = 147; 
  l2cache3.eventSent_FlushLine : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.eventSent_FlushLineInv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.eventSent_FetchResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
-TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l2cache3.eventSent_FetchXResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.eventSent_AckInv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.eventSent_NACK_down : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1632,7 +1632,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 3295; SumSQ.u64 = 3295; Count.u64 = 3295; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1100178; SumSQ.u64 = 10872716; Count.u64 = 111768; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1100178; SumSQ.u64 = 10872716; Count.u64 = 114494; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1336; SumSQ.u64 = 1336; Count.u64 = 1336; 
@@ -1768,7 +1768,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 522; SumSQ.u64 = 522; Count.u64 = 522; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 293036; SumSQ.u64 = 811154; Count.u64 = 111766; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 293036; SumSQ.u64 = 811154; Count.u64 = 114494; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 1272; SumSQ.u64 = 1272; Count.u64 = 1272; 
@@ -2007,7 +2007,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 2935; SumSQ.u64 = 2935; Count.u64 = 2935; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1104468; SumSQ.u64 = 10929142; Count.u64 = 111951; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1104468; SumSQ.u64 = 10929142; Count.u64 = 114494; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1322; SumSQ.u64 = 1322; Count.u64 = 1322; 
@@ -2143,7 +2143,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 528; SumSQ.u64 = 528; Count.u64 = 528; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 290804; SumSQ.u64 = 798304; Count.u64 = 111949; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 290804; SumSQ.u64 = 798304; Count.u64 = 114494; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 1266; SumSQ.u64 = 1266; Count.u64 = 1266; 
@@ -2382,7 +2382,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 2904; SumSQ.u64 = 2904; Count.u64 = 2904; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1074192; SumSQ.u64 = 10621360; Count.u64 = 109013; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1074192; SumSQ.u64 = 10621360; Count.u64 = 114494; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1311; SumSQ.u64 = 1311; Count.u64 = 1311; 
@@ -2518,7 +2518,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l2cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.NACK_recv : Accumulator : Sum.u64 = 500; SumSQ.u64 = 500; Count.u64 = 500; 
- l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 287356; SumSQ.u64 = 800488; Count.u64 = 109011; 
+ l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 287356; SumSQ.u64 = 800488; Count.u64 = 114494; 
  l2cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_E : Accumulator : Sum.u64 = 1251; SumSQ.u64 = 1251; Count.u64 = 1251; 
@@ -2757,7 +2757,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 2776; SumSQ.u64 = 2776; Count.u64 = 2776; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1121132; SumSQ.u64 = 11075210; Count.u64 = 114056; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1121132; SumSQ.u64 = 11075210; Count.u64 = 114494; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1328; SumSQ.u64 = 1328; Count.u64 = 1328; 
@@ -2893,7 +2893,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l2cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.NACK_recv : Accumulator : Sum.u64 = 544; SumSQ.u64 = 544; Count.u64 = 544; 
- l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 290907; SumSQ.u64 = 795151; Count.u64 = 114054; 
+ l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 290907; SumSQ.u64 = 795151; Count.u64 = 114494; 
  l2cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_E : Accumulator : Sum.u64 = 1268; SumSQ.u64 = 1268; Count.u64 = 1268; 
@@ -3105,7 +3105,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 11880; SumSQ.u64 = 21214; Count.u64 = 9458; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 2357504; SumSQ.u64 = 1261518848; Count.u64 = 6708; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 27393334; SumSQ.u64 = 483548659564; Count.u64 = 5112; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 27396064; SumSQ.u64 = 483556112464; Count.u64 = 5113; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 9458; SumSQ.u64 = 9458; Count.u64 = 9458; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3135,7 +3135,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 256302; SumSQ.u64 = 1297334; Count.u64 = 66863; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 256302; SumSQ.u64 = 1297334; Count.u64 = 66868; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3346,7 +3346,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 12614; SumSQ.u64 = 22452; Count.u64 = 10104; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 2592512; SumSQ.u64 = 1392754688; Count.u64 = 7228; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 26665626; SumSQ.u64 = 415329112380; Count.u64 = 5426; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 26850426; SumSQ.u64 = 449480152380; Count.u64 = 5427; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 10104; SumSQ.u64 = 10104; Count.u64 = 10104; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3376,7 +3376,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 263229; SumSQ.u64 = 1358321; Count.u64 = 66608; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 263229; SumSQ.u64 = 1358321; Count.u64 = 66868; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3587,7 +3587,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 12626; SumSQ.u64 = 22836; Count.u64 = 9954; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 2608896; SumSQ.u64 = 1405304832; Count.u64 = 7172; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 26028880; SumSQ.u64 = 348833596792; Count.u64 = 5416; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 26409316; SumSQ.u64 = 493565146888; Count.u64 = 5417; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 9954; SumSQ.u64 = 9954; Count.u64 = 9954; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3617,7 +3617,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 259672; SumSQ.u64 = 1340968; Count.u64 = 66334; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 259672; SumSQ.u64 = 1340968; Count.u64 = 66868; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3828,7 +3828,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache3.packet_latency : Accumulator : Sum.u64 = 12398; SumSQ.u64 = 22098; Count.u64 = 9915; 
  l3cache3.send_bit_count : Accumulator : Sum.u64 = 2540224; SumSQ.u64 = 1364340736; Count.u64 = 7091; 
  l3cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.idle_time : Accumulator : Sum.u64 = 26245810; SumSQ.u64 = 366774844972; Count.u64 = 5341; 
+ l3cache3.idle_time : Accumulator : Sum.u64 = 26680510; SumSQ.u64 = 555738934972; Count.u64 = 5342; 
  l3cache3.TotalEventsReceived : Accumulator : Sum.u64 = 9915; SumSQ.u64 = 9915; Count.u64 = 9915; 
  l3cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3858,7 +3858,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114058 clocks)
  l3cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 259968; SumSQ.u64 = 1326644; Count.u64 = 66258; 
+ l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 259968; SumSQ.u64 = 1326644; Count.u64 = 66868; 
  l3cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2.out
@@ -132,7 +132,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 2952; SumSQ.u64 = 2952; Count.u64 = 2952; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1102178; SumSQ.u64 = 10867284; Count.u64 = 112563; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1102178; SumSQ.u64 = 10867284; Count.u64 = 118183; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1320; SumSQ.u64 = 1320; Count.u64 = 1320; 
@@ -268,7 +268,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 443; SumSQ.u64 = 443; Count.u64 = 443; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 288795; SumSQ.u64 = 794741; Count.u64 = 112561; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 288795; SumSQ.u64 = 794741; Count.u64 = 118183; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 1262; SumSQ.u64 = 1262; Count.u64 = 1262; 
@@ -507,7 +507,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 3326; SumSQ.u64 = 3326; Count.u64 = 3326; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1109747; SumSQ.u64 = 10970179; Count.u64 = 112666; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1109747; SumSQ.u64 = 10970179; Count.u64 = 118183; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 1315; Count.u64 = 1315; 
@@ -643,7 +643,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 501; SumSQ.u64 = 501; Count.u64 = 501; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 289190; SumSQ.u64 = 796300; Count.u64 = 112664; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 289190; SumSQ.u64 = 796300; Count.u64 = 118183; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 1260; SumSQ.u64 = 1260; Count.u64 = 1260; 
@@ -882,7 +882,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 2937; SumSQ.u64 = 2937; Count.u64 = 2937; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1121036; SumSQ.u64 = 11075068; Count.u64 = 114305; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1121036; SumSQ.u64 = 11075068; Count.u64 = 118183; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1306; SumSQ.u64 = 1306; Count.u64 = 1306; 
@@ -1018,7 +1018,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 532; SumSQ.u64 = 532; Count.u64 = 532; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 295651; SumSQ.u64 = 816109; Count.u64 = 114303; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 295651; SumSQ.u64 = 816109; Count.u64 = 118183; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 1245; SumSQ.u64 = 1245; Count.u64 = 1245; 
@@ -1257,7 +1257,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 3187; SumSQ.u64 = 3187; Count.u64 = 3187; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1112656; SumSQ.u64 = 11001344; Count.u64 = 113269; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1112656; SumSQ.u64 = 11001344; Count.u64 = 118183; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1307; SumSQ.u64 = 1307; Count.u64 = 1307; 
@@ -1393,7 +1393,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 520; SumSQ.u64 = 520; Count.u64 = 520; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 302158; SumSQ.u64 = 847200; Count.u64 = 113267; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 302158; SumSQ.u64 = 847200; Count.u64 = 118183; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 1246; SumSQ.u64 = 1246; Count.u64 = 1246; 
@@ -1632,7 +1632,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 3463; SumSQ.u64 = 3463; Count.u64 = 3463; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1129579; SumSQ.u64 = 11170321; Count.u64 = 114639; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1129579; SumSQ.u64 = 11170321; Count.u64 = 118183; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1311; SumSQ.u64 = 1311; Count.u64 = 1311; 
@@ -1768,7 +1768,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 552; SumSQ.u64 = 552; Count.u64 = 552; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 294240; SumSQ.u64 = 807960; Count.u64 = 114637; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 294240; SumSQ.u64 = 807960; Count.u64 = 118183; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 1255; SumSQ.u64 = 1255; Count.u64 = 1255; 
@@ -2007,7 +2007,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 3053; SumSQ.u64 = 3053; Count.u64 = 3053; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1163135; SumSQ.u64 = 11501659; Count.u64 = 118181; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1163135; SumSQ.u64 = 11501659; Count.u64 = 118183; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1338; SumSQ.u64 = 1338; Count.u64 = 1338; 
@@ -2143,7 +2143,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 496; SumSQ.u64 = 496; Count.u64 = 496; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 301377; SumSQ.u64 = 824343; Count.u64 = 118179; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 301377; SumSQ.u64 = 824343; Count.u64 = 118183; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 1277; SumSQ.u64 = 1277; Count.u64 = 1277; 
@@ -2382,7 +2382,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 2802; SumSQ.u64 = 2802; Count.u64 = 2802; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1149601; SumSQ.u64 = 11362607; Count.u64 = 116968; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1149601; SumSQ.u64 = 11362607; Count.u64 = 118183; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1316; SumSQ.u64 = 1316; Count.u64 = 1316; 
@@ -2518,7 +2518,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.NACK_recv : Accumulator : Sum.u64 = 610; SumSQ.u64 = 610; Count.u64 = 610; 
- l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 302026; SumSQ.u64 = 836324; Count.u64 = 116966; 
+ l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 302026; SumSQ.u64 = 836324; Count.u64 = 118183; 
  l2cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_E : Accumulator : Sum.u64 = 1258; SumSQ.u64 = 1258; Count.u64 = 1258; 
@@ -2757,7 +2757,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 2937; SumSQ.u64 = 2937; Count.u64 = 2937; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1128747; SumSQ.u64 = 11156121; Count.u64 = 114904; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1128747; SumSQ.u64 = 11156121; Count.u64 = 118183; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1318; SumSQ.u64 = 1318; Count.u64 = 1318; 
@@ -2893,7 +2893,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l2cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.NACK_recv : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 482; 
- l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 293107; SumSQ.u64 = 801757; Count.u64 = 114902; 
+ l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 293107; SumSQ.u64 = 801757; Count.u64 = 118183; 
  l2cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_E : Accumulator : Sum.u64 = 1262; SumSQ.u64 = 1262; Count.u64 = 1262; 
@@ -3105,7 +3105,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 11540; SumSQ.u64 = 19368; Count.u64 = 9751; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 2839488; SumSQ.u64 = 1457811456; Count.u64 = 9751; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 28706594; SumSQ.u64 = 499566144852; Count.u64 = 7309; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 28709681; SumSQ.u64 = 499575674421; Count.u64 = 7310; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 9751; SumSQ.u64 = 9751; Count.u64 = 9751; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3135,7 +3135,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 266969; SumSQ.u64 = 1368787; Count.u64 = 69017; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 266969; SumSQ.u64 = 1368787; Count.u64 = 69022; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 43; SumSQ.u64 = 43; Count.u64 = 43; 
@@ -3367,7 +3367,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 12345; SumSQ.u64 = 23327; Count.u64 = 10073; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 2923072; SumSQ.u64 = 1499435008; Count.u64 = 10073; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 27997394; SumSQ.u64 = 378456836844; Count.u64 = 7401; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 28482431; SumSQ.u64 = 613717728213; Count.u64 = 7402; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 10073; SumSQ.u64 = 10073; Count.u64 = 10073; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3397,7 +3397,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 267726; SumSQ.u64 = 1365560; Count.u64 = 68342; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 267726; SumSQ.u64 = 1365560; Count.u64 = 69022; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
@@ -3629,7 +3629,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 12307; SumSQ.u64 = 22793; Count.u64 = 10171; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 3007680; SumSQ.u64 = 1549971456; Count.u64 = 10171; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 27818832; SumSQ.u64 = 387656240448; Count.u64 = 7415; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 28099665; SumSQ.u64 = 466523414337; Count.u64 = 7416; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 10171; SumSQ.u64 = 10171; Count.u64 = 10171; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3659,7 +3659,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 274829; SumSQ.u64 = 1422477; Count.u64 = 68628; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 274829; SumSQ.u64 = 1422477; Count.u64 = 69022; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 46; SumSQ.u64 = 46; Count.u64 = 46; 
@@ -3891,7 +3891,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache3.packet_latency : Accumulator : Sum.u64 = 11604; SumSQ.u64 = 20954; Count.u64 = 9580; 
  l3cache3.send_bit_count : Accumulator : Sum.u64 = 2765568; SumSQ.u64 = 1416806400; Count.u64 = 9580; 
  l3cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.idle_time : Accumulator : Sum.u64 = 27983652; SumSQ.u64 = 376716601184; Count.u64 = 7177; 
+ l3cache3.idle_time : Accumulator : Sum.u64 = 28862817; SumSQ.u64 = 1149647698409; Count.u64 = 7178; 
  l3cache3.TotalEventsReceived : Accumulator : Sum.u64 = 9580; SumSQ.u64 = 9580; Count.u64 = 9580; 
  l3cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3921,7 +3921,7 @@ TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
  l3cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 261981; SumSQ.u64 = 1324081; Count.u64 = 67790; 
+ l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 261981; SumSQ.u64 = 1324081; Count.u64 = 69022; 
  l3cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_E : Accumulator : Sum.u64 = 48; SumSQ.u64 = 48; Count.u64 = 48; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2_MC.out
@@ -11,13 +11,13 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (118183 clocks)
+TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
+TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
 TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (114641 clocks)
 TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (113271 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (112565 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (112668 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (114307 clocks)
-TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116970 clocks)
-TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 1209024; SumSQ.u64 = 650391552; Count.u64 = 3347; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 3347; SumSQ.u64 = 3347; Count.u64 = 3347; 
  network.output_port_stalls.port0 : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -132,7 +132,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 2952; SumSQ.u64 = 2952; Count.u64 = 2952; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1102178; SumSQ.u64 = 10867284; Count.u64 = 112563; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 1102178; SumSQ.u64 = 10867284; Count.u64 = 118183; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 1320; SumSQ.u64 = 1320; Count.u64 = 1320; 
@@ -268,7 +268,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 443; SumSQ.u64 = 443; Count.u64 = 443; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 288795; SumSQ.u64 = 794741; Count.u64 = 112561; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 288795; SumSQ.u64 = 794741; Count.u64 = 118183; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 1262; SumSQ.u64 = 1262; Count.u64 = 1262; 
@@ -507,7 +507,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 3326; SumSQ.u64 = 3326; Count.u64 = 3326; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1109747; SumSQ.u64 = 10970179; Count.u64 = 112666; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 1109747; SumSQ.u64 = 10970179; Count.u64 = 118183; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 1315; Count.u64 = 1315; 
@@ -643,7 +643,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 501; SumSQ.u64 = 501; Count.u64 = 501; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 289190; SumSQ.u64 = 796300; Count.u64 = 112664; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 289190; SumSQ.u64 = 796300; Count.u64 = 118183; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 1260; SumSQ.u64 = 1260; Count.u64 = 1260; 
@@ -882,7 +882,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 2937; SumSQ.u64 = 2937; Count.u64 = 2937; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1121036; SumSQ.u64 = 11075068; Count.u64 = 114305; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 1121036; SumSQ.u64 = 11075068; Count.u64 = 118183; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1306; SumSQ.u64 = 1306; Count.u64 = 1306; 
@@ -1018,7 +1018,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 532; SumSQ.u64 = 532; Count.u64 = 532; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 295651; SumSQ.u64 = 816109; Count.u64 = 114303; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 295651; SumSQ.u64 = 816109; Count.u64 = 118183; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 1245; SumSQ.u64 = 1245; Count.u64 = 1245; 
@@ -1257,7 +1257,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 3187; SumSQ.u64 = 3187; Count.u64 = 3187; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1112656; SumSQ.u64 = 11001344; Count.u64 = 113269; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 1112656; SumSQ.u64 = 11001344; Count.u64 = 118183; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 1307; SumSQ.u64 = 1307; Count.u64 = 1307; 
@@ -1393,7 +1393,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 520; SumSQ.u64 = 520; Count.u64 = 520; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 302158; SumSQ.u64 = 847200; Count.u64 = 113267; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 302158; SumSQ.u64 = 847200; Count.u64 = 118183; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 1246; SumSQ.u64 = 1246; Count.u64 = 1246; 
@@ -1632,7 +1632,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 3463; SumSQ.u64 = 3463; Count.u64 = 3463; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1129579; SumSQ.u64 = 11170321; Count.u64 = 114639; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 1129579; SumSQ.u64 = 11170321; Count.u64 = 118183; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 1311; SumSQ.u64 = 1311; Count.u64 = 1311; 
@@ -1768,7 +1768,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 552; SumSQ.u64 = 552; Count.u64 = 552; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 294240; SumSQ.u64 = 807960; Count.u64 = 114637; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 294240; SumSQ.u64 = 807960; Count.u64 = 118183; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 1255; SumSQ.u64 = 1255; Count.u64 = 1255; 
@@ -2007,7 +2007,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 3053; SumSQ.u64 = 3053; Count.u64 = 3053; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1163135; SumSQ.u64 = 11501659; Count.u64 = 118181; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 1163135; SumSQ.u64 = 11501659; Count.u64 = 118183; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1338; SumSQ.u64 = 1338; Count.u64 = 1338; 
@@ -2143,7 +2143,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 496; SumSQ.u64 = 496; Count.u64 = 496; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 301377; SumSQ.u64 = 824343; Count.u64 = 118179; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 301377; SumSQ.u64 = 824343; Count.u64 = 118183; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 1277; SumSQ.u64 = 1277; Count.u64 = 1277; 
@@ -2382,7 +2382,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.NACK_recv : Accumulator : Sum.u64 = 2802; SumSQ.u64 = 2802; Count.u64 = 2802; 
- l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1149601; SumSQ.u64 = 11362607; Count.u64 = 116968; 
+ l1cache6.MSHR_occupancy : Accumulator : Sum.u64 = 1149601; SumSQ.u64 = 11362607; Count.u64 = 118183; 
  l1cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache6.evict_E : Accumulator : Sum.u64 = 1316; SumSQ.u64 = 1316; Count.u64 = 1316; 
@@ -2518,7 +2518,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache6.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.NACK_recv : Accumulator : Sum.u64 = 610; SumSQ.u64 = 610; Count.u64 = 610; 
- l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 302026; SumSQ.u64 = 836324; Count.u64 = 116966; 
+ l2cache6.MSHR_occupancy : Accumulator : Sum.u64 = 302026; SumSQ.u64 = 836324; Count.u64 = 118183; 
  l2cache6.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache6.evict_E : Accumulator : Sum.u64 = 1258; SumSQ.u64 = 1258; Count.u64 = 1258; 
@@ -2757,7 +2757,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l1cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.NACK_recv : Accumulator : Sum.u64 = 2937; SumSQ.u64 = 2937; Count.u64 = 2937; 
- l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1128747; SumSQ.u64 = 11156121; Count.u64 = 114904; 
+ l1cache7.MSHR_occupancy : Accumulator : Sum.u64 = 1128747; SumSQ.u64 = 11156121; Count.u64 = 118183; 
  l1cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache7.evict_E : Accumulator : Sum.u64 = 1318; SumSQ.u64 = 1318; Count.u64 = 1318; 
@@ -2893,7 +2893,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l2cache7.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.NACK_recv : Accumulator : Sum.u64 = 482; SumSQ.u64 = 482; Count.u64 = 482; 
- l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 293107; SumSQ.u64 = 801757; Count.u64 = 114902; 
+ l2cache7.MSHR_occupancy : Accumulator : Sum.u64 = 293107; SumSQ.u64 = 801757; Count.u64 = 118183; 
  l2cache7.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache7.evict_E : Accumulator : Sum.u64 = 1262; SumSQ.u64 = 1262; Count.u64 = 1262; 
@@ -3105,7 +3105,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 11540; SumSQ.u64 = 19368; Count.u64 = 9751; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 2839488; SumSQ.u64 = 1457811456; Count.u64 = 9751; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 28706594; SumSQ.u64 = 499566144852; Count.u64 = 7309; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 28709681; SumSQ.u64 = 499575674421; Count.u64 = 7310; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 9751; SumSQ.u64 = 9751; Count.u64 = 9751; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3135,7 +3135,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 266969; SumSQ.u64 = 1368787; Count.u64 = 69017; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 266969; SumSQ.u64 = 1368787; Count.u64 = 69022; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 43; SumSQ.u64 = 43; Count.u64 = 43; 
@@ -3367,7 +3367,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 12345; SumSQ.u64 = 23327; Count.u64 = 10073; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 2923072; SumSQ.u64 = 1499435008; Count.u64 = 10073; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 27997394; SumSQ.u64 = 378456836844; Count.u64 = 7401; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 28482431; SumSQ.u64 = 613717728213; Count.u64 = 7402; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 10073; SumSQ.u64 = 10073; Count.u64 = 10073; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3397,7 +3397,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 267726; SumSQ.u64 = 1365560; Count.u64 = 68342; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 267726; SumSQ.u64 = 1365560; Count.u64 = 69022; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 44; SumSQ.u64 = 44; Count.u64 = 44; 
@@ -3629,7 +3629,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 12307; SumSQ.u64 = 22793; Count.u64 = 10171; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 3007680; SumSQ.u64 = 1549971456; Count.u64 = 10171; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 27818832; SumSQ.u64 = 387656240448; Count.u64 = 7415; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 28099665; SumSQ.u64 = 466523414337; Count.u64 = 7416; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 10171; SumSQ.u64 = 10171; Count.u64 = 10171; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3659,7 +3659,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 274829; SumSQ.u64 = 1422477; Count.u64 = 68628; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 274829; SumSQ.u64 = 1422477; Count.u64 = 69022; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 46; SumSQ.u64 = 46; Count.u64 = 46; 
@@ -3891,7 +3891,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache3.packet_latency : Accumulator : Sum.u64 = 11604; SumSQ.u64 = 20954; Count.u64 = 9580; 
  l3cache3.send_bit_count : Accumulator : Sum.u64 = 2765568; SumSQ.u64 = 1416806400; Count.u64 = 9580; 
  l3cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.idle_time : Accumulator : Sum.u64 = 27983652; SumSQ.u64 = 376716601184; Count.u64 = 7177; 
+ l3cache3.idle_time : Accumulator : Sum.u64 = 28862817; SumSQ.u64 = 1149647698409; Count.u64 = 7178; 
  l3cache3.TotalEventsReceived : Accumulator : Sum.u64 = 9580; SumSQ.u64 = 9580; Count.u64 = 9580; 
  l3cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -3921,7 +3921,7 @@ TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (114906 clocks)
  l3cache3.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 261981; SumSQ.u64 = 1324081; Count.u64 = 67790; 
+ l3cache3.MSHR_occupancy : Accumulator : Sum.u64 = 261981; SumSQ.u64 = 1324081; Count.u64 = 69022; 
  l3cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache3.evict_E : Accumulator : Sum.u64 = 48; SumSQ.u64 = 48; Count.u64 = 48; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams.out
@@ -111,7 +111,7 @@ Completed @ 4396 ns
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 115; SumSQ.u64 = 115; Count.u64 = 115; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 190; SumSQ.u64 = 190; Count.u64 = 190; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 70543; SumSQ.u64 = 648345; Count.u64 = 10344; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 70543; SumSQ.u64 = 648345; Count.u64 = 10543; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -223,7 +223,7 @@ Completed @ 4396 ns
  l2cache0.packet_latency : Accumulator : Sum.u64 = 670; SumSQ.u64 = 964; Count.u64 = 591; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 101824; SumSQ.u64 = 43380736; Count.u64 = 591; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 2384363; SumSQ.u64 = 34335994535; Count.u64 = 415; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 2465312; SumSQ.u64 = 40888735136; Count.u64 = 416; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 1314; SumSQ.u64 = 1314; Count.u64 = 1314; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 104; SumSQ.u64 = 104; Count.u64 = 104; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -253,7 +253,7 @@ Completed @ 4396 ns
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 115; SumSQ.u64 = 115; Count.u64 = 115; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 190; SumSQ.u64 = 190; Count.u64 = 190; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 23294; SumSQ.u64 = 72170; Count.u64 = 10347; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 23294; SumSQ.u64 = 72170; Count.u64 = 10543; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -496,7 +496,7 @@ Completed @ 4396 ns
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 173; SumSQ.u64 = 173; Count.u64 = 173; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 67690; SumSQ.u64 = 612810; Count.u64 = 10345; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 67690; SumSQ.u64 = 612810; Count.u64 = 10543; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -608,7 +608,7 @@ Completed @ 4396 ns
  l2cache1.packet_latency : Accumulator : Sum.u64 = 630; SumSQ.u64 = 896; Count.u64 = 560; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 92160; SumSQ.u64 = 38338560; Count.u64 = 560; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 2393058; SumSQ.u64 = 38973445678; Count.u64 = 397; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 2473590; SumSQ.u64 = 45458848702; Count.u64 = 398; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 1249; SumSQ.u64 = 1249; Count.u64 = 1249; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -638,7 +638,7 @@ Completed @ 4396 ns
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 173; SumSQ.u64 = 173; Count.u64 = 173; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 21945; SumSQ.u64 = 65753; Count.u64 = 10348; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 21945; SumSQ.u64 = 65753; Count.u64 = 10543; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -881,7 +881,7 @@ Completed @ 4396 ns
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 81; SumSQ.u64 = 81; Count.u64 = 81; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 74370; SumSQ.u64 = 671418; Count.u64 = 10408; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 74370; SumSQ.u64 = 671418; Count.u64 = 10543; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -993,7 +993,7 @@ Completed @ 4396 ns
  l2cache2.packet_latency : Accumulator : Sum.u64 = 660; SumSQ.u64 = 928; Count.u64 = 581; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 91968; SumSQ.u64 = 37441536; Count.u64 = 581; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 2273757; SumSQ.u64 = 30342398487; Count.u64 = 402; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 2328018; SumSQ.u64 = 33286654608; Count.u64 = 403; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 1302; SumSQ.u64 = 1302; Count.u64 = 1302; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 100; SumSQ.u64 = 100; Count.u64 = 100; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1023,7 +1023,7 @@ Completed @ 4396 ns
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 175; SumSQ.u64 = 175; Count.u64 = 175; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 23668; SumSQ.u64 = 70678; Count.u64 = 10411; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 23668; SumSQ.u64 = 70678; Count.u64 = 10543; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1266,7 +1266,7 @@ Completed @ 4396 ns
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 78583; SumSQ.u64 = 720919; Count.u64 = 10541; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 78583; SumSQ.u64 = 720919; Count.u64 = 10543; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1408,7 +1408,7 @@ Completed @ 4396 ns
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 23627; SumSQ.u64 = 68827; Count.u64 = 10536; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 23627; SumSQ.u64 = 68827; Count.u64 = 10543; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1651,7 +1651,7 @@ Completed @ 4396 ns
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 194; SumSQ.u64 = 194; Count.u64 = 194; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 75629; SumSQ.u64 = 694401; Count.u64 = 10410; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 75629; SumSQ.u64 = 694401; Count.u64 = 10543; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1763,7 +1763,7 @@ Completed @ 4396 ns
  l2cache4.packet_latency : Accumulator : Sum.u64 = 673; SumSQ.u64 = 927; Count.u64 = 602; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 94336; SumSQ.u64 = 38182912; Count.u64 = 602; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 2311618; SumSQ.u64 = 31752301580; Count.u64 = 415; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 2365045; SumSQ.u64 = 34606745909; Count.u64 = 416; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 1347; SumSQ.u64 = 1347; Count.u64 = 1347; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 105; SumSQ.u64 = 105; Count.u64 = 105; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1793,7 +1793,7 @@ Completed @ 4396 ns
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 194; SumSQ.u64 = 194; Count.u64 = 194; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 24894; SumSQ.u64 = 78472; Count.u64 = 10413; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 24894; SumSQ.u64 = 78472; Count.u64 = 10543; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2036,7 +2036,7 @@ Completed @ 4396 ns
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 174; SumSQ.u64 = 174; Count.u64 = 174; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 78483; SumSQ.u64 = 718157; Count.u64 = 10501; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 78483; SumSQ.u64 = 718157; Count.u64 = 10543; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2148,7 +2148,7 @@ Completed @ 4396 ns
  l2cache5.packet_latency : Accumulator : Sum.u64 = 683; SumSQ.u64 = 977; Count.u64 = 596; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 90880; SumSQ.u64 = 36192256; Count.u64 = 596; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 2324959; SumSQ.u64 = 33903154385; Count.u64 = 410; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 2339005; SumSQ.u64 = 34100444501; Count.u64 = 411; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 1338; SumSQ.u64 = 1338; Count.u64 = 1338; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 98; SumSQ.u64 = 98; Count.u64 = 98; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2178,7 +2178,7 @@ Completed @ 4396 ns
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 185; SumSQ.u64 = 185; Count.u64 = 185; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 25301; SumSQ.u64 = 78687; Count.u64 = 10506; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 25301; SumSQ.u64 = 78687; Count.u64 = 10543; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2389,7 +2389,7 @@ Completed @ 4396 ns
  l3cache0.packet_latency : Accumulator : Sum.u64 = 1299; SumSQ.u64 = 1913; Count.u64 = 1182; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 377728; SumSQ.u64 = 198172672; Count.u64 = 1182; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1726262; SumSQ.u64 = 13145190004; Count.u64 = 716; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1768349; SumSQ.u64 = 14916505573; Count.u64 = 717; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 1182; SumSQ.u64 = 1182; Count.u64 = 1182; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2419,7 +2419,7 @@ Completed @ 4396 ns
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 9043; SumSQ.u64 = 21981; Count.u64 = 6097; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 9043; SumSQ.u64 = 21981; Count.u64 = 6157; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2630,7 +2630,7 @@ Completed @ 4396 ns
  l3cache1.packet_latency : Accumulator : Sum.u64 = 1319; SumSQ.u64 = 1999; Count.u64 = 1200; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 385024; SumSQ.u64 = 202178560; Count.u64 = 1200; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1736484; SumSQ.u64 = 6621907112; Count.u64 = 773; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1777857; SumSQ.u64 = 8333632241; Count.u64 = 774; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 1200; SumSQ.u64 = 1200; Count.u64 = 1200; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 98; SumSQ.u64 = 98; Count.u64 = 98; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2660,7 +2660,7 @@ Completed @ 4396 ns
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 10262; SumSQ.u64 = 27878; Count.u64 = 6098; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 10262; SumSQ.u64 = 27878; Count.u64 = 6157; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2871,7 +2871,7 @@ Completed @ 4396 ns
  l3cache2.packet_latency : Accumulator : Sum.u64 = 1289; SumSQ.u64 = 1929; Count.u64 = 1153; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 368704; SumSQ.u64 = 193466368; Count.u64 = 1153; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1678962; SumSQ.u64 = 7465608836; Count.u64 = 731; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1683207; SumSQ.u64 = 7483628861; Count.u64 = 732; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 1153; SumSQ.u64 = 1153; Count.u64 = 1153; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2901,7 +2901,7 @@ Completed @ 4396 ns
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 9052; SumSQ.u64 = 22014; Count.u64 = 6150; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 9052; SumSQ.u64 = 22014; Count.u64 = 6157; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams_MC.out
@@ -111,7 +111,7 @@ Completed @ 4396 ns
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 115; SumSQ.u64 = 115; Count.u64 = 115; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 190; SumSQ.u64 = 190; Count.u64 = 190; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 70543; SumSQ.u64 = 648345; Count.u64 = 10344; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 70543; SumSQ.u64 = 648345; Count.u64 = 10543; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -223,7 +223,7 @@ Completed @ 4396 ns
  l2cache0.packet_latency : Accumulator : Sum.u64 = 670; SumSQ.u64 = 964; Count.u64 = 591; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 101824; SumSQ.u64 = 43380736; Count.u64 = 591; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 2384363; SumSQ.u64 = 34335994535; Count.u64 = 415; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 2465312; SumSQ.u64 = 40888735136; Count.u64 = 416; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 1314; SumSQ.u64 = 1314; Count.u64 = 1314; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 104; SumSQ.u64 = 104; Count.u64 = 104; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -253,7 +253,7 @@ Completed @ 4396 ns
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 115; SumSQ.u64 = 115; Count.u64 = 115; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 190; SumSQ.u64 = 190; Count.u64 = 190; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 23294; SumSQ.u64 = 72170; Count.u64 = 10347; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 23294; SumSQ.u64 = 72170; Count.u64 = 10543; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -496,7 +496,7 @@ Completed @ 4396 ns
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 173; SumSQ.u64 = 173; Count.u64 = 173; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 67690; SumSQ.u64 = 612810; Count.u64 = 10345; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 67690; SumSQ.u64 = 612810; Count.u64 = 10543; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -608,7 +608,7 @@ Completed @ 4396 ns
  l2cache1.packet_latency : Accumulator : Sum.u64 = 630; SumSQ.u64 = 896; Count.u64 = 560; 
  l2cache1.send_bit_count : Accumulator : Sum.u64 = 92160; SumSQ.u64 = 38338560; Count.u64 = 560; 
  l2cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.idle_time : Accumulator : Sum.u64 = 2393058; SumSQ.u64 = 38973445678; Count.u64 = 397; 
+ l2cache1.idle_time : Accumulator : Sum.u64 = 2473590; SumSQ.u64 = 45458848702; Count.u64 = 398; 
  l2cache1.TotalEventsReceived : Accumulator : Sum.u64 = 1249; SumSQ.u64 = 1249; Count.u64 = 1249; 
  l2cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l2cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -638,7 +638,7 @@ Completed @ 4396 ns
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 97; SumSQ.u64 = 97; Count.u64 = 97; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 173; SumSQ.u64 = 173; Count.u64 = 173; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 21945; SumSQ.u64 = 65753; Count.u64 = 10348; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 21945; SumSQ.u64 = 65753; Count.u64 = 10543; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -881,7 +881,7 @@ Completed @ 4396 ns
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 81; SumSQ.u64 = 81; Count.u64 = 81; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 74370; SumSQ.u64 = 671418; Count.u64 = 10408; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 74370; SumSQ.u64 = 671418; Count.u64 = 10543; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -993,7 +993,7 @@ Completed @ 4396 ns
  l2cache2.packet_latency : Accumulator : Sum.u64 = 660; SumSQ.u64 = 928; Count.u64 = 581; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 91968; SumSQ.u64 = 37441536; Count.u64 = 581; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 2273757; SumSQ.u64 = 30342398487; Count.u64 = 402; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 2328018; SumSQ.u64 = 33286654608; Count.u64 = 403; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 1302; SumSQ.u64 = 1302; Count.u64 = 1302; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 100; SumSQ.u64 = 100; Count.u64 = 100; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1023,7 +1023,7 @@ Completed @ 4396 ns
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 175; SumSQ.u64 = 175; Count.u64 = 175; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 23668; SumSQ.u64 = 70678; Count.u64 = 10411; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 23668; SumSQ.u64 = 70678; Count.u64 = 10543; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1266,7 +1266,7 @@ Completed @ 4396 ns
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 17; SumSQ.u64 = 17; Count.u64 = 17; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 78583; SumSQ.u64 = 720919; Count.u64 = 10541; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 78583; SumSQ.u64 = 720919; Count.u64 = 10543; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1408,7 +1408,7 @@ Completed @ 4396 ns
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 75; SumSQ.u64 = 75; Count.u64 = 75; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 164; SumSQ.u64 = 164; Count.u64 = 164; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 23627; SumSQ.u64 = 68827; Count.u64 = 10536; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 23627; SumSQ.u64 = 68827; Count.u64 = 10543; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1651,7 +1651,7 @@ Completed @ 4396 ns
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 194; SumSQ.u64 = 194; Count.u64 = 194; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 75629; SumSQ.u64 = 694401; Count.u64 = 10410; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 75629; SumSQ.u64 = 694401; Count.u64 = 10543; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1763,7 +1763,7 @@ Completed @ 4396 ns
  l2cache4.packet_latency : Accumulator : Sum.u64 = 673; SumSQ.u64 = 927; Count.u64 = 602; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 94336; SumSQ.u64 = 38182912; Count.u64 = 602; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 2311618; SumSQ.u64 = 31752301580; Count.u64 = 415; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 2365045; SumSQ.u64 = 34606745909; Count.u64 = 416; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 1347; SumSQ.u64 = 1347; Count.u64 = 1347; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 105; SumSQ.u64 = 105; Count.u64 = 105; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1793,7 +1793,7 @@ Completed @ 4396 ns
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 194; SumSQ.u64 = 194; Count.u64 = 194; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 24894; SumSQ.u64 = 78472; Count.u64 = 10413; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 24894; SumSQ.u64 = 78472; Count.u64 = 10543; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2036,7 +2036,7 @@ Completed @ 4396 ns
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 174; SumSQ.u64 = 174; Count.u64 = 174; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 78483; SumSQ.u64 = 718157; Count.u64 = 10501; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 78483; SumSQ.u64 = 718157; Count.u64 = 10543; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2148,7 +2148,7 @@ Completed @ 4396 ns
  l2cache5.packet_latency : Accumulator : Sum.u64 = 683; SumSQ.u64 = 977; Count.u64 = 596; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 90880; SumSQ.u64 = 36192256; Count.u64 = 596; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 2324959; SumSQ.u64 = 33903154385; Count.u64 = 410; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 2339005; SumSQ.u64 = 34100444501; Count.u64 = 411; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 1338; SumSQ.u64 = 1338; Count.u64 = 1338; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 98; SumSQ.u64 = 98; Count.u64 = 98; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2178,7 +2178,7 @@ Completed @ 4396 ns
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 185; SumSQ.u64 = 185; Count.u64 = 185; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 25301; SumSQ.u64 = 78687; Count.u64 = 10506; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 25301; SumSQ.u64 = 78687; Count.u64 = 10543; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2389,7 +2389,7 @@ Completed @ 4396 ns
  l3cache0.packet_latency : Accumulator : Sum.u64 = 1299; SumSQ.u64 = 1913; Count.u64 = 1182; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 377728; SumSQ.u64 = 198172672; Count.u64 = 1182; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 1726262; SumSQ.u64 = 13145190004; Count.u64 = 716; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 1768349; SumSQ.u64 = 14916505573; Count.u64 = 717; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 1182; SumSQ.u64 = 1182; Count.u64 = 1182; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 88; SumSQ.u64 = 88; Count.u64 = 88; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2419,7 +2419,7 @@ Completed @ 4396 ns
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 9043; SumSQ.u64 = 21981; Count.u64 = 6097; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 9043; SumSQ.u64 = 21981; Count.u64 = 6157; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2630,7 +2630,7 @@ Completed @ 4396 ns
  l3cache1.packet_latency : Accumulator : Sum.u64 = 1319; SumSQ.u64 = 1999; Count.u64 = 1200; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 385024; SumSQ.u64 = 202178560; Count.u64 = 1200; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 1736484; SumSQ.u64 = 6621907112; Count.u64 = 773; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 1777857; SumSQ.u64 = 8333632241; Count.u64 = 774; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 1200; SumSQ.u64 = 1200; Count.u64 = 1200; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 98; SumSQ.u64 = 98; Count.u64 = 98; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2660,7 +2660,7 @@ Completed @ 4396 ns
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 10262; SumSQ.u64 = 27878; Count.u64 = 6098; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 10262; SumSQ.u64 = 27878; Count.u64 = 6157; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2871,7 +2871,7 @@ Completed @ 4396 ns
  l3cache2.packet_latency : Accumulator : Sum.u64 = 1289; SumSQ.u64 = 1929; Count.u64 = 1153; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 368704; SumSQ.u64 = 193466368; Count.u64 = 1153; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 1678962; SumSQ.u64 = 7465608836; Count.u64 = 731; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 1683207; SumSQ.u64 = 7483628861; Count.u64 = 732; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 1153; SumSQ.u64 = 1153; Count.u64 = 1153; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 79; SumSQ.u64 = 79; Count.u64 = 79; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2901,7 +2901,7 @@ Completed @ 4396 ns
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 9052; SumSQ.u64 = 22014; Count.u64 = 6150; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 9052; SumSQ.u64 = 22014; Count.u64 = 6157; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling.out
@@ -1,3 +1,12 @@
+Note (l2cache0): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache1): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache2): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache3): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache4): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache5): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache0): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache1): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache2): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
@@ -112,7 +121,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 256; SumSQ.u64 = 256; Count.u64 = 256; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 790; SumSQ.u64 = 790; Count.u64 = 790; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 81782; SumSQ.u64 = 824582; Count.u64 = 9023; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 81782; SumSQ.u64 = 824582; Count.u64 = 9237; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
@@ -224,7 +233,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 3525; SumSQ.u64 = 17797; Count.u64 = 1332; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 183920; SumSQ.u64 = 60179200; Count.u64 = 1339; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 1655624; SumSQ.u64 = 9703095492; Count.u64 = 965; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 1704464; SumSQ.u64 = 12088441092; Count.u64 = 966; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4324; SumSQ.u64 = 4324; Count.u64 = 4324; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -254,7 +263,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 143; SumSQ.u64 = 143; Count.u64 = 143; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 489; SumSQ.u64 = 489; Count.u64 = 489; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 93; SumSQ.u64 = 93; Count.u64 = 93; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49727; SumSQ.u64 = 307889; Count.u64 = 9118; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49727; SumSQ.u64 = 307889; Count.u64 = 9237; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -498,7 +507,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 108; SumSQ.u64 = 108; Count.u64 = 108; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 241; SumSQ.u64 = 241; Count.u64 = 241; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 642; SumSQ.u64 = 642; Count.u64 = 642; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 90607; SumSQ.u64 = 920883; Count.u64 = 9235; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 90607; SumSQ.u64 = 920883; Count.u64 = 9237; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
@@ -640,7 +649,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 138; SumSQ.u64 = 138; Count.u64 = 138; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 475; SumSQ.u64 = 475; Count.u64 = 475; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 108; SumSQ.u64 = 108; Count.u64 = 108; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52288; SumSQ.u64 = 315018; Count.u64 = 9233; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52288; SumSQ.u64 = 315018; Count.u64 = 9237; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -884,7 +893,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 255; SumSQ.u64 = 255; Count.u64 = 255; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 846; SumSQ.u64 = 846; Count.u64 = 846; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 84684; SumSQ.u64 = 857904; Count.u64 = 9144; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 84684; SumSQ.u64 = 857904; Count.u64 = 9237; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
@@ -996,7 +1005,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 3741; SumSQ.u64 = 19635; Count.u64 = 1365; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 182112; SumSQ.u64 = 57306624; Count.u64 = 1374; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 1614144; SumSQ.u64 = 6947330864; Count.u64 = 994; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 1650891; SumSQ.u64 = 8297672873; Count.u64 = 995; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4394; SumSQ.u64 = 4394; Count.u64 = 4394; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1026,7 +1035,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 124; SumSQ.u64 = 124; Count.u64 = 124; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 491; SumSQ.u64 = 491; Count.u64 = 491; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 111; SumSQ.u64 = 111; Count.u64 = 111; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 51437; SumSQ.u64 = 319219; Count.u64 = 9147; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 51437; SumSQ.u64 = 319219; Count.u64 = 9237; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1270,7 +1279,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 264; SumSQ.u64 = 264; Count.u64 = 264; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 754; SumSQ.u64 = 754; Count.u64 = 754; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 87581; SumSQ.u64 = 881855; Count.u64 = 9144; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 87581; SumSQ.u64 = 881855; Count.u64 = 9237; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
@@ -1382,7 +1391,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 3823; SumSQ.u64 = 19787; Count.u64 = 1410; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 189968; SumSQ.u64 = 60359936; Count.u64 = 1421; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 1526536; SumSQ.u64 = 4615811314; Count.u64 = 1048; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 1563283; SumSQ.u64 = 5966153323; Count.u64 = 1049; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 4452; SumSQ.u64 = 4452; Count.u64 = 4452; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 11; SumSQ.u64 = 11; Count.u64 = 11; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1412,7 +1421,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 136; SumSQ.u64 = 136; Count.u64 = 136; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 504; SumSQ.u64 = 504; Count.u64 = 504; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 105; SumSQ.u64 = 105; Count.u64 = 105; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 52928; SumSQ.u64 = 326356; Count.u64 = 9147; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 52928; SumSQ.u64 = 326356; Count.u64 = 9237; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1656,7 +1665,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 253; SumSQ.u64 = 253; Count.u64 = 253; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 884; SumSQ.u64 = 884; Count.u64 = 884; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 88430; SumSQ.u64 = 900390; Count.u64 = 9137; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 88430; SumSQ.u64 = 900390; Count.u64 = 9237; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
@@ -1768,7 +1777,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 3933; SumSQ.u64 = 20351; Count.u64 = 1426; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 188912; SumSQ.u64 = 59366144; Count.u64 = 1427; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 1569043; SumSQ.u64 = 5372731049; Count.u64 = 1031; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 1605790; SumSQ.u64 = 6723073058; Count.u64 = 1032; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 4570; SumSQ.u64 = 4570; Count.u64 = 4570; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1798,7 +1807,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 514; SumSQ.u64 = 514; Count.u64 = 514; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 125; SumSQ.u64 = 125; Count.u64 = 125; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 53174; SumSQ.u64 = 332888; Count.u64 = 9147; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 53174; SumSQ.u64 = 332888; Count.u64 = 9237; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2042,7 +2051,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 272; SumSQ.u64 = 272; Count.u64 = 272; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 911; SumSQ.u64 = 911; Count.u64 = 911; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90771; SumSQ.u64 = 925871; Count.u64 = 9194; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90771; SumSQ.u64 = 925871; Count.u64 = 9237; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
@@ -2154,7 +2163,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 4186; SumSQ.u64 = 22502; Count.u64 = 1459; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 197152; SumSQ.u64 = 63056384; Count.u64 = 1466; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 1546226; SumSQ.u64 = 5594034790; Count.u64 = 1045; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 1558706; SumSQ.u64 = 5749785190; Count.u64 = 1046; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4729; SumSQ.u64 = 4729; Count.u64 = 4729; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2184,7 +2193,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 148; SumSQ.u64 = 148; Count.u64 = 148; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 515; SumSQ.u64 = 515; Count.u64 = 515; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 53805; SumSQ.u64 = 332983; Count.u64 = 9199; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 53805; SumSQ.u64 = 332983; Count.u64 = 9237; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2395,7 +2404,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 5268; SumSQ.u64 = 15190; Count.u64 = 3007; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 768480; SumSQ.u64 = 390577152; Count.u64 = 2991; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 529738; SumSQ.u64 = 897183284; Count.u64 = 693; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 554155; SumSQ.u64 = 1493373173; Count.u64 = 694; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 3007; SumSQ.u64 = 3007; Count.u64 = 3007; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 255; SumSQ.u64 = 255; Count.u64 = 255; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2425,7 +2434,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 60; SumSQ.u64 = 60; Count.u64 = 60; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 22426; SumSQ.u64 = 118028; Count.u64 = 5359; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 22426; SumSQ.u64 = 118028; Count.u64 = 5394; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2636,7 +2645,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 4740; SumSQ.u64 = 13860; Count.u64 = 2704; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 720768; SumSQ.u64 = 368439296; Count.u64 = 2684; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 668748; SumSQ.u64 = 1188875032; Count.u64 = 747; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 703161; SumSQ.u64 = 2373129601; Count.u64 = 748; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 2704; SumSQ.u64 = 2704; Count.u64 = 2704; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 204; SumSQ.u64 = 204; Count.u64 = 204; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2666,7 +2675,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 55; SumSQ.u64 = 55; Count.u64 = 55; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 18961; SumSQ.u64 = 88195; Count.u64 = 5345; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 18961; SumSQ.u64 = 88195; Count.u64 = 5394; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2877,7 +2886,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 4760; SumSQ.u64 = 14048; Count.u64 = 2766; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 719552; SumSQ.u64 = 366450688; Count.u64 = 2758; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 644570; SumSQ.u64 = 1205277108; Count.u64 = 765; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 647795; SumSQ.u64 = 1215677733; Count.u64 = 766; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 2766; SumSQ.u64 = 2766; Count.u64 = 2766; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 198; SumSQ.u64 = 198; Count.u64 = 198; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2907,7 +2916,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 60; SumSQ.u64 = 60; Count.u64 = 60; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 19449; SumSQ.u64 = 90161; Count.u64 = 5389; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 19449; SumSQ.u64 = 90161; Count.u64 = 5394; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling_MC.out
@@ -1,15 +1,24 @@
+Note (l2cache0): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache1): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache2): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache3): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache4): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l2cache5): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache0): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache1): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
+Note (l3cache2): Changed 'min_packet_size' to 'memNIC.min_packet_size'. Change your input file to remove this notice.
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (8976 clocks)
 TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (9051 clocks)
-TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (8471 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (9237 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (8976 clocks)
+TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9196 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 347264; SumSQ.u64 = 176836608; Count.u64 = 1332; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 1332; SumSQ.u64 = 1332; Count.u64 = 1332; 
  network.output_port_stalls.port0 : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -112,7 +121,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache0.FetchInvX_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
  l1cache0.Inv_recv : Accumulator : Sum.u64 = 256; SumSQ.u64 = 256; Count.u64 = 256; 
  l1cache0.NACK_recv : Accumulator : Sum.u64 = 790; SumSQ.u64 = 790; Count.u64 = 790; 
- l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 81782; SumSQ.u64 = 824582; Count.u64 = 9023; 
+ l1cache0.MSHR_occupancy : Accumulator : Sum.u64 = 81782; SumSQ.u64 = 824582; Count.u64 = 9237; 
  l1cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache0.evict_E : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
@@ -224,7 +233,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache0.packet_latency : Accumulator : Sum.u64 = 3525; SumSQ.u64 = 17797; Count.u64 = 1332; 
  l2cache0.send_bit_count : Accumulator : Sum.u64 = 183920; SumSQ.u64 = 60179200; Count.u64 = 1339; 
  l2cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache0.idle_time : Accumulator : Sum.u64 = 1655624; SumSQ.u64 = 9703095492; Count.u64 = 965; 
+ l2cache0.idle_time : Accumulator : Sum.u64 = 1704464; SumSQ.u64 = 12088441092; Count.u64 = 966; 
  l2cache0.TotalEventsReceived : Accumulator : Sum.u64 = 4324; SumSQ.u64 = 4324; Count.u64 = 4324; 
  l2cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  l2cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -254,7 +263,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache0.FetchInvX_recv : Accumulator : Sum.u64 = 143; SumSQ.u64 = 143; Count.u64 = 143; 
  l2cache0.Inv_recv : Accumulator : Sum.u64 = 489; SumSQ.u64 = 489; Count.u64 = 489; 
  l2cache0.NACK_recv : Accumulator : Sum.u64 = 93; SumSQ.u64 = 93; Count.u64 = 93; 
- l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49727; SumSQ.u64 = 307889; Count.u64 = 9118; 
+ l2cache0.MSHR_occupancy : Accumulator : Sum.u64 = 49727; SumSQ.u64 = 307889; Count.u64 = 9237; 
  l2cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -498,7 +507,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache1.FetchInvX_recv : Accumulator : Sum.u64 = 108; SumSQ.u64 = 108; Count.u64 = 108; 
  l1cache1.Inv_recv : Accumulator : Sum.u64 = 241; SumSQ.u64 = 241; Count.u64 = 241; 
  l1cache1.NACK_recv : Accumulator : Sum.u64 = 642; SumSQ.u64 = 642; Count.u64 = 642; 
- l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 90607; SumSQ.u64 = 920883; Count.u64 = 9235; 
+ l1cache1.MSHR_occupancy : Accumulator : Sum.u64 = 90607; SumSQ.u64 = 920883; Count.u64 = 9237; 
  l1cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache1.evict_E : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
@@ -640,7 +649,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache1.FetchInvX_recv : Accumulator : Sum.u64 = 138; SumSQ.u64 = 138; Count.u64 = 138; 
  l2cache1.Inv_recv : Accumulator : Sum.u64 = 475; SumSQ.u64 = 475; Count.u64 = 475; 
  l2cache1.NACK_recv : Accumulator : Sum.u64 = 108; SumSQ.u64 = 108; Count.u64 = 108; 
- l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52288; SumSQ.u64 = 315018; Count.u64 = 9233; 
+ l2cache1.MSHR_occupancy : Accumulator : Sum.u64 = 52288; SumSQ.u64 = 315018; Count.u64 = 9237; 
  l2cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -884,7 +893,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache2.FetchInvX_recv : Accumulator : Sum.u64 = 89; SumSQ.u64 = 89; Count.u64 = 89; 
  l1cache2.Inv_recv : Accumulator : Sum.u64 = 255; SumSQ.u64 = 255; Count.u64 = 255; 
  l1cache2.NACK_recv : Accumulator : Sum.u64 = 846; SumSQ.u64 = 846; Count.u64 = 846; 
- l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 84684; SumSQ.u64 = 857904; Count.u64 = 9144; 
+ l1cache2.MSHR_occupancy : Accumulator : Sum.u64 = 84684; SumSQ.u64 = 857904; Count.u64 = 9237; 
  l1cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache2.evict_E : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
@@ -996,7 +1005,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache2.packet_latency : Accumulator : Sum.u64 = 3741; SumSQ.u64 = 19635; Count.u64 = 1365; 
  l2cache2.send_bit_count : Accumulator : Sum.u64 = 182112; SumSQ.u64 = 57306624; Count.u64 = 1374; 
  l2cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache2.idle_time : Accumulator : Sum.u64 = 1614144; SumSQ.u64 = 6947330864; Count.u64 = 994; 
+ l2cache2.idle_time : Accumulator : Sum.u64 = 1650891; SumSQ.u64 = 8297672873; Count.u64 = 995; 
  l2cache2.TotalEventsReceived : Accumulator : Sum.u64 = 4394; SumSQ.u64 = 4394; Count.u64 = 4394; 
  l2cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; 
  l2cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1026,7 +1035,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache2.FetchInvX_recv : Accumulator : Sum.u64 = 124; SumSQ.u64 = 124; Count.u64 = 124; 
  l2cache2.Inv_recv : Accumulator : Sum.u64 = 491; SumSQ.u64 = 491; Count.u64 = 491; 
  l2cache2.NACK_recv : Accumulator : Sum.u64 = 111; SumSQ.u64 = 111; Count.u64 = 111; 
- l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 51437; SumSQ.u64 = 319219; Count.u64 = 9147; 
+ l2cache2.MSHR_occupancy : Accumulator : Sum.u64 = 51437; SumSQ.u64 = 319219; Count.u64 = 9237; 
  l2cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1270,7 +1279,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache3.FetchInvX_recv : Accumulator : Sum.u64 = 99; SumSQ.u64 = 99; Count.u64 = 99; 
  l1cache3.Inv_recv : Accumulator : Sum.u64 = 264; SumSQ.u64 = 264; Count.u64 = 264; 
  l1cache3.NACK_recv : Accumulator : Sum.u64 = 754; SumSQ.u64 = 754; Count.u64 = 754; 
- l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 87581; SumSQ.u64 = 881855; Count.u64 = 9144; 
+ l1cache3.MSHR_occupancy : Accumulator : Sum.u64 = 87581; SumSQ.u64 = 881855; Count.u64 = 9237; 
  l1cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache3.evict_E : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
@@ -1382,7 +1391,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache3.packet_latency : Accumulator : Sum.u64 = 3823; SumSQ.u64 = 19787; Count.u64 = 1410; 
  l2cache3.send_bit_count : Accumulator : Sum.u64 = 189968; SumSQ.u64 = 60359936; Count.u64 = 1421; 
  l2cache3.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache3.idle_time : Accumulator : Sum.u64 = 1526536; SumSQ.u64 = 4615811314; Count.u64 = 1048; 
+ l2cache3.idle_time : Accumulator : Sum.u64 = 1563283; SumSQ.u64 = 5966153323; Count.u64 = 1049; 
  l2cache3.TotalEventsReceived : Accumulator : Sum.u64 = 4452; SumSQ.u64 = 4452; Count.u64 = 4452; 
  l2cache3.TotalEventsReplayed : Accumulator : Sum.u64 = 11; SumSQ.u64 = 11; Count.u64 = 11; 
  l2cache3.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1412,7 +1421,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache3.FetchInvX_recv : Accumulator : Sum.u64 = 136; SumSQ.u64 = 136; Count.u64 = 136; 
  l2cache3.Inv_recv : Accumulator : Sum.u64 = 504; SumSQ.u64 = 504; Count.u64 = 504; 
  l2cache3.NACK_recv : Accumulator : Sum.u64 = 105; SumSQ.u64 = 105; Count.u64 = 105; 
- l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 52928; SumSQ.u64 = 326356; Count.u64 = 9147; 
+ l2cache3.MSHR_occupancy : Accumulator : Sum.u64 = 52928; SumSQ.u64 = 326356; Count.u64 = 9237; 
  l2cache3.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache3.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1656,7 +1665,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache4.FetchInvX_recv : Accumulator : Sum.u64 = 95; SumSQ.u64 = 95; Count.u64 = 95; 
  l1cache4.Inv_recv : Accumulator : Sum.u64 = 253; SumSQ.u64 = 253; Count.u64 = 253; 
  l1cache4.NACK_recv : Accumulator : Sum.u64 = 884; SumSQ.u64 = 884; Count.u64 = 884; 
- l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 88430; SumSQ.u64 = 900390; Count.u64 = 9137; 
+ l1cache4.MSHR_occupancy : Accumulator : Sum.u64 = 88430; SumSQ.u64 = 900390; Count.u64 = 9237; 
  l1cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache4.evict_E : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
@@ -1768,7 +1777,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache4.packet_latency : Accumulator : Sum.u64 = 3933; SumSQ.u64 = 20351; Count.u64 = 1426; 
  l2cache4.send_bit_count : Accumulator : Sum.u64 = 188912; SumSQ.u64 = 59366144; Count.u64 = 1427; 
  l2cache4.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache4.idle_time : Accumulator : Sum.u64 = 1569043; SumSQ.u64 = 5372731049; Count.u64 = 1031; 
+ l2cache4.idle_time : Accumulator : Sum.u64 = 1605790; SumSQ.u64 = 6723073058; Count.u64 = 1032; 
  l2cache4.TotalEventsReceived : Accumulator : Sum.u64 = 4570; SumSQ.u64 = 4570; Count.u64 = 4570; 
  l2cache4.TotalEventsReplayed : Accumulator : Sum.u64 = 12; SumSQ.u64 = 12; Count.u64 = 12; 
  l2cache4.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1798,7 +1807,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache4.FetchInvX_recv : Accumulator : Sum.u64 = 135; SumSQ.u64 = 135; Count.u64 = 135; 
  l2cache4.Inv_recv : Accumulator : Sum.u64 = 514; SumSQ.u64 = 514; Count.u64 = 514; 
  l2cache4.NACK_recv : Accumulator : Sum.u64 = 125; SumSQ.u64 = 125; Count.u64 = 125; 
- l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 53174; SumSQ.u64 = 332888; Count.u64 = 9147; 
+ l2cache4.MSHR_occupancy : Accumulator : Sum.u64 = 53174; SumSQ.u64 = 332888; Count.u64 = 9237; 
  l2cache4.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache4.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2042,7 +2051,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l1cache5.FetchInvX_recv : Accumulator : Sum.u64 = 106; SumSQ.u64 = 106; Count.u64 = 106; 
  l1cache5.Inv_recv : Accumulator : Sum.u64 = 272; SumSQ.u64 = 272; Count.u64 = 272; 
  l1cache5.NACK_recv : Accumulator : Sum.u64 = 911; SumSQ.u64 = 911; Count.u64 = 911; 
- l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90771; SumSQ.u64 = 925871; Count.u64 = 9194; 
+ l1cache5.MSHR_occupancy : Accumulator : Sum.u64 = 90771; SumSQ.u64 = 925871; Count.u64 = 9237; 
  l1cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache5.evict_E : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
@@ -2154,7 +2163,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache5.packet_latency : Accumulator : Sum.u64 = 4186; SumSQ.u64 = 22502; Count.u64 = 1459; 
  l2cache5.send_bit_count : Accumulator : Sum.u64 = 197152; SumSQ.u64 = 63056384; Count.u64 = 1466; 
  l2cache5.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache5.idle_time : Accumulator : Sum.u64 = 1546226; SumSQ.u64 = 5594034790; Count.u64 = 1045; 
+ l2cache5.idle_time : Accumulator : Sum.u64 = 1558706; SumSQ.u64 = 5749785190; Count.u64 = 1046; 
  l2cache5.TotalEventsReceived : Accumulator : Sum.u64 = 4729; SumSQ.u64 = 4729; Count.u64 = 4729; 
  l2cache5.TotalEventsReplayed : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; 
  l2cache5.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2184,7 +2193,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l2cache5.FetchInvX_recv : Accumulator : Sum.u64 = 148; SumSQ.u64 = 148; Count.u64 = 148; 
  l2cache5.Inv_recv : Accumulator : Sum.u64 = 515; SumSQ.u64 = 515; Count.u64 = 515; 
  l2cache5.NACK_recv : Accumulator : Sum.u64 = 120; SumSQ.u64 = 120; Count.u64 = 120; 
- l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 53805; SumSQ.u64 = 332983; Count.u64 = 9199; 
+ l2cache5.MSHR_occupancy : Accumulator : Sum.u64 = 53805; SumSQ.u64 = 332983; Count.u64 = 9237; 
  l2cache5.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache5.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2395,7 +2404,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache0.packet_latency : Accumulator : Sum.u64 = 5268; SumSQ.u64 = 15190; Count.u64 = 3007; 
  l3cache0.send_bit_count : Accumulator : Sum.u64 = 768480; SumSQ.u64 = 390577152; Count.u64 = 2991; 
  l3cache0.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache0.idle_time : Accumulator : Sum.u64 = 529738; SumSQ.u64 = 897183284; Count.u64 = 693; 
+ l3cache0.idle_time : Accumulator : Sum.u64 = 554155; SumSQ.u64 = 1493373173; Count.u64 = 694; 
  l3cache0.TotalEventsReceived : Accumulator : Sum.u64 = 3007; SumSQ.u64 = 3007; Count.u64 = 3007; 
  l3cache0.TotalEventsReplayed : Accumulator : Sum.u64 = 255; SumSQ.u64 = 255; Count.u64 = 255; 
  l3cache0.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2425,7 +2434,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache0.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.NACK_recv : Accumulator : Sum.u64 = 60; SumSQ.u64 = 60; Count.u64 = 60; 
- l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 22426; SumSQ.u64 = 118028; Count.u64 = 5359; 
+ l3cache0.MSHR_occupancy : Accumulator : Sum.u64 = 22426; SumSQ.u64 = 118028; Count.u64 = 5394; 
  l3cache0.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache0.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2636,7 +2645,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache1.packet_latency : Accumulator : Sum.u64 = 4740; SumSQ.u64 = 13860; Count.u64 = 2704; 
  l3cache1.send_bit_count : Accumulator : Sum.u64 = 720768; SumSQ.u64 = 368439296; Count.u64 = 2684; 
  l3cache1.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache1.idle_time : Accumulator : Sum.u64 = 668748; SumSQ.u64 = 1188875032; Count.u64 = 747; 
+ l3cache1.idle_time : Accumulator : Sum.u64 = 703161; SumSQ.u64 = 2373129601; Count.u64 = 748; 
  l3cache1.TotalEventsReceived : Accumulator : Sum.u64 = 2704; SumSQ.u64 = 2704; Count.u64 = 2704; 
  l3cache1.TotalEventsReplayed : Accumulator : Sum.u64 = 204; SumSQ.u64 = 204; Count.u64 = 204; 
  l3cache1.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2666,7 +2675,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache1.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.NACK_recv : Accumulator : Sum.u64 = 55; SumSQ.u64 = 55; Count.u64 = 55; 
- l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 18961; SumSQ.u64 = 88195; Count.u64 = 5345; 
+ l3cache1.MSHR_occupancy : Accumulator : Sum.u64 = 18961; SumSQ.u64 = 88195; Count.u64 = 5394; 
  l3cache1.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache1.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2877,7 +2886,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache2.packet_latency : Accumulator : Sum.u64 = 4760; SumSQ.u64 = 14048; Count.u64 = 2766; 
  l3cache2.send_bit_count : Accumulator : Sum.u64 = 719552; SumSQ.u64 = 366450688; Count.u64 = 2758; 
  l3cache2.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache2.idle_time : Accumulator : Sum.u64 = 644570; SumSQ.u64 = 1205277108; Count.u64 = 765; 
+ l3cache2.idle_time : Accumulator : Sum.u64 = 647795; SumSQ.u64 = 1215677733; Count.u64 = 766; 
  l3cache2.TotalEventsReceived : Accumulator : Sum.u64 = 2766; SumSQ.u64 = 2766; Count.u64 = 2766; 
  l3cache2.TotalEventsReplayed : Accumulator : Sum.u64 = 198; SumSQ.u64 = 198; Count.u64 = 198; 
  l3cache2.TotalNoncacheableEventsReceived : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -2907,7 +2916,7 @@ TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (8664 clocks)
  l3cache2.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.NACK_recv : Accumulator : Sum.u64 = 60; SumSQ.u64 = 60; Count.u64 = 60; 
- l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 19449; SumSQ.u64 = 90161; Count.u64 = 5389; 
+ l3cache2.MSHR_occupancy : Accumulator : Sum.u64 = 19449; SumSQ.u64 = 90161; Count.u64 = 5394; 
  l3cache2.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache2.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl2_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl2_1.out
@@ -30,7 +30,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 35568; SumSQ.u64 = 50016; Count.u64 = 208104; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 35568; SumSQ.u64 = 50016; Count.u64 = 208108; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -155,7 +155,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 207770; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 16128; SumSQ.u64 = 25180; Count.u64 = 208108; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_1.out
@@ -32,7 +32,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104063 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 178553; SumSQ.u64 = 331915; Count.u64 = 208122; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 178553; SumSQ.u64 = 331915; Count.u64 = 208130; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -157,7 +157,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104063 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 24; SumSQ.u64 = 24; Count.u64 = 24; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 188609; SumSQ.u64 = 360191; Count.u64 = 208127; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 188609; SumSQ.u64 = 360191; Count.u64 = 208130; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -282,7 +282,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104063 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 265579; SumSQ.u64 = 854413; Count.u64 = 208104; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 265579; SumSQ.u64 = 854413; Count.u64 = 208130; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_2.out
@@ -32,7 +32,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 115387; SumSQ.u64 = 182033; Count.u64 = 208103; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 115387; SumSQ.u64 = 182033; Count.u64 = 208106; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -157,7 +157,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 25; SumSQ.u64 = 25; Count.u64 = 25; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 21; SumSQ.u64 = 21; Count.u64 = 21; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 125225; SumSQ.u64 = 202821; Count.u64 = 208103; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 125225; SumSQ.u64 = 202821; Count.u64 = 208106; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -282,7 +282,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 142168; SumSQ.u64 = 375004; Count.u64 = 207938; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 142168; SumSQ.u64 = 375004; Count.u64 = 208106; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -456,11 +456,3 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  memory.cycles_attempted_issue_but_rejected : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  memory.total_cycles : Accumulator : Sum.u64 = 104053; SumSQ.u64 = 10827026809; Count.u64 = 1; 
 Simulation is complete, simulated time: 104.053 us
-== Loading device model file 'DDR3_micron_32M_8B_x4_sg125.ini' == 
-== Loading system model file 'system.ini' == 
-WARNING: UNKNOWN KEY 'DEBUG_TRANS_FLOW' IN INI FILE
-===== MemorySystem 0 =====
-CH. 0 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-===== MemorySystem 1 =====
-CH. 1 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-DRAMSim2 Clock Frequency =1Hz, CPU Clock Frequency=1Hz

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl3_3.out
@@ -32,7 +32,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 1; SumSQ.u64 = 1; Count.u64 = 1; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 59526; SumSQ.u64 = 86274; Count.u64 = 208103; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 59526; SumSQ.u64 = 86274; Count.u64 = 208106; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -157,7 +157,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 41; SumSQ.u64 = 41; Count.u64 = 41; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 38; SumSQ.u64 = 38; Count.u64 = 38; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 69259; SumSQ.u64 = 100885; Count.u64 = 208103; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 69259; SumSQ.u64 = 100885; Count.u64 = 208106; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -282,7 +282,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104053 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 48364; SumSQ.u64 = 131564; Count.u64 = 207555; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 48364; SumSQ.u64 = 131564; Count.u64 = 208106; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl4_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl4_1.out
@@ -32,7 +32,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 41571; SumSQ.u64 = 61813; Count.u64 = 208105; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 41571; SumSQ.u64 = 61813; Count.u64 = 208108; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -157,7 +157,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 37848; SumSQ.u64 = 56922; Count.u64 = 208105; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 37848; SumSQ.u64 = 56922; Count.u64 = 208108; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -282,7 +282,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 56787; SumSQ.u64 = 148279; Count.u64 = 206730; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 56787; SumSQ.u64 = 148279; Count.u64 = 208108; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl4_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl4_2.out
@@ -32,7 +32,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 32421; SumSQ.u64 = 41355; Count.u64 = 208105; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 32421; SumSQ.u64 = 41355; Count.u64 = 208108; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -157,7 +157,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 76; SumSQ.u64 = 76; Count.u64 = 76; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 28697; SumSQ.u64 = 36479; Count.u64 = 208105; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 28697; SumSQ.u64 = 36479; Count.u64 = 208108; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -282,7 +282,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39030; SumSQ.u64 = 80378; Count.u64 = 206730; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 39030; SumSQ.u64 = 80378; Count.u64 = 208108; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -456,11 +456,3 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  memory.cycles_attempted_issue_but_rejected : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  memory.total_cycles : Accumulator : Sum.u64 = 104054; SumSQ.u64 = 10827234916; Count.u64 = 1; 
 Simulation is complete, simulated time: 104.054 us
-== Loading device model file 'DDR3_micron_32M_8B_x4_sg125.ini' == 
-== Loading system model file 'system.ini' == 
-WARNING: UNKNOWN KEY 'DEBUG_TRANS_FLOW' IN INI FILE
-===== MemorySystem 0 =====
-CH. 0 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-===== MemorySystem 1 =====
-CH. 1 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-DRAMSim2 Clock Frequency =1Hz, CPU Clock Frequency=1Hz

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl5_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl5_1.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105329; SumSQ.u64 = 174275; Count.u64 = 208105; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 105329; SumSQ.u64 = 174275; Count.u64 = 208108; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -163,7 +163,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 112632; SumSQ.u64 = 189200; Count.u64 = 208105; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 112632; SumSQ.u64 = 189200; Count.u64 = 208108; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -288,7 +288,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 190552; SumSQ.u64 = 572538; Count.u64 = 207193; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 190552; SumSQ.u64 = 572538; Count.u64 = 208108; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -478,7 +478,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 112450; SumSQ.u64 = 187002; Count.u64 = 208105; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 112450; SumSQ.u64 = 187002; Count.u64 = 208108; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -603,7 +603,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106907; SumSQ.u64 = 175737; Count.u64 = 208105; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 106907; SumSQ.u64 = 175737; Count.u64 = 208108; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -728,7 +728,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 77; SumSQ.u64 = 77; Count.u64 = 77; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 87; SumSQ.u64 = 87; Count.u64 = 87; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 194521; SumSQ.u64 = 595997; Count.u64 = 207387; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 194521; SumSQ.u64 = 595997; Count.u64 = 208108; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -918,7 +918,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 118436; SumSQ.u64 = 266796; Count.u64 = 207265; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 118436; SumSQ.u64 = 266796; Count.u64 = 208108; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1092,11 +1092,3 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104054 clocks)
  memory.cycles_attempted_issue_but_rejected : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  memory.total_cycles : Accumulator : Sum.u64 = 104054; SumSQ.u64 = 10827234916; Count.u64 = 1; 
 Simulation is complete, simulated time: 104.054 us
-== Loading device model file 'DDR3_micron_32M_8B_x4_sg125.ini' == 
-== Loading system model file 'system.ini' == 
-WARNING: UNKNOWN KEY 'DEBUG_TRANS_FLOW' IN INI FILE
-===== MemorySystem 0 =====
-CH. 0 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-===== MemorySystem 1 =====
-CH. 1 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-DRAMSim2 Clock Frequency =1Hz, CPU Clock Frequency=1Hz

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_1.out
@@ -31,7 +31,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1323907 clocks
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 21783189; SumSQ.u64 = 186792419; Count.u64 = 2647810; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 21783189; SumSQ.u64 = 186792419; Count.u64 = 2647814; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -156,7 +156,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1323907 clocks
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 21266910; SumSQ.u64 = 178408242; Count.u64 = 2647789; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 21266910; SumSQ.u64 = 178408242; Count.u64 = 2647814; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -350,7 +350,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1323907 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 20355758; SumSQ.u64 = 164078522; Count.u64 = 2647764; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 20355758; SumSQ.u64 = 164078522; Count.u64 = 2647814; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_3.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9164635; SumSQ.u64 = 89496761; Count.u64 = 942458; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9164635; SumSQ.u64 = 89496761; Count.u64 = 942462; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -163,7 +163,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9057462; SumSQ.u64 = 88276296; Count.u64 = 935546; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9057462; SumSQ.u64 = 88276296; Count.u64 = 942462; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -288,7 +288,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18026925; SumSQ.u64 = 346912687; Count.u64 = 942417; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18026925; SumSQ.u64 = 346912687; Count.u64 = 942462; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -478,7 +478,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9045886; SumSQ.u64 = 88365576; Count.u64 = 933530; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9045886; SumSQ.u64 = 88365576; Count.u64 = 942462; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -603,7 +603,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 2; SumSQ.u64 = 2; Count.u64 = 2; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9149384; SumSQ.u64 = 89387172; Count.u64 = 941450; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 9149384; SumSQ.u64 = 89387172; Count.u64 = 942462; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -728,7 +728,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18008109; SumSQ.u64 = 347087713; Count.u64 = 941409; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 18008109; SumSQ.u64 = 347087713; Count.u64 = 942462; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -922,7 +922,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (470727 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35488231; SumSQ.u64 = 1344993371; Count.u64 = 942372; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 35488231; SumSQ.u64 = 1344993371; Count.u64 = 942462; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_4.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl8_4.out
@@ -38,7 +38,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 199216; SumSQ.u64 = 612294; Count.u64 = 208753; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 199216; SumSQ.u64 = 612294; Count.u64 = 208762; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -163,7 +163,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 208180; SumSQ.u64 = 639546; Count.u64 = 208758; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 208180; SumSQ.u64 = 639546; Count.u64 = 208762; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -288,7 +288,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 364138; SumSQ.u64 = 2020158; Count.u64 = 208717; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 364138; SumSQ.u64 = 2020158; Count.u64 = 208762; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -478,7 +478,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 211092; SumSQ.u64 = 653194; Count.u64 = 208526; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 211092; SumSQ.u64 = 653194; Count.u64 = 208762; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -603,7 +603,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 78; SumSQ.u64 = 78; Count.u64 = 78; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 204261; SumSQ.u64 = 635333; Count.u64 = 208477; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 204261; SumSQ.u64 = 635333; Count.u64 = 208762; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -728,7 +728,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 78; SumSQ.u64 = 78; Count.u64 = 78; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 86; SumSQ.u64 = 86; Count.u64 = 86; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 373240; SumSQ.u64 = 2100936; Count.u64 = 208595; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 373240; SumSQ.u64 = 2100936; Count.u64 = 208762; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -922,7 +922,7 @@ TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 289818; SumSQ.u64 = 1482952; Count.u64 = 208667; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 289818; SumSQ.u64 = 1482952; Count.u64 = 208762; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_1.out
@@ -33,7 +33,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4628642; SumSQ.u64 = 15229844; Count.u64 = 2009792; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4628642; SumSQ.u64 = 15229844; Count.u64 = 2009796; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -158,7 +158,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 4126908; SumSQ.u64 = 12555698; Count.u64 = 2009771; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 4126908; SumSQ.u64 = 12555698; Count.u64 = 2009796; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -348,7 +348,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 3210628; SumSQ.u64 = 8306010; Count.u64 = 2009746; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 3210628; SumSQ.u64 = 8306010; Count.u64 = 2009796; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_1_MC.out
@@ -33,7 +33,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4628642; SumSQ.u64 = 15229844; Count.u64 = 2009792; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4628642; SumSQ.u64 = 15229844; Count.u64 = 2009796; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -158,7 +158,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 4126908; SumSQ.u64 = 12555698; Count.u64 = 2009771; 
+ l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 4126908; SumSQ.u64 = 12555698; Count.u64 = 2009796; 
  l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -348,7 +348,7 @@ TrivialCPU cpu Finished after 10000 issued reads, 10000 returned (1004898 clocks
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 3210628; SumSQ.u64 = 8306010; Count.u64 = 2009746; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 3210628; SumSQ.u64 = 8306010; Count.u64 = 2009796; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_2.out
@@ -62,7 +62,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c0.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.Inv_recv : Accumulator : Sum.u64 = 3; SumSQ.u64 = 3; Count.u64 = 3; 
  c0.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 201090; SumSQ.u64 = 598462; Count.u64 = 208753; 
+ c0.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 201090; SumSQ.u64 = 598462; Count.u64 = 208772; 
  c0.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c0.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -187,7 +187,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c1.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c1.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 212290; SumSQ.u64 = 629360; Count.u64 = 208758; 
+ c1.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 212290; SumSQ.u64 = 629360; Count.u64 = 208772; 
  c1.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c1.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -312,7 +312,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c2.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c2.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 265328; SumSQ.u64 = 799916; Count.u64 = 208763; 
+ c2.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 265328; SumSQ.u64 = 799916; Count.u64 = 208772; 
  c2.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c2.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -437,7 +437,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c3.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; 
  c3.l1cache.Inv_recv : Accumulator : Sum.u64 = 85; SumSQ.u64 = 85; Count.u64 = 85; 
  c3.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 274216; SumSQ.u64 = 831186; Count.u64 = 208768; 
+ c3.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 274216; SumSQ.u64 = 831186; Count.u64 = 208772; 
  c3.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c3.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -562,7 +562,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  n0.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 6; SumSQ.u64 = 6; Count.u64 = 6; 
  n0.l2cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 853445; SumSQ.u64 = 8916927; Count.u64 = 208727; 
+ n0.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 853445; SumSQ.u64 = 8916927; Count.u64 = 208772; 
  n0.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n0.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -752,7 +752,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c4.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c4.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 212371; SumSQ.u64 = 643049; Count.u64 = 208526; 
+ c4.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 212371; SumSQ.u64 = 643049; Count.u64 = 208772; 
  c4.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c4.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -877,7 +877,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c5.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c5.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 221503; SumSQ.u64 = 672951; Count.u64 = 208531; 
+ c5.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 221503; SumSQ.u64 = 672951; Count.u64 = 208772; 
  c5.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c5.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1002,7 +1002,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c6.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c6.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 231977; SumSQ.u64 = 705961; Count.u64 = 208536; 
+ c6.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 231977; SumSQ.u64 = 705961; Count.u64 = 208772; 
  c6.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c6.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1127,7 +1127,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  c7.l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 73; SumSQ.u64 = 73; Count.u64 = 73; 
  c7.l1cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  c7.l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 264025; SumSQ.u64 = 816423; Count.u64 = 208477; 
+ c7.l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 264025; SumSQ.u64 = 816423; Count.u64 = 208772; 
  c7.l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  c7.l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1252,7 +1252,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  n1.l2cache.FetchInvX_recv : Accumulator : Sum.u64 = 73; SumSQ.u64 = 73; Count.u64 = 73; 
  n1.l2cache.Inv_recv : Accumulator : Sum.u64 = 82; SumSQ.u64 = 82; Count.u64 = 82; 
  n1.l2cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 839648; SumSQ.u64 = 9011394; Count.u64 = 208595; 
+ n1.l2cache.MSHR_occupancy : Accumulator : Sum.u64 = 839648; SumSQ.u64 = 9011394; Count.u64 = 208772; 
  n1.l2cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  n1.l2cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -1446,7 +1446,7 @@ TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104240 clocks)
  l3cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 356610; SumSQ.u64 = 1698808; Count.u64 = 208667; 
+ l3cache.MSHR_occupancy : Accumulator : Sum.u64 = 356610; SumSQ.u64 = 1698808; Count.u64 = 208772; 
  l3cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l3cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_1.out
@@ -29,7 +29,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (108400 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 1123864; SumSQ.u64 = 6878612; Count.u64 = 216797; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 1123864; SumSQ.u64 = 6878612; Count.u64 = 216800; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_2.out
@@ -29,7 +29,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 39276; SumSQ.u64 = 47872; Count.u64 = 208104; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 39276; SumSQ.u64 = 47872; Count.u64 = 208108; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -138,11 +138,3 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  memory.cycles_attempted_issue_but_rejected : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  memory.total_cycles : Accumulator : Sum.u64 = 104054; SumSQ.u64 = 10827234916; Count.u64 = 1; 
 Simulation is complete, simulated time: 104.054 us
-== Loading device model file 'DDR3_micron_32M_8B_x4_sg125.ini' == 
-== Loading system model file 'system.ini' == 
-WARNING: UNKNOWN KEY 'DEBUG_TRANS_FLOW' IN INI FILE
-===== MemorySystem 0 =====
-CH. 0 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-===== MemorySystem 1 =====
-CH. 1 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-DRAMSim2 Clock Frequency =1Hz, CPU Clock Frequency=1Hz

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl_3.out
@@ -29,7 +29,7 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  l1cache.FetchInvX_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.Inv_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.NACK_recv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
- l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4324; SumSQ.u64 = 5068; Count.u64 = 208104; 
+ l1cache.MSHR_occupancy : Accumulator : Sum.u64 = 4324; SumSQ.u64 = 5068; Count.u64 = 208108; 
  l1cache.Bank_conflicts : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  l1cache.evict_E : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
@@ -138,11 +138,3 @@ TrivialCPU cpu Finished after 1000 issued reads, 1000 returned (104054 clocks)
  memory.cycles_attempted_issue_but_rejected : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; 
  memory.total_cycles : Accumulator : Sum.u64 = 104054; SumSQ.u64 = 10827234916; Count.u64 = 1; 
 Simulation is complete, simulated time: 104.054 us
-== Loading device model file 'DDR3_micron_32M_8B_x4_sg125.ini' == 
-== Loading system model file 'system.ini' == 
-WARNING: UNKNOWN KEY 'DEBUG_TRANS_FLOW' IN INI FILE
-===== MemorySystem 0 =====
-CH. 0 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-===== MemorySystem 1 =====
-CH. 1 TOTAL_STORAGE : 2048MB | 1 Ranks | 16 Devices per rank
-DRAMSim2 Clock Frequency =1Hz, CPU Clock Frequency=1Hz


### PR DESCRIPTION
Add emergencyShutdown() and printStatus() so that memH dumps its state on fatal() and SIGUSR2
Update mshr cache stats at finish() if clock was off
Rearch memNIC so that multi-port memNICs can use its init() functions