### PR TITLE
Remove std::cout in dragonfly-machine allocators

### DIFF
--- a/src/sst/elements/scheduler/allocators/DflyHybridAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyHybridAllocator.cc
@@ -62,7 +62,7 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
         //This set keeps track of allocated nodes in the current allocation.
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
-        std::cout << "jobSize=" << jobSize << ", ";
+        //std::cout << "jobSize=" << jobSize << ", ";
         if (jobSize <= dMach.nodesPerRouter) {
             //find the router with the most free nodes.
             int BestRouter = -1;
@@ -90,7 +90,7 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                     if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                         ai->nodeIndices[i] = nodeID;
                         occupiedNodes.insert(nodeID);
-                        std::cout << nodeID << " ";
+                        //std::cout << nodeID << " ";
                         ++i;
                         ++nodeID;
                     }
@@ -98,8 +98,8 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                         ++nodeID;
                     }
                 }
-                std::cout << ",inRouter";
-                std::cout << endl;
+                //std::cout << ",inRouter";
+                //std::cout << endl;
                 return ai;
             }
         }
@@ -132,7 +132,7 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                         if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                             ai->nodeIndices[i] = nodeID;
                             occupiedNodes.insert(nodeID);
-                            std::cout << nodeID << " ";
+                            //std::cout << nodeID << " ";
                             //change router.
                             if (routerID < (BestGroup + 1) * dMach.routersPerGroup - 1) {
                                 ++routerID;
@@ -162,8 +162,8 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                         }
                     }
                 }
-                std::cout << ",inGroup";
-                std::cout << endl;
+                //std::cout << ",inGroup";
+                //std::cout << endl;
                 return ai;
             }
         }
@@ -177,7 +177,7 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                 if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                     ai->nodeIndices[i] = nodeID;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                     //change group.
                     if (groupID < dMach.numGroups - 1) {
                         ++groupID;
@@ -206,8 +206,8 @@ AllocInfo* DflyHybridAllocator::allocate(Job* j)
                 }
             }
         }
-        std::cout << ",spread";
-        std::cout << endl;
+        //std::cout << ",spread";
+        //std::cout << endl;
         return ai;
     }
     return NULL;

--- a/src/sst/elements/scheduler/allocators/DflyJokanovicAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyJokanovicAllocator.cc
@@ -46,7 +46,7 @@ AllocInfo* DflyJokanovicAllocator::allocate(Job* j)
         //This set keeps track of allocated nodes in the current allocation.
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
-        std::cout << "jobSize=" << jobSize << ", ";
+        //std::cout << "jobSize=" << jobSize << ", ";
         int nodesPerGroup = dMach.routersPerGroup * dMach.nodesPerRouter;
         if (jobSize <= nodesPerGroup) {
             //start from the leftmost group, find a group with enough idle nodes. If there isn't one, just put it simply from the leftmost place.
@@ -71,12 +71,12 @@ AllocInfo* DflyJokanovicAllocator::allocate(Job* j)
                         if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                             ai->nodeIndices[i] = nodeID;
                             occupiedNodes.insert(nodeID);
-                            std::cout << nodeID << " ";
+                            //std::cout << nodeID << " ";
                             ++i;
                             if (i == jobSize) {
                                 finish = true;
-                                std::cout << ",grouped";
-                                std::cout << endl;
+                                //std::cout << ",grouped";
+                                //std::cout << endl;
                                 break;
                             }
                         }
@@ -95,11 +95,11 @@ AllocInfo* DflyJokanovicAllocator::allocate(Job* j)
                 if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                     ai->nodeIndices[i] = nodeID;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                     ++i;
                     if (i == jobSize) {
-                        std::cout << ",simple from left";
-                        std::cout << endl;
+                        //std::cout << ",simple from left";
+                        //std::cout << endl;
                         break;
                     }
                 }
@@ -116,11 +116,11 @@ AllocInfo* DflyJokanovicAllocator::allocate(Job* j)
                 if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                     ai->nodeIndices[i] = nodeID;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                     ++i;
                     if (i == jobSize) {
-                        std::cout << ",simple from right";
-                        std::cout << endl;
+                        //std::cout << ",simple from right";
+                        //std::cout << endl;
                         break;
                     }
                 }

--- a/src/sst/elements/scheduler/allocators/DflyRDGAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyRDGAllocator.cc
@@ -53,7 +53,7 @@ AllocInfo* DflyRDGAllocator::allocate(Job* j)
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
         const int nodesPerGroup = dMach.nodesPerRouter * dMach.routersPerGroup;
-        std::cout << "jobSize = " << jobSize << ", allocation, ";
+        //std::cout << "jobSize = " << jobSize << ", allocation, ";
         int i = 0;
         while (i < jobSize) {
             //randomly choose a group.
@@ -65,7 +65,7 @@ AllocInfo* DflyRDGAllocator::allocate(Job* j)
                     ai->nodeIndices[i] = nodeID;
                     ++i;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                 }
                 else {
                     continue;
@@ -75,7 +75,7 @@ AllocInfo* DflyRDGAllocator::allocate(Job* j)
                 }
             }
         }
-        std::cout << endl;
+        //std::cout << endl;
         return ai;
     }
     return NULL;

