### PR TITLE
updating stake initialization to match upstream riscv-isa-sim

### DIFF
--- a/src/sst/elements/miranda/generators/stake.cc
+++ b/src/sst/elements/miranda/generators/stake.cc
@@ -182,7 +182,7 @@ void Stake::generate(MirandaRequestQueue<GeneratorRequest*>* q) {
         }
 
         spike = new sim_t(isa.c_str(), cores, false, (reg_t)(pc),
-                          mems, htif_args, hartids, 2 );
+                          mems, htif_args, hartids, 2, 0, false );
 
         // setup the pre-runtime parameters
         spike->set_debug(false);


### PR DESCRIPTION
Following the latest merge of the SST "Stake" Spike simulator, we found that the top-level simulation class changed its default constructor.  As a result, we were forced to update the Stake miranda generator in order to support the upstream development version of the riscv-isa-sim (Spike).  This pull request enables users to utilize the latest revision of Spike (thus supporting the latest updates to the SBI).