### PR TITLE
Merlin topo changes

### DIFF
--- a/src/sst/elements/merlin/hr_router/hr_router.cc
+++ b/src/sst/elements/merlin/hr_router/hr_router.cc
@@ -220,6 +220,9 @@ hr_router::hr_router(ComponentId_t cid, Params& params) :
     std::string inspector_config = params.find<std::string>("network_inspectors", "");
     split(inspector_config,",",inspector_names);
 
+    bool oql_track_port = params.find<bool>("oql_track_port","false");
+    bool oql_track_remote = params.find<bool>("oql_track_remote","false");
+    
     params.enableVerify(false);
     for ( int i = 0; i < num_ports; i++ ) {
         in_port_busy[i] = 0;
@@ -245,7 +248,8 @@ hr_router::hr_router(ComponentId_t cid, Params& params) :
                                    getLogicalGroupParam(params,topo,i,"input_buf_size"),
                                    getLogicalGroupParam(params,topo,i,"output_buf_size"),
                                    inspector_names,
-								   std::stof(getLogicalGroupParam(params,topo,i,"dlink_thresh", "-1")));
+								   std::stof(getLogicalGroupParam(params,topo,i,"dlink_thresh", "-1")),
+                                   oql_track_port,oql_track_remote);
         
     }
     params.enableVerify(true);

--- a/src/sst/elements/merlin/hr_router/hr_router.h
+++ b/src/sst/elements/merlin/hr_router/hr_router.h
@@ -64,6 +64,8 @@ public:
         {"input_buf_size",     "Size of input buffers specified in b or B (can include SI prefix)."},
         {"output_buf_size",    "Size of output buffers specified in b or B (can include SI prefix)."},
         {"network_inspectors", "Comma separated list of network inspectors to put on output ports.", ""},
+        {"oql_track_port",     "Set to true to track output queue length for an entire port.  False tracks per VC.", "false"},
+        {"oql_track_remote",   "Set to true to track output queue length including remote input queue.  False tracks only local queue.", "false"},
         {"debug",              "Turn on debugging for router. Set to 1 for on, 0 for off.", "0"}
     )
 

--- a/src/sst/elements/merlin/portControl.h
+++ b/src/sst/elements/merlin/portControl.h
@@ -107,6 +107,19 @@ private:
     // can be used by topology objects to make adaptive routing
     // decisions.
     int* output_queue_lengths;
+
+    // Tracks whether queue_lengths are per VC or for the entire port.
+    // If for the entire port, it will increment and decrement all VCs
+    // so that they track the enire queue occupancy for the port.
+    bool oql_track_port;
+
+    // Tracks whether or not the output_queue_lengths will track only
+    // the local output port, or will also track the next input queue.
+    // In this mode, it only decrements the count on returned credits
+    // from next router.
+    bool oql_track_remote;
+
+    
     
     // Variables to keep track of credits.  You need to keep track of
     // the credits available for your next buffer, as well as track
@@ -200,7 +213,7 @@ public:
                 SimTime_t output_latency_cycles, std::string output_latency_timebase,
                 const UnitAlgebra& in_buf_size, const UnitAlgebra& out_buf_size,
                 std::vector<std::string>& inspector_names,
-				const float dlink_thresh);
+				const float dlink_thresh, bool oql_track_port, bool oql_track_remote);
 
     void initVCs(int vcs, internal_router_event** vc_heads, int* xbar_in_credits, int* output_queue_lengths);
 

--- a/src/sst/elements/merlin/pymerlin.py
+++ b/src/sst/elements/merlin/pymerlin.py
@@ -807,7 +807,7 @@ class topoDragonFlyLegacy(Topo):
     def prepParams(self):
 #        if "xbar_arb" not in _params:
 #            _params["xbar_arb"] = "merlin.xbar_arb_lru"
-        _params["topology"] = "merlin.dragonfly"
+        _params["topology"] = "merlin.dragonfly_legacy"
         _params["debug"] = debug
         _params["num_vns"] = 1
         _params["router_radix"] = int(_params["router_radix"])

--- a/src/sst/elements/merlin/topology/dragonfly.cc
+++ b/src/sst/elements/merlin/topology/dragonfly.cc
@@ -15,12 +15,40 @@
 //
 
 #include <sst_config.h>
+#include <sst/core/sharedRegion.h>
+#include "sst/core/rng/xorshift.h"
+
 #include "dragonfly.h"
 
 #include <stdlib.h>
-
+#include <sstream>
 
 using namespace SST::Merlin;
