### PR TITLE
Added GPGPU-Sim configure option

### DIFF
--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -15,12 +15,15 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
       [],
       [
       AS_IF([test "$sst_check_cuda_happy" = "no"],
-            [AC_MSG_ERROR([Valid Cuda required for GPGPU-Sim])])
+            [AC_MSG_ERROR([valid Cuda required for GPGPU-Sim])])
    ])
    
    #Need compiler versions
-   CC_VERSION=$(gcc -dumpversion) 
-   CUDA_VERSION_STRING=$(nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | $AWK '{printf("%02u%02u", 10*int(@S|@1), 10*@S|@2);}')
+   CC_VERSION=$(gcc -dumpversion)  
+   AC_CHECK_FILE($with_cuda/bin/nvcc, 
+                 [CUDA_VERSION_STRING=$($with_cuda/bin/nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | $AWK '{printf("%02u%02u", 10*int(@S|@1), 10*@S|@2);}')],
+                 []
+   )   
    GPGPUSIM_LIB_DIR=lib/gcc-$CC_VERSION/cuda-$CUDA_VERSION_STRING/release
 
    AS_IF([test ! -z "$with_gpgpusim" -a "$with_gpgpusim" != "yes"],

--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -10,9 +10,17 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
    LDFLAGS_saved="$LDFLAGS"
    LIBS_saved="$LIBS"
 
+   #Need Cuda
+   AS_IF([test "$sst_check_gpgpusim_happy" = "no"],
+      [],
+      [
+      AS_IF([test "$sst_check_cuda_happy" = "no"],
+            [AC_MSG_ERROR([Valid Cuda required for GPGPU-Sim])])
+   ])
+   
    #Need compiler versions
-   CC_VERSION=$(gcc -dumpversion)
-   CUDA_VERSION_STRING=$(nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | awk '{printf("%02u%02u", 10*int(@S|@1), 10*@S|@2);}')
+   CC_VERSION=$(gcc -dumpversion) 
+   CUDA_VERSION_STRING=$(nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | $AWK '{printf("%02u%02u", 10*int(@S|@1), 10*@S|@2);}')
    GPGPUSIM_LIB_DIR=lib/gcc-$CC_VERSION/cuda-$CUDA_VERSION_STRING/release
 
    AS_IF([test ! -z "$with_gpgpusim" -a "$with_gpgpusim" != "yes"],
@@ -25,13 +33,6 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
             GPGPUSIM_LDFLAGS=
             GPGPUSIM_LIBDIR=
             GPGPUSIM_LIB=
-   ])
-
-   AS_IF([test "$sst_check_gpgpusim_happy" = "no"],
-      [],
-      [
-      AS_IF([test "$sst_check_cuda_happy" = "no"],
-            [AC_MSG_ERROR([Valid Cuda required for GPGPU-Sim])])
    ])
 
    AC_MSG_CHECKING([for cudart_mod in $GPGPUSIM_LIBDIR])

--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -1,0 +1,67 @@
+AC_DEFUN([SST_CHECK_GPGPUSIM],
+[
+   sst_check_gpgpusim_happy="no"
+
+   AC_ARG_WITH([gpgpusim],
+      [AS_HELP_STRING([--with-gpgpusim@<:@=DIR@:>@],
+         [Specify the root directory for GPGPU-Sim])])
+
+   CPPFLAGS_saved="$CPPFLAGS"
+   LDFLAGS_saved="$LDFLAGS"
+   LIBS_saved="$LIBS"
+
+   #Need compiler versions
+   CC_VERSION=$(gcc -dumpversion)
+   CUDA_VERSION_STRING=$(nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | awk '{printf("%02u%02u", 10*int(@S|@1), 10*@S|@2);}')
+   GPGPUSIM_LIB_DIR=lib/gcc-$CC_VERSION/cuda-$CUDA_VERSION_STRING/release
+
+   AS_IF([test ! -z "$with_gpgpusim" -a "$with_gpgpusim" != "yes"],
+         [GPGPUSIM_CPPFLAGS=""
+            CPPFLAGS="$GPGPUSIM_CPPFLAGS $CPPFLAGS"
+            GPGPUSIM_LIBDIR="$with_gpgpusim/$GPGPUSIM_LIB_DIR"
+            GPGPUSIM_LDFLAGS="-L$GPGPUSIM_LIBDIR"
+            LDFLAGS="$GPGPUSIM_LDFLAGS $LDFLAGS"],
+         [GPGPUSIM_CPPFLAGS=
+            GPGPUSIM_LDFLAGS=
+            GPGPUSIM_LIBDIR=
+            GPGPUSIM_LIB=
+   ])
+
+   AS_IF([test "$sst_check_gpgpusim_happy" = "no"],
+      [],
+      [
+      AS_IF([test "$sst_check_cuda_happy" = "no"],
+            [AC_MSG_ERROR([Valid Cuda required for GPGPU-Sim])])
+   ])
+
+   AC_MSG_CHECKING([for cudart_mod in $GPGPUSIM_LIBDIR])
+      if test -f "$GPGPUSIM_LIBDIR/libcudart_mod.so" ; then
+         GPGPUSIM_LIB="-lcudart_mod"
+         sst_check_gpgpusim_happy="yes"
+         AC_MSG_RESULT([yes])
+      else
+         AC_MSG_RESULT(libcudart_mod.so not found)
+      fi
+
+   ##TODO
+   #This is a better test but fails because it must be linked against the SST GPU component
+   #AC_LANG_PUSH(C++)
+   #AC_CHECK_LIB([cudart_mod], [cudaLaunch],
+      #[GPGPUSIM_LIB="-lcudart_mod"], [sst_check_gpgpusim_happy="no"]
+   #)
+   #AC_LANG_POP(C++)
+
+   CPPFLAGS="$CPPFLAGS_saved"
+   LDFLAGS="$LDFLAGS_saved"
+   LIBS="$LIBS_saved"
+
+   AC_SUBST([GPGPUSIM_CPPFLAGS])
+   AC_SUBST([GPGPUSIM_LDFLAGS])
+   AC_SUBST([GPGPUSIM_LIBDIR])
+   AC_SUBST([GPGPUSIM_LIB])
+
+   AS_IF([test "$sst_check_gpgpusim_happy" = "yes"],
+         [AC_DEFINE_UNQUOTED([GPGPUSIM_LIBDIR], ["$GPGPUSIM_LIBDIR"], [Library directory where GPGPU-Sim can be found.])])
+   AS_IF([test "$sst_check_gpgpusim_happy" = "yes"], [$1], [$2])
+
+])


### PR DESCRIPTION
New configure flag: --with-gpgpusim

Balar also updated to accept 	GPGPUSIM_LIBDIR and  GPGPUSIM_LIB, which should point to the modified cudart library, cudart_mod.