### PR TITLE
Temp Fix for Older autoconf

### DIFF
--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -22,7 +22,7 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
    CC_VERSION=$(gcc -dumpversion)  
    AC_CHECK_FILE($with_cuda/bin/nvcc, 
                  [CUDA_VERSION_STRING=$($with_cuda/bin/nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | sed 's/$/ /' | sed 's/\ /0/g')],
-                 []
+                 [CUDA_VERSION_STRING=""]
    )   
    GPGPUSIM_LIB_DIR=lib/gcc-$CC_VERSION/cuda-$CUDA_VERSION_STRING/release
 


### PR DESCRIPTION
Older versions of autoconf leave the else part of AC_CHECK_FILE (file, [action-if-found], [action-if-not-found]) intact but empty, causing an error. New versions omit else if the action is empty in the macro.

if test "x$as_val" = x""yes; then
  #Do STUFF
else

fi