+
+
+
+void
+RouteToGroup::init(SharedRegion* sr, size_t g, size_t r)
+{
+    region = sr;
+    data = sr->getPtr<const RouterPortPair*>();
+    groups = g;
+    routes = r;
+    
+}
+
+const RouterPortPair&
+RouteToGroup::getRouterPortPair(int group, int route_number)
+{
+    // data = static_cast<RouterPortPair*>(region->getRawPtr());
+    return data[group*routes + route_number];
+}
+
+void
+RouteToGroup::setRouterPortPair(int group, int route_number, const RouterPortPair& pair) {
+    // output.output("%d, %d, %d, %d\n",group,route_number,pair.router,pair.port);
+    region->modifyArray(group*routes+route_number,pair);
+}
 
 
 /*
@@ -29,7 +57,6 @@ using namespace SST::Merlin;
  * [params.p, params.p+params.a-1)  // Routers within this group
  * [params.p+params.a-1, params.k)  // Other groups
  */
-
 topo_dragonfly::topo_dragonfly(Component* comp, Params &p) :
     Topology(comp)
 {
@@ -38,9 +65,70 @@ topo_dragonfly::topo_dragonfly(Component* comp, Params &p) :
     params.k = (uint32_t)p.find<int>("num_ports");
     params.h = (uint32_t)p.find<int>("dragonfly:intergroup_per_router");
     params.g = (uint32_t)p.find<int>("dragonfly:num_groups");
+    params.n = (uint32_t)p.find<int>("dragonfly:intergroup_links");
 
+    std::string global_route_mode_s = p.find<std::string>("dragonfly:global_route_mode","absolute");
+    if ( global_route_mode_s == "absolute" ) global_route_mode = ABSOLUTE;
+    else if ( global_route_mode_s == "relative" ) global_route_mode = RELATIVE;
+    else {
+        output.fatal(CALL_INFO, -1, "Invalid dragonfly:global_route_mode specified: %s.\n",global_route_mode_s.c_str());        
+    }
+    
     std::string route_algo = p.find<std::string>("dragonfly:algorithm", "minimal");
 
+    adaptive_threshold = p.find<double>("dragonfly:adaptive_threshold",2.0);
+    
+    // Get the global link map
+    std::vector<int64_t> global_link_map;
+
+    // For now, parse array ourselves so as not to create a dependency
+    // on new core features.  Once we want to use new core features,
+    // delete code below and uncomment line above (can also get rid of
+    // #include <sstream> above).
+    std::string array = p.find<std::string>("dragonfly:global_link_map");
+    if ( array != "" ) {
+        array = array.substr(1,array.size()-2);
+    
+        std::stringstream ss(array);
+    
+        while( ss.good() ) {
+            std::string substr;
+            getline( ss, substr, ',' );
+            global_link_map.push_back(strtol(substr.c_str(), NULL, 0));
+        }
+    }
+    // End parse array on our own
+    
+    // Get a shared region
+    SharedRegion* sr = Simulation::getSharedRegionManager()->getGlobalSharedRegion("dragonfly:group_to_global_port",
+                                                                                  ((params.g-1) * params.n) * sizeof(RouterPortPair),
+                                                                                   new SharedRegionMerger());
+    // Set up the RouteToGroup object
+    group_to_global_port.init(sr, params.g, params.n);
+
+    // Fill in the shared region using the RouteToGroupObject (if
+    // vector for param dragonfly:global_link_map is empty, then
+    // nothing will be intialized.
+    for ( int i = 0; i < global_link_map.size(); i++ ) {
+        // Figure out all the mappings
+        int64_t value = global_link_map[i];
+        if ( value == -1 ) continue;
+        
+        int group = value % (params.g - 1);
+        int route_num = value / (params.g - 1);
+        int router = i / params.h;
+        int port = (i % params.h) + params.p + params.a - 1;
+        
+        RouterPortPair rpp;
+        rpp.router = router;
+        rpp.port = port;
+        group_to_global_port.setRouterPortPair(group, route_num, rpp);
+    }
+
+    
+    // Publish the shared region to make sure everyone has the data.
+    sr->publish();
+    
     if ( !route_algo.compare("valiant") ) {
         if ( params.g <= 2 ) {
             /* 2 or less groups... no point in valiant */
@@ -48,13 +136,20 @@ topo_dragonfly::topo_dragonfly(Component* comp, Params &p) :
         } else {
             algorithm = VALIANT;
         }
-    } else {
+    }
+    else if ( !route_algo.compare("adaptive-local") ) {
+        algorithm = ADAPTIVE_LOCAL;
+    }
+    else {
         algorithm = MINIMAL;
     }
 
     uint32_t id = p.find<int>("id");
     group_id = id / params.a;
     router_id = id % params.a;
+
+    rng = new RNG::XORShiftRNG(id+1);
+
     output.verbose(CALL_INFO, 1, 1, "%u:%u:  ID: %u   Params:  p = %u  a = %u  k = %u  h = %u  g = %u\n",
             group_id, router_id, id, params.p, params.a, params.k, params.h, params.g);
 }
