### PR TITLE
Add a Params Processing Simple Example to test Core Parameter Handling

### DIFF
--- a/src/sst/elements/simpleElementExample/simpleParamComponent.cc
+++ b/src/sst/elements/simpleElementExample/simpleParamComponent.cc
@@ -1,0 +1,65 @@
+// Copyright 2009-2018 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2018, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+//#include <assert.h>
+
+#include "sst_config.h"
+#include "simpleParamComponent.h"
+
+namespace SST {
+namespace SimpleParamComponent {
+
+simpleParamComponent::simpleParamComponent(ComponentId_t id, Params& params) :
+  Component(id) 
+{
+	int32_t i32v = params.find<int32_t>("int32t-param");
+	printf("int32_t      value=%" PRId32 "\n", i32v);
+
+	uint32_t u32v = params.find<uint32_t>("uint32t-param");
+	printf("uint32_t     value=%" PRIu32 "\n", u32v);
+
+	int64_t i64v = params.find<int64_t>("int64t-param");
+	printf("int64_t      value=%" PRId64 "\n", i64v);
+
+	uint64_t u64v = params.find<uint64_t>("uint64t-param");
+	printf("uint64_t     value=%" PRIu64 "\n", u64v);
+
+	bool btruev = params.find<bool>("bool-true-param");
+	printf("bool-true    value=%s\n", (btruev ? "true" : "false"));
+
+	bool bfalsev = params.find<bool>("bool-false-param");
+	printf("bool-false    value=%s\n", (bfalsev ? "true" : "false"));
+
+	float f32v = params.find<float>("float-param");
+	printf("float         value=%f\n", f32v);
+
+	double f64v = params.find<double>("double-param");
+	printf("double        value=%f\n", f64v);
+
+	std::string strv = params.find<std::string>("string-param");
+	printf("string        value=\"%s\"\n", strv.c_str());
+
+}
+
+simpleParamComponent::simpleParamComponent() :
+    Component(-1)
+{
+
+}
+
+} // namespace simpleParamComponent
+} // namespace SST
+
+

--- a/src/sst/elements/simpleElementExample/simpleParamComponent.h
+++ b/src/sst/elements/simpleElementExample/simpleParamComponent.h
@@ -1,0 +1,70 @@
+// Copyright 2009-2018 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+// 
+// Copyright (c) 2009-2018, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _SIMPLE_PARAM_COMPONENT_H
+#define _SIMPLE_PARAM_COMPONENT_H
+
+#include <sst/core/component.h>
+#include <sst/core/elementinfo.h>
+
+namespace SST {
+namespace SimpleParamComponent {
+
+class simpleParamComponent : public SST::Component 
+{
+public:
+
+    // REGISTER THIS COMPONENT INTO THE ELEMENT LIBRARY
+    SST_ELI_REGISTER_COMPONENT(
+        simpleParamComponent,
+        "simpleElementExample",
+        "simpleParamComponent",
+        SST_ELI_ELEMENT_VERSION(1,0,0),
+        "Param Check Component",
+        COMPONENT_CATEGORY_UNCATEGORIZED
+    )
+    
+    SST_ELI_DOCUMENT_PARAMS(
+ 	{ "int-param",  "Check for integer values", "-1" },
+	{ "str-param",  "Check for string values",  "test" },
+	{ "bool-param", "Check for bool values", "true" }
+    )
+
+    // Optional since there is nothing to document
+    SST_ELI_DOCUMENT_STATISTICS(
+    )
+
+    // Optional since there is nothing to document
+    SST_ELI_DOCUMENT_PORTS(
+    )
+    
+    // Optional since there is nothing to document
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+    )
+
+    simpleParamComponent(SST::ComponentId_t id, SST::Params& params);
+    void setup()  { }
+    void finish() { }
+
+private:
+    simpleParamComponent();  // for serialization only
+    simpleParamComponent(const simpleParamComponent&); // do not implement
+    void operator=(const simpleParamComponent&); // do not implement
+};
+
+} // namespace simpleParamComponent
+} // namespace SST
+
+#endif /* simpleParamComponent */

--- a/src/sst/elements/simpleElementExample/tests/test_simpleParamComponent.py
+++ b/src/sst/elements/simpleElementExample/tests/test_simpleParamComponent.py
@@ -1,0 +1,48 @@
+# Automatically generated SST Python input
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1 ps")
+sst.setProgramOption("stopAtCycle", "25us")
+
+# Define the simulation components
+param_c0 = sst.Component("c0.0", "simpleElementExample.simpleParamComponent")
+param_c0.addParams({
+	"int32t-param" : 32332,
+	"uint32t-param" : 4242424,
+	"int64-param" : 9223372036854775807,
+	"uint64t-param" : 18446744073709551615,
+	"bool-true-param" : True,
+	"bool-false-param" : False,
+	"float-param" : 1.0101,
+	"double-param" : 1.3333e-10,
+	"string-param" : "teststring123"
+})
+
+# Define the simulation components
+param_c1 = sst.Component("c1.0", "simpleElementExample.simpleParamComponent")
+param_c1.addParams({
+	"int32t-param" : -32332,
+	"uint32t-param" : 4242424,
+	"int64-param" : -9223372036854775808,
+	"uint64t-param" : 18446744073709551615,
+	"bool-true-param" : "true",
+	"bool-false-param" : "false",
+	"float-param" : 1.00000000e-15,
+	"double-param" : 1.3333e-52,
+	"string-param" : "teststring123"
+})
+
+# Define the simulation components
+param_c2 = sst.Component("c2.0", "simpleElementExample.simpleParamComponent")
+param_c2.addParams({
+	"int32t-param" : -32332,
+	"uint32t-param" : 4242424,
+	"int64-param" : -9223372036854775808,
+	"uint64t-param" : 18446744073709551615,
+	"bool-true-param" : 1,
+	"bool-false-param" : 0,
+	"float-param" : -1.0000e-15,
+	"double-param" : -1.33e-18,
+	"string-param" : "teststring123"
+})


### PR DESCRIPTION
Adds a component to test core parameter passing/handling. This has been raised as a potential bug in SST core.
