### PR TITLE
Allow memH to Select Link Control to Load

### DIFF
--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -205,7 +205,9 @@ MemNIC::MemNIC(Component * parent, Params &params) : MemNICBase(parent, params) 
     std::string linkInbufSize = params.find<std::string>("network_input_buffer_size", "1KiB");
     std::string linkOutbufSize = params.find<std::string>("network_output_buffer_size", "1KiB");
 
-    link_control = (SimpleNetwork*)parent->loadSubComponent("merlin.linkcontrol", parent, params); // But link control doesn't use params so manually initialize
+    std::string link_control_class = params.find<std::string>("network_link_control", "merlin.linkcontrol");
+
+    link_control = (SimpleNetwork*)parent->loadSubComponent(link_control_class, parent, params); // But link control doesn't use params so manually initialize
     link_control->initialize(linkName, UnitAlgebra(linkBandwidth), num_vcs, UnitAlgebra(linkInbufSize), UnitAlgebra(linkOutbufSize));
 
     // Packet size

--- a/src/sst/elements/memHierarchy/memNIC.h
+++ b/src/sst/elements/memHierarchy/memNIC.h
@@ -157,6 +157,7 @@ class MemNIC : public MemNICBase {
 public:
 /* Element Library Info */
 #define MEMNIC_ELI_PARAMS MEMNICBASE_ELI_PARAMS, \
+        { "network_link_control",        "(string) Link control for network", "merlin.linkcontrol" },\
         { "network_bw",                  "(string) Network bandwidth", "80GiB/s" },\
         { "network_input_buffer_size",   "(string) Size of input buffer", "1KiB"},\
         { "network_output_buffer_size",  "(string) Size of output buffer", "1KiB"},\


### PR DESCRIPTION
Allows memH to query for network link controls so we can load non-merlin-based networks.