### PR TITLE
fixing warnings in printing Stake configuration options

### DIFF
--- a/src/sst/elements/miranda/generators/stake.cc
+++ b/src/sst/elements/miranda/generators/stake.cc
@@ -54,14 +54,14 @@ Stake::Stake( Component* owner, Params& params ) :
           out->fatal(CALL_INFO, -1, "Failed to specify the RISC-V binary" );
         }
 
-        out->verbose(CALL_INFO, 1, 0, "RISC-V Cores = %" PRIu32 "\n", cores );
+        out->verbose(CALL_INFO, 1, 0, "RISC-V Cores = %" PRIu64 "\n", cores );
         out->verbose(CALL_INFO, 1, 0, "Starting PC = 0x%" PRIx64 "\n", pc );
         out->verbose(CALL_INFO, 1, 0, "ISA = %s\n", isa.c_str() );
         if( ext.length() > 0 ){
-          out->verbose(CALL_INFO, 1, 0, "RoCC Extension = %s\n", ext );
+          out->verbose(CALL_INFO, 1, 0, "RoCC Extension = %s\n", ext.c_str() );
         }
         if( extlib.length() > 0 ){
-          out->verbose(CALL_INFO, 1, 0, "External Library = %s\n", extlib );
+          out->verbose(CALL_INFO, 1, 0, "External Library = %s\n", extlib.c_str() );
         }
 
         done = false;


### PR DESCRIPTION
Compiling SST-Elements (master or devel) with Stake enabled would throw several warnings regarding the printing of Stake configuration options using the standard SST "out->verbose(...)" method.  This patch fixes those warnings by correctly specifying the incoming data types and/or c_str()-ized versions of C++ strings.  The remaining warnings indicate macro collisions with the Spike simulator source.  These will likely need to be fixed in the Stake riscv-isa-sim source.