### PR TITLE
MemH: Fix for coherent shootdowns

### DIFF
--- a/src/sst/elements/memHierarchy/cacheController.h
+++ b/src/sst/elements/memHierarchy/cacheController.h
@@ -379,6 +379,7 @@ private:
     bool                    isLL;
     bool                    lowerIsNoninclusive;
     bool                    expectWritebackAcks;
+    bool                    silentEvict;
 
     /* Performance enhancement: turn clocks off when idle */
     bool                    clockIsOn_;                 // Tell us whether clock is on or off

--- a/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
+++ b/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
@@ -389,8 +389,8 @@ void CoherenceController::recordEvictionState(State state) {
 
 
 /* Setup variables controlling interactions with other memory levels */
-void CoherenceController::setupLowerStatus(bool isLastCoherenceLevel, bool expectWritebackAck, bool lowerIsNoninclusive) {
-    silentEvictClean_ = isLastCoherenceLevel; // Level below us doesn't do coherence so just drop clean blocks
+void CoherenceController::setupLowerStatus(bool silentEvict, bool isLastCoherenceLevel, bool expectWritebackAck, bool lowerIsNoninclusive) {
+    silentEvictClean_ = silentEvict; // Level below us doesn't track block presence so just drop clean blocks
     lastLevel_ = isLastCoherenceLevel;
     expectWritebackAck_ = expectWritebackAck; // Level below us will send writeback acks so wait for it
     writebackCleanBlocks_ = lowerIsNoninclusive; // Attach a payload to clean writebacks if the lower level might not have data

--- a/src/sst/elements/memHierarchy/coherencemgr/coherenceController.h
+++ b/src/sst/elements/memHierarchy/coherencemgr/coherenceController.h
@@ -110,7 +110,7 @@ public:
     /***** Setup and initialization functions *****/
 
     /* Initialize variables that tell this coherence controller how to interact with the cache below it */
-    void setupLowerStatus(bool isLastLevel, bool isNoninclusive, bool isDir);
+    void setupLowerStatus(bool silentEvict, bool isLastLevel, bool isNoninclusive, bool isDir);
 
     /* Setup pointers to other subcomponents/cache structures */
     void setCacheListener(CacheListener* ptr) { listener_ = ptr; }

--- a/src/sst/elements/memHierarchy/coherentMemoryController.cc
+++ b/src/sst/elements/memHierarchy/coherentMemoryController.cc
@@ -51,6 +51,24 @@ CoherentMemController::CoherentMemController(ComponentId_t id, Params &params) :
     timestamp_ = 0;
 }
 
+/**
+ * Init
+ */
+void CoherentMemController::init(unsigned int phase) {
+    link_->init(phase);
+    
+    region_ = link_->getRegion(); // This can change during init, but should stabilize before we start receiving init data
+    
+    /* Inherit region from our source(s) */
+    if (!phase) {
+        /* Announce our presence on link */
+        link_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Memory, true, false, memBackendConvertor_->getRequestWidth(), true));
+    }
+
+    while (MemEventInit *ev = link_->recvInitData()) {
+        processInitEvent(ev);
+    }
+}
 
 /*
  * After init we know line size so initialize cacheStatus_

--- a/src/sst/elements/memHierarchy/coherentMemoryController.h
+++ b/src/sst/elements/memHierarchy/coherentMemoryController.h
@@ -54,10 +54,13 @@ public:
 
     /* Event handling */
     void handleMemResponse(SST::Event::id_type id, uint32_t flags);
+    
+    /* Component API */
+    virtual void init(unsigned int phase);
+    virtual void setup();
 
 protected:
     virtual void processInitEvent(MemEventInit* ev);
-    virtual void setup();
     
     virtual void handleEvent(SST::Event * event);
 

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -1912,10 +1912,10 @@ void DirectoryController::init(unsigned int phase) {
         }
         // Tell memory we're here
         if (memLink) {
-            memLink->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Directory, true, true, cacheLineSize));
+            memLink->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Directory, true, true, cacheLineSize, true));
         }
         // Announce to network we're here
-        network->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Directory, true, true, cacheLineSize));
+        network->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Directory, true, true, cacheLineSize, true));
     }
 
     /* Pass data on to memory */

