### PR TITLE
Target get fix for uniform distribution 

### DIFF
--- a/src/sst/elements/merlin/target_generator/uniform.h
+++ b/src/sst/elements/merlin/target_generator/uniform.h
@@ -67,7 +67,7 @@ public:
     }
     
     void initialize(int id, int num_peers) {
-        gen = new MersenneRNG(13);
+        gen = new MersenneRNG(id);
 
         if ( min == -1 ) min = 0;
         if ( max == -1 ) max = num_peers;


### PR DESCRIPTION
Fixed a typo in uniform target generator model that initialized the random number generator of all endpoints to the same value.
