### PR TITLE
move miranda counter to single class definition

### DIFF
--- a/src/sst/elements/miranda/mirandaCPU.cc
+++ b/src/sst/elements/miranda/mirandaCPU.cc
@@ -23,6 +23,8 @@
 #include "mirandaCPU.h"
 #include "mirandaEvent.h"
 
+std::atomic<uint64_t> SST::Miranda::GeneratorRequest::nextGeneratorRequestID(0);
+
 using namespace SST::Miranda;
 
 RequestGenCPU::RequestGenCPU(SST::ComponentId_t id, SST::Params& params) :

--- a/src/sst/elements/miranda/mirandaGenerator.h
+++ b/src/sst/elements/miranda/mirandaGenerator.h
@@ -35,7 +35,6 @@ typedef enum {
         OPCOUNT
 } ReqOperation;
 
-static std::atomic<uint64_t> nextGeneratorRequestID(0);
 
 class GeneratorRequest {
 public:
@@ -81,6 +80,8 @@ protected:
 	uint64_t reqID;
 	uint64_t issueTime;
 	std::vector<uint64_t> dependsOn;
+private:
+	static std::atomic<uint64_t> nextGeneratorRequestID;
 };
 
 template<typename QueueType>


### PR DESCRIPTION
Fix to bizarre behavior observed by other pull requests. On GCC 4.8.5 on a particular fork of core, request IDs were getting reset to zero causing event ordering differences.