--- a/src/sst/elements/memHierarchy/memEventBase.h
+++ b/src/sst/elements/memHierarchy/memEventBase.h
@@ -307,13 +307,14 @@ class MemEventInitCoherence : public MemEventInit  {
 public:
     
     /* Init events for coordintating coherence policies */
-    MemEventInitCoherence(std::string src, Endpoint type, bool inclusive, bool WBAck, Addr lineSize) : 
-        MemEventInit(src, InitCommand::Coherence), type_(type), inclusive_(inclusive), needWBAck_(WBAck), lineSize_(lineSize) { }
+    MemEventInitCoherence(std::string src, Endpoint type, bool inclusive, bool WBAck, Addr lineSize, bool tracksPresence) : 
+        MemEventInit(src, InitCommand::Coherence), type_(type), inclusive_(inclusive), needWBAck_(WBAck), lineSize_(lineSize), tracksPresence_(tracksPresence) { }
 
     Endpoint getType() { return type_; }
     bool getInclusive() { return inclusive_; }
     bool getWBAck() { return needWBAck_; }
     Addr getLineSize() { return lineSize_; }
+    bool getTracksPresence() { return tracksPresence_; }
 
     virtual MemEventInitCoherence* clone(void) override {
         return new MemEventInitCoherence(*this);
@@ -322,7 +323,7 @@ public:
     virtual std::string getVerboseString() override {
         std::ostringstream str;
         str << " Type: " << (int) type_ << " Inclusive: " << (inclusive_ ? "true" : "false");
-        str << " LineSize: " << lineSize_;
+        str << " LineSize: " << lineSize_ << " Tracks presence: " << (tracksPresence_ ? "true" : "false");
         return MemEventInit::getVerboseString() + str.str();
     }
 
@@ -331,6 +332,7 @@ private:
     bool inclusive_;    // Whether endpoint is inclusive
     bool needWBAck_;    // Whether endpoint expects writeback acks
     Addr lineSize_;     // Endpoint's linesize
+    bool tracksPresence_;     // Endpoint manages or tracks coherence
 
     MemEventInitCoherence() {} // For serialization only
 
@@ -341,6 +343,7 @@ public:
         ser & inclusive_;
         ser & needWBAck_;
         ser & lineSize_;
+        ser & tracksPresence_;
     }
     
     ImplementSerializable(SST::MemHierarchy::MemEventInitCoherence);

--- a/src/sst/elements/memHierarchy/memHierarchyInterface.cc
+++ b/src/sst/elements/memHierarchy/memHierarchyInterface.cc
@@ -46,7 +46,7 @@ void MemHierarchyInterface::init(unsigned int phase) {
         region.interleaveSize = 0;
         link_->sendInitData(new MemEventInitRegion(parent->getName(), region, false));
 
-        MemEventInitCoherence * event = new MemEventInitCoherence(parent->getName(), Endpoint::CPU, false, false, 0);
+        MemEventInitCoherence * event = new MemEventInitCoherence(parent->getName(), Endpoint::CPU, false, false, 0, false);
         link_->sendInitData(event);
 
     }

--- a/src/sst/elements/memHierarchy/memHierarchyScratchInterface.cc
+++ b/src/sst/elements/memHierarchy/memHierarchyScratchInterface.cc
@@ -47,7 +47,7 @@ MemHierarchyScratchInterface::MemHierarchyScratchInterface(SST::Component *comp,
 void MemHierarchyScratchInterface::init(unsigned int phase) {
     if (!phase) {
         // Name, NULLCMD, Endpoint type, inclusive of all upper levels, will send writeback acks, line size
-        link_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::CPU, false, false, 0));
+        link_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::CPU, false, false, 0, false));
     }
 
     while (SST::Event * ev = link_->recvInitData()) {

--- a/src/sst/elements/memHierarchy/memoryController.cc
+++ b/src/sst/elements/memHierarchy/memoryController.cc
@@ -425,7 +425,7 @@ void MemController::init(unsigned int phase) {
     /* Inherit region from our source(s) */
     if (!phase) {
         /* Announce our presence on link */
-        link_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Memory, true, false, memBackendConvertor_->getRequestWidth()));
+        link_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Memory, true, false, memBackendConvertor_->getRequestWidth(), false));
     }
 
     while (MemEventInit *ev = link_->recvInitData()) {

--- a/src/sst/elements/memHierarchy/scratchpad.cc
+++ b/src/sst/elements/memHierarchy/scratchpad.cc
@@ -269,8 +269,8 @@ void Scratchpad::init(unsigned int phase) {
 
     // Send initial info out
     if (!phase) {
-        linkDown_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Scratchpad, true, true, scratchLineSize_));
-        if (linkUp_ != linkDown_) linkUp_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Scratchpad, true, true, scratchLineSize_));
+        linkDown_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Scratchpad, true, true, scratchLineSize_, true));
+        if (linkUp_ != linkDown_) linkUp_->sendInitData(new MemEventInitCoherence(getName(), Endpoint::Scratchpad, true, true, scratchLineSize_, true));
     }
 
     // Handle incoming events

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
@@ -145,7 +145,7 @@
  l1cache.eventSent_FlushLineResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.stateEvent_AckPut_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.eventSent_PutS : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.eventSent_PutE : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
+ l1cache.eventSent_PutE : Accumulator : Sum.u64 = 2470; SumSQ.u64 = 2470; Count.u64 = 2470; Min.u64 = 1; Max.u64 = 1; 
  l1cache.prefetch_evict : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.prefetch_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.prefetch_useful : Accumulator : Sum.u64 = 1953; SumSQ.u64 = 1953; Count.u64 = 1953; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
@@ -145,7 +145,7 @@
  l1cache.eventSent_FlushLineResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.stateEvent_AckPut_I : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.eventSent_PutS : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.eventSent_PutE : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
+ l1cache.eventSent_PutE : Accumulator : Sum.u64 = 2470; SumSQ.u64 = 2470; Count.u64 = 2470; Min.u64 = 1; Max.u64 = 1; 
  l1cache.prefetch_evict : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.prefetch_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.prefetch_useful : Accumulator : Sum.u64 = 1953; SumSQ.u64 = 1953; Count.u64 = 1953; Min.u64 = 1; Max.u64 = 1; 


### PR DESCRIPTION
Update to turn off silent evictions for coherent memory controllers
Also enable setting the mshr_latency parameter for L1s