### PR TITLE
fix nonblocking SHMEM get

### DIFF
--- a/src/sst/elements/ember/shmem/motifs/emberShmemGetNBI.h
+++ b/src/sst/elements/ember/shmem/motifs/emberShmemGetNBI.h
@@ -94,7 +94,9 @@ public:
             ret = true;
             if ( m_my_pe != 0 ) {
 				double time = m_stopTime-m_startTime;
-                printf("%d:%s: count=%d, %.3lf ns \n",m_my_pe, getMotifName().c_str(), m_count,time/(double)m_count);
+				size_t bytes = m_count * m_nelems * sizeof(TYPE);
+                printf("%d:%s: count=%d, %.3lf ns, %zu bytes, %.3lf GB/s \n",m_my_pe, getMotifName().c_str(), 
+						m_count,time/(double)m_count, bytes, (double) bytes/ time );
             }
         }
         ++m_phase;

--- a/src/sst/elements/firefly/nicShmem.cc
+++ b/src/sst/elements/firefly/nicShmem.cc
@@ -352,6 +352,7 @@ void Nic::Shmem::get( NicShmemGetCmdEvent* event, int id )
                 if ( event->isBlocking() ) {
                     m_nic.getVirtNic(id)->notifyShmem( getNic2HostDelay_ns(), callback );
                 } else {
+                    m_nic.shmemDecPending( id );
                     incFreeCmdSlots();
                 }
             } 

--- a/src/sst/elements/firefly/nicShmemStream.cc
+++ b/src/sst/elements/firefly/nicShmemStream.cc
@@ -134,10 +134,6 @@ void Nic::RecvMachine::ShmemStream::processGetResp( ShmemMsgHdr& hdr, FireflyNet
 
         Hermes::MemAddr memAddr = m_ctx->findShmem( local_pid, addr, hdr.length ); 
 
-        if ( ! static_cast<NicShmemGetCmdEvent*>(entry->getCmd())->isBlocking() ) {
-	        m_ctx->nic().shmemDecPending( local_pid );
-        }
-
         m_recvEntry = new ShmemGetbRespRecvEntry( m_ctx->getShmem(), local_pid, hdr.length, static_cast<ShmemGetbSendEntry*>(entry), 
                 memAddr.getBacking() );
     }


### PR DESCRIPTION
For the case of a non-blocking get the outstanding operation count was getting decremented before the get response was completely received.