### PR TITLE
Changes to fix sst-core detect if another core is in the path

### DIFF
--- a/config/sst_core_check_install.m4
+++ b/config/sst_core_check_install.m4
@@ -2,28 +2,32 @@
 AC_DEFUN([SST_CORE_CHECK_INSTALL], [
 	AC_ARG_WITH([sst-core],
 	  [AS_HELP_STRING([--with-sst-core=@<:@=DIR@:>@],
-	    [Use SST Discrete Event Core installed in DIR])])
+	    [Use SST Discrete Event Core installed in DIR])],
+	    [with_sst_core=$withval/bin],
+	    [with_sst_core=$PATH])
 
   SST_CONFIG_TOOL=""
   SST_REGISTER_TOOL=""
 
-  AS_IF( [test "x$with_sst_core" = "x"],
-	 [AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$PATH])],
-	 [AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$with_sst_core/bin])] )
+  AS_IF( [test x"$with_sst_core" = "x/bin"],
+	 [AC_MSG_ERROR([User undefined path while using --with-sst-core], [1])], [] )
 
-  AC_MSG_CHECKING([for sst-config tool])
+  AS_IF( [test x"$with_sst_core" = "xyes/bin"],
+	 [AC_MSG_ERROR([User undefined path while using --with-sst-core], [1])], [] )
+
+  AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$with_sst_core])
+
+  AC_MSG_CHECKING([for sst-config tool available])
   AS_IF([test -x "$SST_CONFIG_TOOL"],
 	[AC_MSG_RESULT([found $SST_CONFIG_TOOL])],
-	[AC_MSG_ERROR([Unable to find sst-config in the sst-core directory or in the PATH], [1])])
+	[AC_MSG_ERROR([Unable to find sst-config in $with_sst_core], [1])])
 
-  AS_IF( [test "x$with_sst_core" = "x"],
-	 [AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$PATH])],
-	 [AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$with_sst_core/bin])] )
+  AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$with_sst_core])
 
-  AC_MSG_CHECKING([for sst-register tool])
+  AC_MSG_CHECKING([for sst-register tool available])
   AS_IF([test -x "$SST_REGISTER_TOOL"],
 	[AC_MSG_RESULT([found $SST_REGISTER_TOOL])],
-	[AC_MSG_ERROR([Unable to find sst-register in the sst-core directory or in the PATH], [1])])
+	[AC_MSG_ERROR([Unable to find sst-register in $with_sst_core], [1])])
 
   SST_PREFIX=`$SST_CONFIG_TOOL --prefix`
   SST_CPPFLAGS=`$SST_CONFIG_TOOL --CPPFLAGS`

--- a/config/sst_core_check_install.m4
+++ b/config/sst_core_check_install.m4
@@ -7,23 +7,23 @@ AC_DEFUN([SST_CORE_CHECK_INSTALL], [
   SST_CONFIG_TOOL=""
   SST_REGISTER_TOOL=""
 
-  AS_IF( [test "x$with_sst_core" = "xyes"],
+  AS_IF( [test "x$with_sst_core" = "x"],
 	 [AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$PATH])],
-	 [AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$PATH$PATH_SEPARATOR$with_sst_core/bin])] )
+	 [AC_PATH_PROG([SST_CONFIG_TOOL], [sst-config], [], [$with_sst_core/bin])] )
 
   AC_MSG_CHECKING([for sst-config tool])
   AS_IF([test -x "$SST_CONFIG_TOOL"],
 	[AC_MSG_RESULT([found $SST_CONFIG_TOOL])],
-	[AC_MSG_ERROR([Unable to find sst-config in the PATH or in the sst-core directory], [1])])
+	[AC_MSG_ERROR([Unable to find sst-config in the sst-core directory or in the PATH], [1])])
 
-  AS_IF( [test "x$with_sst_core" = "xyes"],
+  AS_IF( [test "x$with_sst_core" = "x"],
 	 [AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$PATH])],
-	 [AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$PATH$PATH_SEPARATOR$with_sst_core/bin])] )
+	 [AC_PATH_PROG([SST_REGISTER_TOOL], [sst-register], [], [$with_sst_core/bin])] )
 
   AC_MSG_CHECKING([for sst-register tool])
   AS_IF([test -x "$SST_REGISTER_TOOL"],
 	[AC_MSG_RESULT([found $SST_REGISTER_TOOL])],
-	[AC_MSG_ERROR([Unable to find sst-register in the PATH or in sst-core directory], [1])])
+	[AC_MSG_ERROR([Unable to find sst-register in the sst-core directory or in the PATH], [1])])
 
   SST_PREFIX=`$SST_CONFIG_TOOL --prefix`
   SST_CPPFLAGS=`$SST_CONFIG_TOOL --CPPFLAGS`


### PR DESCRIPTION
This PR is to address issue #1417.

During configure, --with-sst-core=corepath will improperly find an previously built core if it is in the $PATH rather than the user defined "corepath".

Basically if a previously built core in the the $PATH, the --with-sst-core will find that one rather than the corepath defined by the user. The configure script will report which one it found, but if the user does not double check, they may believe that the configure worked and selected the corepath they wanted. This can cause a newer SST-Elements to be built with an older SST-core (that might be defined in the path).

There are basically 3 changes:
1 - Lines 10 and 19 fix incorrect logic.  This test was always failing because $with_sst_core actually returns the user defined path, not a "yes".  This caused lines 12 and 21 (fail condition) to always execute.
2 - Lines 12 and 21 would search the $PATH first for a copy of sst-core then if not found it would search the user defined path.  The change here basically will force a check **only** of the user defined path if the --with-sst-core is defined.  if --with-sst-core is not defined, the script will search $PATH for a copy of sst-core.
3 - Slight change to the error message on lines 17 and 26 showing preference for the user defined directory.

With this change, if core is not found in the user defined path the configure will fail.  It will no longer attempt to search the $PATH and possibly find a different core that the user did not want.  

However if --with-sst-core is not provided, then the script will search $PATH for a core, and if not found will cause configure to fail.

@gvoskuilen @feldergast can you please review and if/when approved, I will remove the WIP flags and allow the autotester to run and merge this PR.