--- a/src/sst/elements/scheduler/allocators/DflyRDRAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyRDRAllocator.cc
@@ -53,7 +53,7 @@ AllocInfo* DflyRDRAllocator::allocate(Job* j)
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
         const int routerNum = dMach.routersPerGroup * dMach.numGroups;
-        std::cout << "jobSize = " << jobSize << ", allocation, ";
+        //std::cout << "jobSize = " << jobSize << ", allocation, ";
         int i = 0;
         while (i < jobSize) {
             //randomly choose a router.
@@ -65,7 +65,7 @@ AllocInfo* DflyRDRAllocator::allocate(Job* j)
                     ai->nodeIndices[i] = nodeID;
                     ++i;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                 }
                 else {
                     continue;
@@ -75,7 +75,7 @@ AllocInfo* DflyRDRAllocator::allocate(Job* j)
                 }
             }
         }
-        std::cout << endl;
+        //std::cout << endl;
         return ai;
     }
     return NULL;

--- a/src/sst/elements/scheduler/allocators/DflyRRNAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyRRNAllocator.cc
@@ -50,7 +50,7 @@ AllocInfo* DflyRRNAllocator::allocate(Job* j)
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
         const int nodesPerGroup = dMach.routersPerGroup * dMach.nodesPerRouter;
-        std::cout << "jobSize = " << jobSize << ", allocation, ";
+        //std::cout << "jobSize = " << jobSize << ", allocation, ";
         int groupID = 0;
         for (int i = 0; i < jobSize; i++) {
             int localNodeID = 0;
@@ -59,7 +59,7 @@ AllocInfo* DflyRRNAllocator::allocate(Job* j)
                 if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                     ai->nodeIndices[i] = nodeID;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                     //change group.
                     if (groupID < dMach.numGroups - 1) {
                         ++groupID;
@@ -88,7 +88,7 @@ AllocInfo* DflyRRNAllocator::allocate(Job* j)
                 }
             }
         }
-        std::cout << endl;
+        //std::cout << endl;
         return ai;
     }
     return NULL;

--- a/src/sst/elements/scheduler/allocators/DflyRRRAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflyRRRAllocator.cc
@@ -50,7 +50,7 @@ AllocInfo* DflyRRRAllocator::allocate(Job* j)
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
         const int nodesPerGroup = dMach.nodesPerRouter * dMach.routersPerGroup;
-        std::cout << "jobSize = " << jobSize << ", allocation, ";
+        //std::cout << "jobSize = " << jobSize << ", allocation, ";
         int groupID = 0;
         int i = 0;
         while (i < jobSize) {
@@ -86,7 +86,7 @@ AllocInfo* DflyRRRAllocator::allocate(Job* j)
                 if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                     ai->nodeIndices[i] = nodeID;
                     occupiedNodes.insert(nodeID);
-                    std::cout << nodeID << " ";
+                    //std::cout << nodeID << " ";
                     ++i;
                     if (i == jobSize) {
                         break;
@@ -101,7 +101,7 @@ AllocInfo* DflyRRRAllocator::allocate(Job* j)
                 groupID = 0;
             }
         }
-        std::cout << endl;
+        //std::cout << endl;
         return ai;
     }
     return NULL;

--- a/src/sst/elements/scheduler/allocators/DflySlurmAllocator.cc
+++ b/src/sst/elements/scheduler/allocators/DflySlurmAllocator.cc
@@ -52,7 +52,7 @@ AllocInfo* DflySlurmAllocator::allocate(Job* j)
         //This set keeps track of allocated nodes in the current allocation.
         std::set<int> occupiedNodes;
         const int jobSize = ai->getNodesNeeded();
-        std::cout << "jobSize = " << jobSize << ", allocation, ";
+        //std::cout << "jobSize = " << jobSize << ", allocation, ";
         int BestRouter = -1;
         // possible to fit in one router.
         if (jobSize <= dMach.nodesPerRouter) {
@@ -82,7 +82,7 @@ AllocInfo* DflySlurmAllocator::allocate(Job* j)
                     if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                         ai->nodeIndices[i] = nodeID;
                         occupiedNodes.insert(nodeID);
-                        std::cout << nodeID << " ";
+                        //std::cout << nodeID << " ";
                         ++i;
                         ++nodeID;
                     }
@@ -90,7 +90,7 @@ AllocInfo* DflySlurmAllocator::allocate(Job* j)
                         ++nodeID;
                     }
                 }
-                std::cout << endl;
+                //std::cout << endl;
                 return ai;
             }
         }
@@ -122,7 +122,7 @@ AllocInfo* DflySlurmAllocator::allocate(Job* j)
                     if ( dMach.isFree(nodeID) && occupiedNodes.find(nodeID) == occupiedNodes.end() ) {
                         ai->nodeIndices[i] = nodeID;
                         occupiedNodes.insert(nodeID);
-                        std::cout << nodeID << " ";
+                        //std::cout << nodeID << " ";
                         ++i;
                         if (i == jobSize) {
                             break;
@@ -139,7 +139,7 @@ AllocInfo* DflySlurmAllocator::allocate(Job* j)
                     }
                 }
             }
-            std::cout << endl;
+            //std::cout << endl;
             return ai;
         }
     }


### PR DESCRIPTION
I contributed my dragonfly-machine allocators a month ago.
Now I remove those unnecessary outputs calling std::cout, because they are not recommended to use.