### PR TITLE
Allevin/clean opal warnings

### DIFF
--- a/src/sst/elements/Opal/Opal.cc
+++ b/src/sst/elements/Opal/Opal.cc
@@ -435,7 +435,7 @@ REQRESPONSE Opal::allocateFromReservedMemory(int node, uint64_t reserved_vAddres
 	}
 	else
 	{
-		output->fatal(CALL_INFO, -1, "Opal: address :%lld requested with fileId:%d has no space left\n", vAddress, fileID);
+		output->fatal(CALL_INFO, -1, "Opal: address :%lu requested with fileId:%d has no space left\n", vAddress, fileID);
 	}
 
 	return response;
@@ -519,7 +519,7 @@ void Opal::migratePages(int node, int coreId, int pages)
 	std::list<std::pair<uint64_t, std::pair<uint64_t, int> > > lm_pages = nodeInfo[node]->getPagesToMigrate(pages);
 
 	// get shared memory pages
-	int sharedMemPoolId;
+	int sharedMemPoolId = 0;
 	std::list<uint64_t> sm_pages;
 	for(uint32_t i = 0; i<num_shared_mempools; i++) {
 
@@ -556,7 +556,7 @@ void Opal::migratePages(int node, int coreId, int pages)
 
 
 	// error checking
-	if( (uint32_t)lm_pages.size() != pages && (uint32_t)sm_pages.size() != pages)
+	if( (uint32_t)lm_pages.size() != (uint32_t)pages && (uint32_t)sm_pages.size() != (uint32_t)pages)
 		output->fatal(CALL_INFO, -1, "Opal: This should not happen\n");
 
 	// swap

--- a/src/sst/elements/Opal/Opal.cc
+++ b/src/sst/elements/Opal/Opal.cc
@@ -435,7 +435,7 @@ REQRESPONSE Opal::allocateFromReservedMemory(int node, uint64_t reserved_vAddres
 	}
 	else
 	{
-		output->fatal(CALL_INFO, -1, "Opal: address :%lu requested with fileId:%d has no space left\n", vAddress, fileID);
+		output->fatal(CALL_INFO, -1, "Opal: address :%" PRIu64 "llu requested with fileId:%d has no space left\n", vAddress, fileID);
 	}
 
 	return response;

--- a/src/sst/elements/Opal/Opal.cc
+++ b/src/sst/elements/Opal/Opal.cc
@@ -356,7 +356,7 @@ REQRESPONSE Opal::allocateLocalMemory(int node, int coreId, uint64_t vAddress, i
 	else {
 		OPAL_VERBOSE(8, output->verbose(CALL_INFO, 8, 0, "Node%" PRIu32 " Local Memory is drained out\n", node));
 
-		if(nodeInfo[node]->page_migration && !nodeInfo[node]->memoryAllocationPolicy || 4 == fault_level) {
+		if((nodeInfo[node]->page_migration && !nodeInfo[node]->memoryAllocationPolicy) || 4 == fault_level) {
 			if(4 == fault_level)
 				std::cerr << getName().c_str() << " migrating a page to allocate memory for node " << node << " core " << coreId << " CR3" << std::endl;
 

--- a/src/sst/elements/Opal/Opal_Event.h
+++ b/src/sst/elements/Opal/Opal_Event.h
@@ -107,7 +107,7 @@ namespace SST{ namespace OpalComponent{
 			void setHint(int x) { hint = x; }
 			int getHint() { return hint; }
 
-			void serialize_order(SST::Core::Serialization::serializer &ser) {
+			void serialize_order(SST::Core::Serialization::serializer &ser) override{
 				Event::serialize_order(ser);
 				ser & ev;
 				ser & address;


### PR DESCRIPTION
Clean up warnings in Opal that show up in XCode 10, gcc 4.8 and 5.3