### PR TITLE
Capture Data Values for Writing Back to Memory Model when using Ariel

### DIFF
--- a/src/sst/elements/ariel/ariel_shmem.h
+++ b/src/sst/elements/ariel/ariel_shmem.h
@@ -53,6 +53,7 @@ struct ArielCommand {
             uint64_t addr;
             uint32_t instClass;
             uint32_t simdElemCount;
+	    	uint8_t  payload[64];
         } inst;
         struct {
             uint64_t vaddr;

--- a/src/sst/elements/ariel/ariel_shmem.h
+++ b/src/sst/elements/ariel/ariel_shmem.h
@@ -21,6 +21,8 @@
 #include <sst/core/interprocess/ipctunnel.h>
 #include "ariel_inst_class.h"
 
+#define ARIEL_MAX_PAYLOAD_SIZE 64
+
 namespace SST {
 namespace ArielComponent {
 
@@ -53,7 +55,7 @@ struct ArielCommand {
             uint64_t addr;
             uint32_t instClass;
             uint32_t simdElemCount;
-	    	uint8_t  payload[64];
+	    	uint8_t  payload[ARIEL_MAX_PAYLOAD_SIZE];
         } inst;
         struct {
             uint64_t vaddr;

--- a/src/sst/elements/ariel/arielcore.cc
+++ b/src/sst/elements/ariel/arielcore.cc
@@ -47,6 +47,7 @@ ArielCore::ArielCore(ArielTunnel *tunnel, SimpleMem* coreToCacheLink,
     memmgr = memMgr;
 
     opal_enabled = false;
+    writePayloads = params.find<int>("writepayloadtrace") ? false : true;
 
     coreQ = new std::queue<ArielEvent*>();
     pendingTransactions = new std::unordered_map<SimpleMem::Request::id_t, SimpleMem::Request*>();
@@ -160,13 +161,15 @@ void ArielCore::commitReadEvent(const uint64_t address,
 }
 
 void ArielCore::commitWriteEvent(const uint64_t address,
-            const uint64_t virtAddress, const uint32_t length) {
+            const uint64_t virtAddress, const uint32_t length, const uint8_t* payload) {
 
     if(length > 0) {
         SimpleMem::Request *req = new SimpleMem::Request(SimpleMem::Request::Write, address, length);
         req->setVirtualAddress(virtAddress);
 
-        // TODO BJM:  DO we need to fill in dummy data?
+		if( writePayloads ) {
+			req->setPayload( (uint8_t*) payload, length );
+		}
 
         pending_transaction_count++;
         pendingTransactions->insert( std::pair<SimpleMem::Request::id_t, SimpleMem::Request*>(req->id, req) );
@@ -301,8 +304,8 @@ void ArielCore::createFreeEvent(uint64_t vAddr) {
     ARIEL_CORE_VERBOSE(2, output->verbose(CALL_INFO, 2, 0, "Generated a free event for virtual address=%" PRIu64 "\n", vAddr));
 }
 
-void ArielCore::createWriteEvent(uint64_t address, uint32_t length) {
-    ArielWriteEvent* ev = new ArielWriteEvent(address, length);
+void ArielCore::createWriteEvent(uint64_t address, uint32_t length, const uint8_t* payload) {
+    ArielWriteEvent* ev = new ArielWriteEvent(address, length, payload);
     coreQ->push(ev);
 
     ARIEL_CORE_VERBOSE(4, output->verbose(CALL_INFO, 4, 0, "Generated a WRITE event, addr=%" PRIu64 ", length=%" PRIu32 "\n", address, length));
@@ -416,7 +419,7 @@ bool ArielCore::refillQueue() {
                                     break;
 
                             case ARIEL_PERFORM_WRITE:
-                                    createWriteEvent(ac.inst.addr, ac.inst.size);
+                                    createWriteEvent(ac.inst.addr, ac.inst.size, &ac.inst.payload[0]);
                                     break;
 
                             case ARIEL_END_INSTRUCTION:
@@ -589,7 +592,12 @@ void ArielCore::handleWriteRequest(ArielWriteEvent* wEv) {
         ARIEL_CORE_VERBOSE(4, output->verbose(CALL_INFO, 4, 0, "Core %" PRIu32 " issuing write, VAddr=%" PRIu64 ", Size=%" PRIu64 ", PhysAddr=%" PRIu64 "\n",
                             coreID, writeAddress, writeLength, physAddr));
 
-        commitWriteEvent(physAddr, writeAddress, (uint32_t) writeLength);
+		if( writePayloads ) {
+        	commitWriteEvent(physAddr, writeAddress, (uint32_t) writeLength, NULL);
+        } else {
+        	uint8_t* payloadPtr = wEv->getPayload();
+        	commitWriteEvent(physAddr, writeAddress, (uint32_t) writeLength, payloadPtr);
+        }
     } else {
         ARIEL_CORE_VERBOSE(4, output->verbose(CALL_INFO, 4, 0, "Core %" PRIu32 " generating a split write request: Addr=%" PRIu64 " Length=%" PRIu64 "\n",
                             coreID, writeAddress, writeLength));
@@ -624,8 +632,15 @@ void ArielCore::handleWriteRequest(ArielWriteEvent* wEv) {
             }*/
         }
 
-        commitWriteEvent(physLeftAddr, leftAddr, (uint32_t) leftSize);
-        commitWriteEvent(physRightAddr, rightAddr, (uint32_t) rightSize);
+		if( writePayloads ) {
+			uint8_t* payloadPtr = wEv->getPayload();
+		
+        	commitWriteEvent(physLeftAddr, leftAddr, (uint32_t) leftSize, payloadPtr);
+        	commitWriteEvent(physRightAddr, rightAddr, (uint32_t) rightSize, &payloadPtr[leftSize]);
+        } else {
+        	commitWriteEvent(physLeftAddr, leftAddr, (uint32_t) leftSize, NULL);
+        	commitWriteEvent(physRightAddr, rightAddr, (uint32_t) rightSize, NULL);
+        }
         statSplitWriteRequests->addData(1);
     }
 

--- a/src/sst/elements/ariel/arielcore.h
+++ b/src/sst/elements/ariel/arielcore.h
@@ -82,7 +82,7 @@ class ArielCore {
         void unfence();
         void finishCore();
         void createReadEvent(uint64_t addr, uint32_t size);
-        void createWriteEvent(uint64_t addr, uint32_t size);
+        void createWriteEvent(uint64_t addr, uint32_t size, const uint8_t* payload);
         void createAllocateEvent(uint64_t vAddr, uint64_t length, uint32_t level, uint64_t ip);
         void createMmapEvent(uint32_t fileID, uint64_t vAddr, uint64_t length, uint32_t level, uint64_t instPtr);
         void createNoOpEvent();
@@ -108,7 +108,7 @@ class ArielCore {
         void setOpalLink(Link * opallink);
 
         void commitReadEvent(const uint64_t address, const uint64_t virtAddr, const uint32_t length);
-        void commitWriteEvent(const uint64_t address, const uint64_t virtAddr, const uint32_t length);
+        void commitWriteEvent(const uint64_t address, const uint64_t virtAddr, const uint32_t length, const uint8_t* payload);
         void commitFlushEvent(const uint64_t address, const uint64_t virtAddr, const uint32_t length);
 
         // Setting the max number of instructions to be simulated
@@ -121,6 +121,7 @@ class ArielCore {
         bool processNextEvent();
         bool refillQueue();
         bool opal_enabled;
+        bool writePayloads;
         uint32_t coreID;
         uint32_t maxPendingTransactions;
         Output* output;

--- a/src/sst/elements/ariel/arielcpu.cc
+++ b/src/sst/elements/ariel/arielcpu.cc
@@ -220,7 +220,7 @@ ArielCPU::ArielCPU(ComponentId_t id, Params& params) :
     appLauncher = params.find<std::string>("launcher", PINTOOL_EXECUTABLE);
 
     const uint32_t launch_param_count = (uint32_t) params.find<uint32_t>("launchparamcount", 0);
-    const uint32_t pin_arg_count = 27 + launch_param_count;
+    const uint32_t pin_arg_count = 29 + launch_param_count;
 
     execute_args = (char**) malloc(sizeof(char*) * (pin_arg_count + app_argc));
 
@@ -237,6 +237,13 @@ ArielCPU::ArielCPU(ComponentId_t id, Params& params) :
     execute_args[arg++] = const_cast<char*>("15");
 #endif
     execute_args[arg++] = const_cast<char*>("-follow_execv");
+    execute_args[arg++] = const_cast<char*>("-w");
+
+	if( params.find<int>("writepayloadtrace") == 0 ) {
+    	execute_args[arg++] = const_cast<char*>("0");
+    } else {
+    	execute_args[arg++] = const_cast<char*>("1");
+    }
 
     char* param_name_buffer = (char*) malloc(sizeof(char) * 512);
 

--- a/src/sst/elements/ariel/arielcpu.cc
+++ b/src/sst/elements/ariel/arielcpu.cc
@@ -237,13 +237,6 @@ ArielCPU::ArielCPU(ComponentId_t id, Params& params) :
     execute_args[arg++] = const_cast<char*>("15");
 #endif
     execute_args[arg++] = const_cast<char*>("-follow_execv");
-    execute_args[arg++] = const_cast<char*>("-w");
-
-	if( params.find<int>("writepayloadtrace") == 0 ) {
-    	execute_args[arg++] = const_cast<char*>("0");
-    } else {
-    	execute_args[arg++] = const_cast<char*>("1");
-    }
 
     char* param_name_buffer = (char*) malloc(sizeof(char) * 512);
 
@@ -266,6 +259,14 @@ ArielCPU::ArielCPU(ComponentId_t id, Params& params) :
     execute_args[arg++] = const_cast<char*>("-t");
     execute_args[arg++] = (char*) malloc(sizeof(char) * (ariel_tool.size() + 1));
     strcpy(execute_args[arg-1], ariel_tool.c_str());
+    execute_args[arg++] = const_cast<char*>("-w");
+
+	if( params.find<int>("writepayloadtrace") == 0 ) {
+    	execute_args[arg++] = const_cast<char*>("0");
+    } else {
+    	execute_args[arg++] = const_cast<char*>("1");
+    }
+
     execute_args[arg++] = const_cast<char*>("-p");
     execute_args[arg++] = (char*) malloc(sizeof(char) * (shmem_region_name.length() + 1));
     strcpy(execute_args[arg-1], shmem_region_name.c_str());

--- a/src/sst/elements/ariel/arielcpu.h
+++ b/src/sst/elements/ariel/arielcpu.h
@@ -73,6 +73,7 @@ class ArielCPU : public SST::Component {
         {"clock", "Clock rate at which events are generated and processed", "1GHz"},
         {"tracegen", "Select the trace generator for Ariel (which records traced memory operations", ""},
         {"memmgr", "Memory manager to use for address translation", "ariel.MemoryManagerSimple"},
+        {"writepayloadtrace", "Trace write payloads and put real memory contents into the memory system", "0"},
         {"opal_enabled", "If enabled, MLM allocation hints will be communicated to the centralized memory manager", "0"})
 
     SST_ELI_DOCUMENT_PORTS(

--- a/src/sst/elements/ariel/arielwriteev.h
+++ b/src/sst/elements/ariel/arielwriteev.h
@@ -27,11 +27,18 @@ namespace ArielComponent {
 class ArielWriteEvent : public ArielEvent {
 
     public:
-        ArielWriteEvent(uint64_t wAddr, uint32_t length) :
+        ArielWriteEvent(uint64_t wAddr, uint32_t length, const uint8_t* payloadData) :
                 writeAddress(wAddr), writeLength(length) {
+                
+                payload = new uint8_t[length];
+                
+                for( int i = 0; i < length; ++i ) {
+                	payload[i] = payloadData[i];
+                }
         }
 
         ~ArielWriteEvent() {
+        	delete payload;
         }
 
         ArielEventType getEventType() const {
@@ -45,10 +52,15 @@ class ArielWriteEvent : public ArielEvent {
         uint32_t getLength() const {
                 return writeLength;
         }
+        
+        uint8_t* getPayload() const {
+        		return payload;
+        }
 
     private:
         const uint64_t writeAddress;
         const uint32_t writeLength;
+              uint8_t* payload;
 
 };
 

--- a/src/sst/elements/ariel/frontend/simple/fesimple.cc
+++ b/src/sst/elements/ariel/frontend/simple/fesimple.cc
@@ -82,6 +82,9 @@ KNOB<UINT32> DefaultMemoryPool(KNOB_MODE_WRITEONCE, "pintool",
 
 #define ARIEL_MAX(a,b) \
    ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a > _b ? _a : _b; })
+   
+#define ARIEL_MIN(a,b) \
+   ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
 
 typedef struct {
     int64_t insExecuted;
@@ -361,7 +364,12 @@ VOID WriteInstructionWrite(ADDRINT* address, UINT32 writeSize, THREADID thr, ADD
     ac.inst.simdElemCount = simdOpWidth;
     
     if( writeTrace ) {
-    	PIN_SafeCopy( &ac.inst.payload[0], address, writeSize );
+//    	if( writeSize > ARIEL_MAX_PAYLOAD_SIZE ) {
+//    		fprintf(stderr, "Error: Payload exceeds maximum size (%d > %d)\n",
+//    			writeSize, ARIEL_MAX_PAYLOAD_SIZE);
+//    		exit(-1);
+//    	}
+    	PIN_SafeCopy( &ac.inst.payload[0], address, ARIEL_MIN( writeSize, ARIEL_MAX_PAYLOAD_SIZE ) );
 	}
 	
     tunnel->writeMessage(thr, ac);


### PR DESCRIPTION
Allows optional capture of write values ("application data") for forwarding into the memory system when using Ariel. This is the first commit which actively tracks instructions with clear stores. The application ELF data segment is not loaded so the mapping of some data will still not be correct.