### PR TITLE
fix for Issue #1305; Repairing Stake class interfaces

### DIFF
--- a/src/sst/elements/miranda/generators/stake.cc
+++ b/src/sst/elements/miranda/generators/stake.cc
@@ -22,15 +22,15 @@ using namespace SST::Miranda;
 
 Stake *__GStake;
 
-Stake::Stake( Component* owner, Params& params ) :
-	RequestGenerator(owner, params) {
-            build(params);
-        }
+Stake::Stake( ComponentId_t id, Params& params )
+  : RequestGenerator(id, params) {
+    build(params);
+}
 
-Stake::Stake( Component* owner, Params& params ) :
-	RequestGenerator(owner, params) {
-            build(params);
-        }
+Stake::Stake( Component* owner, Params& params )
+  : RequestGenerator(owner, params) {
+    build(params);
+}
 
 void Stake::build(Params &params) {
         // default parameters

--- a/src/sst/elements/miranda/generators/stake.h
+++ b/src/sst/elements/miranda/generators/stake.h
@@ -42,10 +42,9 @@ namespace Miranda {
 class Stake : public RequestGenerator {
 
 public:
-	Stake( Component* owner, Params& params );
-	Stake( ComponentId_t id, Params& params );
+        Stake( ComponentId_t id, Params& params );
+        Stake( Component* owner, Params& params );
         void build(Params& params); // Temporary while legacy constructor is getting deprecated
-
 	~Stake();
 	void generate(MirandaRequestQueue<GeneratorRequest*>* q);
 	bool isFinished();


### PR DESCRIPTION
This is a small fix for Issue #1305.  It repairs the Stake miranda generator interfaces for the Stake class in order to adhere to the latest interface standard for generators.  This was tested against the sst-elements devel branch from 07/01/2019 and the sst-core master branch from 07/01/2019.
