### PR TITLE
Add virtual destructors for custom command info classes

### DIFF
--- a/src/sst/elements/memHierarchy/customcmd/customCmdMemory.h
+++ b/src/sst/elements/memHierarchy/customcmd/customCmdMemory.h
@@ -35,6 +35,8 @@ public:
     
     CustomCmdInfo(SST::Event::id_type id, std::string rqstr, uint32_t flags = 0 ) :
       id_(id), flags_(flags), rqstr_(rqstr) { }
+
+    virtual ~CustomCmdInfo() = default;
     
     /* String-ify info for debug */
     virtual std::string getString() { 

--- a/src/sst/elements/memHierarchy/customcmd/customOpCodeCmd.h
+++ b/src/sst/elements/memHierarchy/customcmd/customOpCodeCmd.h
@@ -36,6 +36,8 @@ public:
     CustomOpCodeCmdInfo(SST::Event::id_type id, std::string rqstr, Addr addr, uint32_t opc, uint32_t flags = 0) :
         CustomCmdInfo(id, rqstr, flags), addr_(addr), custOpc_(opc) { }
 
+    virtual ~CustomOpCodeCmdInfo() = default;
+
     /* String-ify for debug */
     virtual std::string getString() {
         std::ostringstream str;


### PR DESCRIPTION
This was throwing an error in gcc's address sanitizer, because
CustomCmdInfo gets deleted through the base pointer at one point.