### PR TITLE
Updated SingleXStream

### DIFF
--- a/src/sst/elements/miranda/generators/revsinglestream.cc
+++ b/src/sst/elements/miranda/generators/revsinglestream.cc
@@ -36,8 +36,8 @@ void ReverseSingleStreamGenerator::build(Params& params) {
 
 	out = new Output("ReverseSingleStreamGenerator[@p:@l]: ", verbose, 0, Output::STDOUT);
 
-	stopIndex   = params.find<uint64_t>("stop_at", 0);
-	startIndex  = params.find<uint64_t>("start_at", 1024);
+	stopIndex   = params.find<uint64_t>("stopat", 0);
+	startIndex  = params.find<uint64_t>("startat", 1024);
 	datawidth   = params.find<uint64_t>("datawidth", 8);
 	stride      = params.find<uint64_t>("stride", 1);
 

--- a/src/sst/elements/miranda/generators/revsinglestream.h
+++ b/src/sst/elements/miranda/generators/revsinglestream.h
@@ -28,39 +28,39 @@ namespace Miranda {
 class ReverseSingleStreamGenerator : public RequestGenerator {
 
 public:
-	ReverseSingleStreamGenerator( Component* owner, Params& params );
-	ReverseSingleStreamGenerator( ComponentId_t id, Params& params );
-        void build(Params& params);
-	~ReverseSingleStreamGenerator();
-	void generate(MirandaRequestQueue<GeneratorRequest*>* q);
-	bool isFinished();
-	void completed();
+      ReverseSingleStreamGenerator( Component* owner, Params& params );
+      ReverseSingleStreamGenerator( ComponentId_t id, Params& params );
+      void build(Params& params);
+      ~ReverseSingleStreamGenerator();
+      void generate(MirandaRequestQueue<GeneratorRequest*>* q);
+      bool isFinished();
+      void completed();
 
-	SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
-               	ReverseSingleStreamGenerator,
-                "miranda",
-                "ReverseSingleStreamGenerator",
-                SST_ELI_ELEMENT_VERSION(1,0,0),
-		"Creates a single reverse ordering stream of accesses to/from memory",
-                SST::Miranda::RequestGenerator
-        )
+      SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
+            ReverseSingleStreamGenerator,
+            "miranda",
+            "ReverseSingleStreamGenerator",
+            SST_ELI_ELEMENT_VERSION(1,0,0),
+            "Creates a single reverse ordering stream of accesses to/from memory",
+            SST::Miranda::RequestGenerator
+         )
 
-	SST_ELI_DOCUMENT_PARAMS(
-		{ "start_at",         "Sets the start *index* for this generator", "2048" },
-    		{ "stop_at",          "Sets the stop *index* for this generator, stop < start", "0" },
-    		{ "verbose",          "Sets the verbosity of the output", "0" },
-    		{ "datawidth",        "Sets the width of the memory operation", "8" },
-    		{ "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" },
-        )
+      SST_ELI_DOCUMENT_PARAMS(
+            { "startat",          "Sets the start *index* for this generator", "2048" },
+            { "stopat",           "Sets the stop *index* for this generator, stop < start", "0" },
+            { "verbose",          "Sets the verbosity of the output", "0" },
+            { "datawidth",        "Sets the width of the memory operation", "8" },
+            { "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" },
+         )
 
-private:
-	uint64_t startIndex;
-	uint64_t stopIndex;
-	uint64_t datawidth;
-	uint64_t nextIndex;
-	uint64_t stride;
+   private:
+      uint64_t startIndex;
+      uint64_t stopIndex;
+      uint64_t datawidth;
+      uint64_t nextIndex;
+      uint64_t stride;
 
-	Output*  out;
+      Output*  out;
 
 };
 

--- a/src/sst/elements/miranda/generators/singlestream.h
+++ b/src/sst/elements/miranda/generators/singlestream.h
@@ -28,38 +28,40 @@ namespace Miranda {
 class SingleStreamGenerator : public RequestGenerator {
 
 public:
-	SingleStreamGenerator( Component* owner, Params& params );
-	SingleStreamGenerator( ComponentId_t id, Params& params );
-        void build(Params& params);
-	~SingleStreamGenerator();
-	void generate(MirandaRequestQueue<GeneratorRequest*>* q);
-	bool isFinished();
-	void completed();
+      SingleStreamGenerator( Component* owner, Params& params );
+      SingleStreamGenerator( ComponentId_t id, Params& params );
+      void build(Params& params);
+      ~SingleStreamGenerator();
+      void generate(MirandaRequestQueue<GeneratorRequest*>* q);
+      bool isFinished();
+      void completed();
 
-	SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
-		SingleStreamGenerator,
-                "miranda",
-                "SingleStreamGenerator",
-                SST_ELI_ELEMENT_VERSION(1,0,0),
-		"Creates a single reverse ordering stream of accesses to/from memory",
-                SST::Miranda::RequestGenerator
-        )
+      SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
+            SingleStreamGenerator,
+            "miranda",
+            "SingleStreamGenerator",
+            SST_ELI_ELEMENT_VERSION(1,0,0),
+            "Creates a single reverse ordering stream of accesses to/from memory",
+            SST::Miranda::RequestGenerator
+         )
 
