### PR TITLE
Bug Fix for Issue 1253

### DIFF
--- a/src/sst/elements/shogun/arb/shogunarb.h
+++ b/src/sst/elements/shogun/arb/shogunarb.h
@@ -20,7 +20,7 @@ namespace Shogun {
     virtual void moveEvents(const int num_events,
                             const int port_count,
                             ShogunQueue<ShogunEvent*>** inputQueues,
-                            uint32_t output_slots,
+                            int32_t output_slots,
                             ShogunEvent*** outputEvents,
                             uint64_t cycle )
                             = 0;

--- a/src/sst/elements/shogun/arb/shogunrrarb.h
+++ b/src/sst/elements/shogun/arb/shogunrrarb.h
@@ -17,7 +17,7 @@ namespace Shogun {
         void moveEvents(const int num_events,
                         const int port_count,
                         ShogunQueue<ShogunEvent*>** inputQueues,
-                        uint32_t output_slots,
+                        int32_t output_slots,
                         ShogunEvent*** outputEvents,
                         uint64_t cycle ) override;
 

--- a/src/sst/elements/shogun/shogun.h
+++ b/src/sst/elements/shogun/shogun.h
@@ -47,8 +47,8 @@ public:
         { "arbitration",            "Select the arbitration scheme", "roundrobin" },
         { "clock",                  "Clock Frequency for the crossbar", "1.0GHz" },
         { "queue_slots",            "Depth of input queue", "64" },
-        { "input_message_slots",    "Number of messages injested per cycle", "1" },
-        { "output_message_slots",   "Number of messages ejected per cycle", "1" },
+        { "input_message_slots",    "Number of messages injested per cycle; -1 is unlimited", "1" },
+        { "output_message_slots",   "Number of messages ejected per cycle; -1 is unlimited", "1" },
     )
 
     SST_ELI_DOCUMENT_STATISTICS(
@@ -95,9 +95,8 @@ private:
     int32_t queue_slots;
     int32_t pending_events;
 
-    uint32_t events_per_clock;
-    uint32_t input_message_slots;
-    uint32_t output_message_slots;
+    int32_t  input_message_slots;
+    int32_t  output_message_slots;
 
     ShogunStatisticsBundle* stats;
     SST::Link** links;


### PR DESCRIPTION
This fixes the bug described in issue https://github.com/sstsimulator/sst-elements/issues/1253. Overwrites the num_events variable with input_message_slots and uses this to limit the number of messages retrieved from inputQueues[] each arbitration cycle.
