### PR TITLE
added (back?) the ability to attach a CachListener to MemSieve

### DIFF
--- a/src/sst/elements/memHierarchy/Sieve/sieveController.cc
+++ b/src/sst/elements/memHierarchy/Sieve/sieveController.cc
@@ -131,7 +131,20 @@ void Sieve::processEvent(SST::Event* ev) {
         cacheArray_->replace(baseAddr, line);
         line->setState(M);
 
-        recordMiss(event->getVirtualAddress(), (cmd == Command::GetS));
+        bool isRead = (cmd == Command::GetS);
+        recordMiss(event->getVirtualAddress(), isRead);
+
+        // notify profiler, if any
+        if (listener_) {
+            CacheListenerNotification notify(event->getBaseAddr(), 
+                                             event->getVirtualAddress(),
+                                             event->getInstructionPointer(), 
+                                             event->getSize(), 
+                                             isRead ? READ : WRITE,
+                                             MISS);
+            listener_->notifyAccess(notify);
+        }
+
     } else {
         if (cmd == Command::GetS) statReadHits->addData(1);
         else statWriteHits->addData(1);

--- a/src/sst/elements/memHierarchy/Sieve/sieveController.h
+++ b/src/sst/elements/memHierarchy/Sieve/sieveController.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 
 #include "sst/elements/memHierarchy/cacheArray.h"
+#include "sst/elements/memHierarchy/cacheListener.h"
 #include "sst/elements/memHierarchy/replacementManager.h"
 #include "sst/elements/memHierarchy/util.h"
 #include "sst/elements/ariel/arielalloctrackev.h"
@@ -116,6 +117,9 @@ private:
     /** Function to find and configure links */
     void configureLinks();
 
+    /** Function to configure profiler, if any */
+    void createProfiler(const Params &params);
+
     /** Handler for incoming link events.  */
     void processEvent(SST::Event* event);
     /** Handler for incoming allocation events.  */
@@ -130,6 +134,7 @@ private:
     vector<SST::Link*>  cpuLinks_;
     uint32_t            cpuLinkCount_;
     vector<SST::Link*>  allocLinks_;
+    CacheListener*      listener_;
 
     /* Statistics */
     Statistic<uint64_t>* statReadHits;

--- a/src/sst/elements/memHierarchy/Sieve/sieveFactory.cc
+++ b/src/sst/elements/memHierarchy/Sieve/sieveFactory.cc
@@ -76,6 +76,9 @@ Sieve::Sieve(ComponentId_t id, Params &params) : Component(id) {
     // optional link for allocation / free tracking
     configureLinks();
 
+    /* Load profiler, if any */
+    createProfiler(params);
+
     /* Register statistics */
     statReadHits    = registerStatistic<uint64_t>("ReadHits");
     statReadMisses  = registerStatistic<uint64_t>("ReadMisses");
@@ -112,4 +115,17 @@ void Sieve::configureLinks() {
     }
 }
 
-    }}
+void Sieve::createProfiler(const Params &params) {
+    string profiler = params.find<std::string>("profiler", "");
+
+    if (profiler.empty()) {
+	listener_ = 0;
+    } else {
+	Params profilerParams = params.find_prefix_params("profiler." );
+        listener_ = dynamic_cast<CacheListener*>(loadSubComponent(profiler, this, profilerParams));        
+    }
+
+}
+
+
+    }} // end namespaces


### PR DESCRIPTION
At some point, the memSieve component could have a cacheListener attached to make a histogram of accesses (a gold output file and vestigial parameters in a test script indicate this). However, this ability seems to have been lost. I added it back in. 