@@ -69,28 +164,212 @@ void topo_dragonfly::route(int port, int vc, internal_router_event* ev)
 {
     topo_dragonfly_event *td_ev = static_cast<topo_dragonfly_event*>(ev);
 
-    if ( (uint32_t)port >= (params.p + params.a-1) ) {
+    // Break this up by port type
+    uint32_t next_port = 0;
+    if ( (uint32_t)port < params.p ) { 
+        // Host ports
+
+        if ( td_ev->dest.group == td_ev->src_group ) {
+            // Packets stays within the group
+            if ( td_ev->dest.router == router_id ) {
+                // Stays within the router
+                next_port = td_ev->dest.host;
+            }
+            else {
+                // Route to the router specified by mid_group.  If
+                // this is a direct route then mid_group will equal
+                // router and packet will go direct.
+                next_port = port_for_router(td_ev->dest.mid_group);
+            }
+        }
+        else {
+            // Packet is leaving group.  Simply route to group
+            // specified by mid_group.  If this is a direct route then
+            // mid_group will be set to group.
+            next_port = port_for_group(td_ev->dest.mid_group, td_ev->global_slice);
+        }        
+    }
+    else if ( (uint32_t)port < ( params.p + params.a - 1) ) {
+        // Intragroup links
+
+        if ( td_ev->dest.group == group_id ) {
+            // In final group
+            if ( td_ev->dest.router == router_id ) {
+                // In final router, route to host port
+                next_port = td_ev->dest.host;
+            }
+            else {
+                // This is a valiantly routed packet within a group.
+                // Need to increment the VC and route to correct
+                // router.
+                td_ev->setVC(vc+1);
+                next_port = port_for_router(td_ev->dest.router);
+            }
+        }
+        else {
+            // Not in correct group, should route out one of the
+            // global links
+            if ( td_ev->dest.mid_group != group_id ) {
+                next_port = port_for_group(td_ev->dest.mid_group, td_ev->global_slice);
+            } else {
+                next_port = port_for_group(td_ev->dest.group, td_ev->global_slice);
+            }
+        }
+    }
+    else { // global
         /* Came in from another group.  Increment VC */
         td_ev->setVC(vc+1);
-    }
-
-
-    /* Minimal Route */
-    uint32_t next_port = 0;
-    if ( td_ev->dest.group != group_id ) {
-        if ( td_ev->dest.mid_group != group_id ) {
-            next_port = port_for_group(td_ev->dest.mid_group);
-        } else {
-            next_port = port_for_group(td_ev->dest.group);
+        if ( td_ev->dest.group == group_id ) {
+            if ( td_ev->dest.router == router_id ) {
+                // In final router, route to host port
+                next_port = td_ev->dest.host;
+            }
+            else {
+                // Go to final router
+                next_port = port_for_router(td_ev->dest.router);
+            }
         }
-    } else if ( td_ev->dest.router != router_id ) {
-        next_port = port_for_router(td_ev->dest.router);
-    } else {
-        next_port = td_ev->dest.host;
+        else {
+            // Just passing through on a valiant route.  Route
+            // directly to final group
+            next_port = port_for_group(td_ev->dest.group, td_ev->global_slice);
+        }
     }
+
 
     output.verbose(CALL_INFO, 1, 1, "%u:%u, Recv: %d/%d  Setting Next Port/VC:  %u/%u\n", group_id, router_id, port, vc, next_port, td_ev->getVC());
     td_ev->setNextPort(next_port);
+}
+
+void topo_dragonfly::reroute(int port, int vc, internal_router_event* ev)
+{
+    if ( algorithm != ADAPTIVE_LOCAL ) return;
+
+    // For now, we make the adaptive routing decision only at the
+    // input to the network and at the input to a group for adaptively
+    // routed packets
+    if ( port >= params.p && port < (params.p + params.a-1) ) return;
+
+    
+    topo_dragonfly_event *td_ev = static_cast<topo_dragonfly_event*>(ev);
+
+    // Adaptive routing when packet stays in group
+    if ( port < params.p && td_ev->dest.group == group_id ) {
+        // If we're at the correct router, no adaptive needed
+        if ( td_ev->dest.router == router_id) return;
+
+        int direct_route_port = port_for_router(td_ev->dest.router);
+        int direct_route_credits = output_credits[direct_route_port * num_vcs + vc];
+
+        int valiant_route_port = port_for_router(td_ev->dest.mid_group);
+        int valiant_route_credits = output_credits[valiant_route_port * num_vcs + vc];
+
+        if ( valiant_route_credits > (int)((double)direct_route_credits * adaptive_threshold) ) {
+            td_ev->setNextPort(valiant_route_port);
+        }
+        else {
+            td_ev->setNextPort(direct_route_port);
+        }
+        
+        return;
+    }
+    
+    // If the dest is in the same group, no need to adaptively route
+    if ( td_ev->dest.group == group_id ) return;
+
+    
+    // Based on the output queue depths, choose minimal or valiant
+    // route.  We'll chose the direct route unless the remaining
+    // output credits for the direct route is half of the valiant
+    // route.  We'll look at two slice for each direct and indirect,
+    // giving us a total of 4 routes we are looking at.  For packets
+    // which came in adaptively on global links, look at two direct
+    // routes and chose between the.
+    int direct_slice1 = td_ev->global_slice_shadow;
+    // int direct_slice2 = td_ev->global_slice;
+    int direct_slice2 = (td_ev->global_slice_shadow + 1) % params.n;
+    int direct_route_port1 = port_for_group(td_ev->dest.group, direct_slice1, 0 );
+    int direct_route_port2 = port_for_group(td_ev->dest.group, direct_slice2, 1 );
+    int direct_route_credits1 = output_credits[direct_route_port1 * num_vcs + vc];
+    int direct_route_credits2 = output_credits[direct_route_port2 * num_vcs + vc];
+    int direct_slice;
+    int direct_route_port;
+    int direct_route_credits;
+    if ( direct_route_credits1 > direct_route_credits2 ) {
+        direct_slice = direct_slice1;
+        direct_route_port = direct_route_port1;
+        direct_route_credits = direct_route_credits1;
+    }
+    else {
+        direct_slice = direct_slice2;
+        direct_route_port = direct_route_port2;
+        direct_route_credits = direct_route_credits2;        
+    }
+    // if ( td_ev->getTraceType() != SST::Interfaces::SimpleNetwork::Request::NONE ) {
+    //     output.output("TRACE(%d): reroute():"
+    //                   " mid_group_shadow = %u,"
+    //                   " direct_slice1 = %d,"
+    //                   " direct_slice2 = %d,"
+    //                   " direct_route_port1 = %d,"
+    //                   " direct_route_port2 = %d",
+    //                   td_ev->getTraceID(),
+    //                   td_ev->dest.mid_group_shadow,
+    //                   direct_slice1,
+    //                   direct_slice2,
+    //                   direct_route_port1,
+    //                   direct_route_port2);
+    // }
+
+    int valiant_slice = 0;
+    int valiant_route_port = 0;
+    int valiant_route_credits = 0;
+
+    if ( port >= (params.p + params.a-1) ) {
+        // Global port, no indirect routes.  Set credits negative so
+        // it will never get chosen
+        valiant_route_credits = -1;
+    }
+    else {
+        int valiant_slice1 = td_ev->global_slice;
+        // int valiant_slice2 = td_ev->global_slice;
+        int valiant_slice2 = (td_ev->global_slice + 1) % params.n;
+        int valiant_route_port1 = port_for_group(td_ev->dest.mid_group_shadow, valiant_slice1, 2 );
+        int valiant_route_port2 = port_for_group(td_ev->dest.mid_group_shadow, valiant_slice2, 3 );
+        int valiant_route_credits1 = output_credits[valiant_route_port1 * num_vcs + vc];
+        int valiant_route_credits2 = output_credits[valiant_route_port2 * num_vcs + vc];
+        if ( valiant_route_credits1 > valiant_route_credits2 ) {
+            valiant_slice = valiant_slice1;
+            valiant_route_port = valiant_route_port1;
+            valiant_route_credits = valiant_route_credits1;
+        }
+        else {
+            valiant_slice = valiant_slice2;
+            valiant_route_port = valiant_route_port2;
+            valiant_route_credits = valiant_route_credits2;        
+        }
+    }
+
+    
+    if ( valiant_route_credits > (int)((double)direct_route_credits * adaptive_threshold) ) { // Use valiant route
+        td_ev->dest.mid_group = td_ev->dest.mid_group_shadow;
+        td_ev->setNextPort(valiant_route_port);
+        // output.output("valiant_slice = %d\n", valiant_slice);
+        td_ev->global_slice = valiant_slice;
+    }
+    else { // Use direct route
+        td_ev->dest.mid_group = td_ev->dest.group;
+        td_ev->setNextPort(direct_route_port);
+        // output.output("direct_slice = %d\n", valiant_slice);
+        td_ev->global_slice = direct_slice;
+    }
+
+    // if ( td_ev->getTraceType() != SST::Interfaces::SimpleNetwork::Request::NONE ) {
+    //     output.output("TRACE(%d): reroute():"
+    //                   " mid_group_shadow = %u\n",
+    //                   td_ev->getTraceID(),
+    //                   td_ev->dest.mid_group_shadow);
+    // }
+    
 }
 
 
@@ -98,30 +377,50 @@ internal_router_event* topo_dragonfly::process_input(RtrEvent* ev)
 {
     dgnflyAddr dstAddr = {0, 0, 0, 0};
     idToLocation(ev->request->dest, &dstAddr);
-
+    
     switch (algorithm) {
     case MINIMAL:
-        dstAddr.mid_group = dstAddr.group;
+        if ( dstAddr.group == group_id ) {
+            dstAddr.mid_group = dstAddr.router;
+        }
+        else {
+            dstAddr.mid_group = dstAddr.group;
+        }
         break;
     case VALIANT:
+    case ADAPTIVE_LOCAL:
         if ( dstAddr.group == group_id ) {
-            // staying here.
-            dstAddr.mid_group = dstAddr.group;
+            // staying within group, set mid_group to be an intermediate router within group
+            do {
+                dstAddr.mid_group = rng->generateNextUInt32() % params.a;
+                // dstAddr.mid_group = router_id;
+            }
+            while ( dstAddr.mid_group == router_id );
+            // dstAddr.mid_group = dstAddr.group;
         } else {
             do {
-                dstAddr.mid_group = rand() % params.g;
+                dstAddr.mid_group = rng->generateNextUInt32() % params.g;
+                // dstAddr.mid_group = rand() % params.g;
             } while ( dstAddr.mid_group == group_id || dstAddr.mid_group == dstAddr.group );
         }
         break;
     }
-
+    dstAddr.mid_group_shadow = dstAddr.mid_group;
     // output.verbose(CALL_INFO, 1, 1, "Init packet from %d to %d to %u:%u:%u:%u\n", ev->request->src, ev->request->dest, dstAddr.group, dstAddr.mid_group, dstAddr.router, dstAddr.host);
 
     topo_dragonfly_event *td_ev = new topo_dragonfly_event(dstAddr);
     td_ev->src_group = group_id;
     td_ev->setEncapsulatedEvent(ev);
     td_ev->setVC(ev->request->vn * 3);
-    
+    td_ev->global_slice = ev->request->src % params.n;
+    td_ev->global_slice_shadow = ev->request->src % params.n;
+
+    if ( td_ev->getTraceType() != SST::Interfaces::SimpleNetwork::Request::NONE ) {
+        output.output("TRACE(%d): process_input():"
+                      " mid_group_shadow = %u\n",
+                      td_ev->getTraceID(),
+                      td_ev->dest.mid_group_shadow);
+    }
     return td_ev;
 }
 
@@ -129,6 +428,7 @@ internal_router_event* topo_dragonfly::process_input(RtrEvent* ev)
 
 void topo_dragonfly::routeInitData(int port, internal_router_event* ev, std::vector<int> &outPorts)
 {
+    bool broadcast_to_groups = false;
     topo_dragonfly_event *td_ev = static_cast<topo_dragonfly_event*>(ev);
     if ( td_ev->dest.host == (uint32_t)INIT_BROADCAST_ADDR ) {
         if ( (uint32_t)port >= (params.p + params.a-1) ) {
@@ -147,22 +447,48 @@ void topo_dragonfly::routeInitData(int port, internal_router_event* ev, std::vec
                 outPorts.push_back((int)p);
             }
             if ( td_ev->src_group == group_id ) {
-                for ( uint32_t p = (params.p+params.a-1) ; p < params.k ; p++ ) {
-                    outPorts.push_back((int)p);
-                }
+                broadcast_to_groups = true;
+                // for ( uint32_t p = (params.p+params.a-1) ; p < params.k ; p++ ) {
+                //     outPorts.push_back((int)p);
+                // }
             }
         } else {
             /* Came in from a host
              * Send to all other hosts and routers in group, and all groups
              */
-            for ( int p = 0 ; p < (int)params.k ; p++ ) {
+            // for ( int p = 0 ; p < (int)params.k ; p++ ) {
+            for ( int p = 0 ; p < (int)(params.p + params.a - 1) ; p++ ) {
                 if ( p != port )
                     outPorts.push_back((int)p);
             }
+            broadcast_to_groups = true;
+        }
+
+        if ( broadcast_to_groups ) {
+            for ( int p = 0; p < (int)(params.g - 1); p++ ) {
+                const RouterPortPair& pair = group_to_global_port.getRouterPortPair(p,0);
+                if ( pair.router == router_id ) outPorts.push_back((int)(pair.port));
+            }
         }
     } else {
-        route(port, 0, ev);
-        outPorts.push_back(ev->getNextPort());
+        //Not all data structures used for routing during run are
+        //initialized yet, so we need to just do a quick minimal
+        //routing scheme for init.
+        // route(port, 0, ev);
+
+        // TraceFunction(CALL_INFO);
+        // Minimal Route
+        int next_port;
+        if ( td_ev->dest.group != group_id ) {
+            next_port = port_for_group(td_ev->dest.group, td_ev->global_slice);
+        }
+        else if ( td_ev->dest.router != router_id ) {
+            next_port = port_for_router(td_ev->dest.router);
+        }
+        else {
+            next_port = td_ev->dest.host;
+        }
+        outPorts.push_back(next_port);
     }
 
 }
@@ -203,8 +529,15 @@ topo_dragonfly::getEndpointID(int port)
         (router_id * params.p /*hosts_per_rtr*/) + port;
 }
 
+void
+topo_dragonfly::setOutputBufferCreditArray(int const* array, int vcs)
+{
+    output_credits = array;
+    num_vcs = vcs;
+}
 
-void topo_dragonfly::idToLocation(int id, dgnflyAddr *location) const
+
+void topo_dragonfly::idToLocation(int id, dgnflyAddr *location)
 {
     if ( id == INIT_BROADCAST_ADDR) {
         location->group = (uint32_t)INIT_BROADCAST_ADDR;
@@ -220,9 +553,9 @@ void topo_dragonfly::idToLocation(int id, dgnflyAddr *location) const
 }
 
 
-uint32_t topo_dragonfly::router_to_group(uint32_t group) const
+uint32_t topo_dragonfly::router_to_group(uint32_t group)
 {
-    /* For now, assume only 1 connection to each group */
+
     if ( group < group_id ) {
         return group / params.h;
     } else if ( group > group_id ) {
@@ -235,28 +568,41 @@ uint32_t topo_dragonfly::router_to_group(uint32_t group) const
 
 
 /* returns local router port if group can't be reached from this router */
-uint32_t topo_dragonfly::port_for_group(uint32_t group) const
+uint32_t topo_dragonfly::port_for_group(uint32_t group, uint32_t slice, int id)
 {
-    uint32_t tgt_rtr = router_to_group(group);
-    if ( tgt_rtr == router_id ) {
-        uint32_t port = params.p + params.a-1;
-        if ( group < group_id ) {
-            port += (group % params.h);
-        } else {
-            port += ((group-1) % params.h);
+    // Look up global port to use
+    switch ( global_route_mode ) {
+    case ABSOLUTE:
+        if ( group >= group_id ) group--;
+        break;
+    case RELATIVE:
+        if ( group > group_id ) {
+            group = group - group_id - 1;
         }
-        return port;
+        else {
+            group = params.g - group_id + group - 1;
+        }
+        break;
+    default:
+        break;
+    }
+
+    const RouterPortPair& pair = group_to_global_port.getRouterPortPair(group,slice);
+
+    if ( pair.router == router_id ) {
+        return pair.port;
     } else {
-        return port_for_router(tgt_rtr);
+        return port_for_router(pair.router);
     }
 
 }
 
 
-uint32_t topo_dragonfly::port_for_router(uint32_t router) const
+uint32_t topo_dragonfly::port_for_router(uint32_t router)
 {
     uint32_t tgt = params.p + router;
     if ( router > router_id ) tgt--;
     return tgt;
 }
+
 

--- a/src/sst/elements/merlin/topology/dragonfly.h
+++ b/src/sst/elements/merlin/topology/dragonfly.h
@@ -23,13 +23,49 @@
 #include <sst/core/event.h>
 #include <sst/core/link.h>
 #include <sst/core/params.h>
+#include <sst/core/rng/sstrng.h>
 
 #include "sst/elements/merlin/router.h"
 
+
+
 namespace SST {
+class SharedRegion;
+
 namespace Merlin {
 
 class topo_dragonfly_event;
+
+struct RouterPortPair {
+    uint16_t router;
+    uint16_t port;
+
+    RouterPortPair(int router, int port) :
+        router(router),
+        port(port)
+        {}
+
+    RouterPortPair() {}
+};
+
+class RouteToGroup {
+private:
+    const RouterPortPair* data;
+    SharedRegion* region;
+    size_t groups;
+    size_t routes;
+    
+    
+public:
+    RouteToGroup() {}
+
+    void init(SharedRegion* sr, size_t g, size_t r);
+
+    const RouterPortPair& getRouterPortPair(int group, int route_number);
+
+    void setRouterPortPair(int group, int route_number, const RouterPortPair& pair);
+};
+
 
 class topo_dragonfly: public Topology {
 
@@ -40,18 +76,21 @@ public:
         "merlin",
         "dragonfly",
         SST_ELI_ELEMENT_VERSION(1,0,0),
-        "Dragonfly topology object",
+        "Dragonfly topology object.  Implements a dragonfly with a single all to all pattern within the group.",
         "SST::Merlin::Topology")
     
     SST_ELI_DOCUMENT_PARAMS(
         {"dragonfly:hosts_per_router",      "Number of hosts connected to each router."},
         {"dragonfly:routers_per_group",     "Number of links used to connect to routers in same group."},
         {"dragonfly:intergroup_per_router", "Number of links per router connected to other groups."},
+        {"dragonfly:intergroup_links",      "Number of links between each pair of groups."},
         {"dragonfly:num_groups",            "Number of groups in network."},
-        {"dragonfly:algorithm",             "Routing algorithm to use [minmal (default) | valiant].", "minimal"}
+        {"dragonfly:algorithm",             "Routing algorithm to use [minmal (default) | valiant].", "minimal"},
+        {"dragonfly:adaptive_threshold",    "Threshold to use when make adaptive routing decisions.", "2.0"},
+        {"dragonfly:global_link_map",       "Array specifying connectivity of global links in each dragonfly group."},
+        {"dragonfly:global_route_mode",     "Mode for intepreting global link map [absolute (default) | relative].","absolute"},
     )
 
-    
     /* Assumed connectivity of each router:
      * ports [0, p-1]:      Hosts
      * ports [p, p+a-2]:    Intra-group
@@ -64,23 +103,36 @@ public:
         uint32_t k;  /* Router Radix */
         uint32_t h;  /* # of ports / router to connect to other groups */
         uint32_t g;  /* # of Groups */
+        uint32_t n;  /* # of links between groups in a pair */
     };
 
     enum RouteAlgo {
         MINIMAL,
-        VALIANT
+        VALIANT,
+        ADAPTIVE_LOCAL
     };
 
-
+    RouteToGroup group_to_global_port;
+    
     struct dgnflyParams params;
     RouteAlgo algorithm;
+    double adaptive_threshold;
     uint32_t group_id;
     uint32_t router_id;
+
+    RNG::SSTRandom* rng;
+
+    int const* output_credits;
+    int num_vcs;
+    
+    enum global_route_mode_t { ABSOLUTE, RELATIVE };
+    global_route_mode_t global_route_mode;
 
 public:
     struct dgnflyAddr {
         uint32_t group;
         uint32_t mid_group;
+        uint32_t mid_group_shadow;
         uint32_t router;
         uint32_t host;
     };
@@ -89,6 +141,7 @@ public:
     ~topo_dragonfly();
 
     virtual void route(int port, int vc, internal_router_event* ev);
+    virtual void reroute(int port, int vc, internal_router_event* ev);
     virtual internal_router_event* process_input(RtrEvent* ev);
 
     virtual PortState getPortState(int port) const;
@@ -100,11 +153,13 @@ public:
     virtual int computeNumVCs(int vns) { return vns * 3; }
     virtual int getEndpointID(int port);
 
+    virtual void setOutputBufferCreditArray(int const* array, int vcs);
+    
 private:
-    void idToLocation(int id, dgnflyAddr *location) const;
-    uint32_t router_to_group(uint32_t group) const;
-    uint32_t port_for_router(uint32_t router) const;
-    uint32_t port_for_group(uint32_t group) const;
+    void idToLocation(int id, dgnflyAddr *location);
+    uint32_t router_to_group(uint32_t group);
+    uint32_t port_for_router(uint32_t router);
+    uint32_t port_for_group(uint32_t group, uint32_t global_slice, int id = -1);
 
 };
 
@@ -116,9 +171,13 @@ class topo_dragonfly_event : public internal_router_event {
 public:
     uint32_t src_group;
     topo_dragonfly::dgnflyAddr dest;
+    uint16_t global_slice;
+    uint16_t global_slice_shadow;
 
     topo_dragonfly_event() { }
-    topo_dragonfly_event(const topo_dragonfly::dgnflyAddr &dest) : dest(dest) {}
+    topo_dragonfly_event(const topo_dragonfly::dgnflyAddr &dest) :
+        dest(dest), global_slice(0)
+        {}
     ~topo_dragonfly_event() { }
 
     virtual internal_router_event *clone(void) override
@@ -131,12 +190,16 @@ public:
         ser & src_group;
         ser & dest.group;
         ser & dest.mid_group;
+        ser & dest.mid_group_shadow;
         ser & dest.router;
         ser & dest.host;
+        ser & global_slice;
+        ser & global_slice_shadow;
     }
-    
+
 private:
     ImplementSerializable(SST::Merlin::topo_dragonfly_event)
+
 };
 
 }

--- a/src/sst/elements/merlin/topology/dragonfly2.cc
+++ b/src/sst/elements/merlin/topology/dragonfly2.cc
@@ -28,24 +28,24 @@ using namespace SST::Merlin;
 
 
 void
-RouteToGroup::init(SharedRegion* sr, size_t g, size_t r)
+RouteToGroup2::init(SharedRegion* sr, size_t g, size_t r)
 {
     region = sr;
-    data = sr->getPtr<const RouterPortPair*>();
+    data = sr->getPtr<const RouterPortPair2*>();
     groups = g;
     routes = r;
     
 }
 
-const RouterPortPair&
-RouteToGroup::getRouterPortPair(int group, int route_number)
+const RouterPortPair2&
+RouteToGroup2::getRouterPortPair(int group, int route_number)
 {
-    // data = static_cast<RouterPortPair*>(region->getRawPtr());
+    // data = static_cast<RouterPortPair2*>(region->getRawPtr());
     return data[group*routes + route_number];
 }
 
 void
-RouteToGroup::setRouterPortPair(int group, int route_number, const RouterPortPair& pair) {
+RouteToGroup2::setRouterPortPair(int group, int route_number, const RouterPortPair2& pair) {
     // output.output("%d, %d, %d, %d\n",group,route_number,pair.router,pair.port);
     region->modifyArray(group*routes+route_number,pair);
 }
@@ -101,7 +101,7 @@ topo_dragonfly2::topo_dragonfly2(Component* comp, Params &p) :
     
     // Get a shared region
     SharedRegion* sr = Simulation::getSharedRegionManager()->getGlobalSharedRegion("dragonfly:group_to_global_port",
-                                                                                  ((params.g-1) * params.n) * sizeof(RouterPortPair),
+                                                                                  ((params.g-1) * params.n) * sizeof(RouterPortPair2),
                                                                                    new SharedRegionMerger());
     // Set up the RouteToGroup object
     group_to_global_port.init(sr, params.g, params.n);
@@ -119,7 +119,7 @@ topo_dragonfly2::topo_dragonfly2(Component* comp, Params &p) :
         int router = i / params.h;
         int port = (i % params.h) + params.p + params.a - 1;
         
-        RouterPortPair rpp;
+        RouterPortPair2 rpp;
         rpp.router = router;
         rpp.port = port;
         group_to_global_port.setRouterPortPair(group, route_num, rpp);
@@ -466,7 +466,7 @@ void topo_dragonfly2::routeInitData(int port, internal_router_event* ev, std::ve
 
         if ( broadcast_to_groups ) {
             for ( int p = 0; p < (int)(params.g - 1); p++ ) {
-                const RouterPortPair& pair = group_to_global_port.getRouterPortPair(p,0);
+                const RouterPortPair2& pair = group_to_global_port.getRouterPortPair(p,0);
                 if ( pair.router == router_id ) outPorts.push_back((int)(pair.port));
             }
         }
@@ -587,7 +587,7 @@ uint32_t topo_dragonfly2::port_for_group(uint32_t group, uint32_t slice, int id)
         break;
     }
 
-    const RouterPortPair& pair = group_to_global_port.getRouterPortPair(group,slice);
+    const RouterPortPair2& pair = group_to_global_port.getRouterPortPair(group,slice);
 
     if ( pair.router == router_id ) {
         return pair.port;

--- a/src/sst/elements/merlin/topology/dragonfly2.h
+++ b/src/sst/elements/merlin/topology/dragonfly2.h
@@ -36,34 +36,34 @@ namespace Merlin {
 
 class topo_dragonfly2_event;
 
-struct RouterPortPair {
+struct RouterPortPair2 {
     uint16_t router;
     uint16_t port;
 
-    RouterPortPair(int router, int port) :
+    RouterPortPair2(int router, int port) :
         router(router),
         port(port)
         {}
 
-    RouterPortPair() {}
+    RouterPortPair2() {}
 };
 
-class RouteToGroup {
+class RouteToGroup2 {
 private:
-    const RouterPortPair* data;
+    const RouterPortPair2* data;
     SharedRegion* region;
     size_t groups;
     size_t routes;
     
     
 public:
-    RouteToGroup() {}
+    RouteToGroup2() {}
 
     void init(SharedRegion* sr, size_t g, size_t r);
 
-    const RouterPortPair& getRouterPortPair(int group, int route_number);
+    const RouterPortPair2& getRouterPortPair(int group, int route_number);
 
-    void setRouterPortPair(int group, int route_number, const RouterPortPair& pair);
+    void setRouterPortPair(int group, int route_number, const RouterPortPair2& pair);
 };
 
 
@@ -112,7 +112,7 @@ public:
         ADAPTIVE_LOCAL
     };
 
-    RouteToGroup group_to_global_port;
+    RouteToGroup2 group_to_global_port;
     
     struct dgnfly2Params params;
     RouteAlgo algorithm;


### PR DESCRIPTION
Removed old dragonfly topolgy and made it identical to dragonfly2.
    
    Development on dragonfly2 will now stop and all future changes
    will be done to dragonfly.

Added options to output_queue_length computation.
    
    Can now track for a whole port instead of per VC by setting
    oql_track_port to true.  Can also track an approximation of
    output queue length and next router input queue length by
    setting oql_track_remote to true.