-	SST_ELI_DOCUMENT_PARAMS(
-		{ "start_at",         "Sets the start *index* for this generator", "2048" },
-    		{ "stop_at",          "Sets the stop *index* for this generator, stop < start", "0" },
-    		{ "verbose",          "Sets the verbosity of the output", "0" },
-    		{ "datawidth",        "Sets the width of the memory operation", "8" },
-    		{ "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" }
-        )
-private:
-	uint64_t reqLength;
-	uint64_t maxAddr;
-	uint64_t issueCount;
-	uint64_t nextAddr;
-	uint64_t startAddr;
-	Output*  out;
-	ReqOperation memOp;
+      SST_ELI_DOCUMENT_PARAMS(
+            { "startat",         "Sets the start *index* for this generator", "2048" },
+            { "stopat",          "Sets the stop *index* for this generator, stop < start", "0" },
+            { "verbose",          "Sets the verbosity of the output", "0" },
+            { "datawidth",        "Sets the width of the memory operation", "8" },
+            { "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" }
+         )
+
+   private:
+      uint64_t reqLength;
+      uint64_t maxAddr;
+      uint64_t issueCount;
+      uint64_t nextAddr;
+      uint64_t startAddr;
+      
+      Output*  out;
+      ReqOperation memOp;
 
 };
 

--- a/src/sst/elements/miranda/generators/singlestream.h
+++ b/src/sst/elements/miranda/generators/singlestream.h
@@ -46,11 +46,11 @@ public:
          )
 
       SST_ELI_DOCUMENT_PARAMS(
-            { "startat",         "Sets the start *index* for this generator", "2048" },
-            { "stopat",          "Sets the stop *index* for this generator, stop < start", "0" },
-            { "verbose",          "Sets the verbosity of the output", "0" },
-            { "datawidth",        "Sets the width of the memory operation", "8" },
-            { "stride",           "Sets the stride, since this is a reverse stream this is subtracted per iteration, def=1", "1" }
+            { "startat",      "Sets the start *index* for this generator", "2048" },
+            { "stopat",       "Sets the stop *index* for this generator, stop < start", "0" },
+            { "verbose",      "Sets the verbosity of the output", "0" },
+            { "datawidth",    "Sets the width of the memory operation", "8" },
+            { "stride",       "Sets the stride", "1" }
          )
 
    private:
@@ -59,7 +59,7 @@ public:
       uint64_t issueCount;
       uint64_t nextAddr;
       uint64_t startAddr;
-      
+
       Output*  out;
       ReqOperation memOp;
 

--- a/src/sst/elements/miranda/generators/singlestream.h
+++ b/src/sst/elements/miranda/generators/singlestream.h
@@ -41,7 +41,7 @@ public:
             "miranda",
             "SingleStreamGenerator",
             SST_ELI_ELEMENT_VERSION(1,0,0),
-            "Creates a single reverse ordering stream of accesses to/from memory",
+            "Creates a single ordered stream of accesses to/from memory",
             SST::Miranda::RequestGenerator
          )
 

--- a/src/sst/elements/miranda/generators/singlestream.h
+++ b/src/sst/elements/miranda/generators/singlestream.h
@@ -46,11 +46,12 @@ public:
          )
 
       SST_ELI_DOCUMENT_PARAMS(
-            { "startat",      "Sets the start *index* for this generator", "2048" },
-            { "stopat",       "Sets the stop *index* for this generator, stop < start", "0" },
             { "verbose",      "Sets the verbosity of the output", "0" },
-            { "datawidth",    "Sets the width of the memory operation", "8" },
-            { "stride",       "Sets the stride", "1" }
+            { "count",        "Total number of requests", "1000" },
+            { "length",       "Sets the length of the request", "8" },
+            { "startat",      "Sets the start address of the array", "0" },
+            { "max_address",  "Maximum address allowed for generation", "524288" },
+            { "memOp",        "All reqeusts will be of this type, [Read/Write]", "Read" },
          )
 
    private:

--- a/src/sst/elements/miranda/tests/revsinglestream.py
+++ b/src/sst/elements/miranda/tests/revsinglestream.py
@@ -7,17 +7,17 @@ sst.setProgramOption("stopAtCycle", "0 ns")
 # Define the simulation components
 comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
 comp_cpu.addParams({
-	"verbose" : 0,
-	"clock" : "2GHz",
-	"printStats" : 1,
+      "verbose" : 0,
+      "clock" : "2GHz",
+      "printStats" : 1,
 })
 
 gen = comp_cpu.setSubComponent("generator", "miranda.ReverseSingleStreamGenerator")
 gen.addParams({
-	"verbose" : 1,
-        "start_at" : 65536,
-        "stop_at" : 0,
-        "stride" : 8,
+      "verbose" : 1,
+      "startat" : 65536,
+      "stopat" : 0,
+      "stride" : 8,
 })
 
 # Tell SST what statistics handling we want
@@ -35,7 +35,7 @@ comp_l1cache.addParams({
       "associativity" : "4",
       "cache_line_size" : "64",
       "prefetcher" : "cassini.StridePrefetcher",
-      "debug" : "1",
+      "debug" : "0",
       "L1" : "1",
       "cache_size" : "2KB"
 })


### PR DESCRIPTION
Help for SingleStream was incorrect; it listed the parameters start_at and stop_at but the subcomponent expects startat and stopat.

Updated ReverseSingleStream to be consistent with other subcomponents, using startat and stopat.

This is a fix for https://github.com/sstsimulator/sst-elements/issues/1302