### PR TITLE
Fix test directories registration for 4 elements

### DIFF
--- a/src/sst/elements/firefly/Makefile.am
+++ b/src/sst/elements/firefly/Makefile.am
@@ -166,4 +166,3 @@ libfirefly_la_LDFLAGS = -module -avoid-version
 
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     firefly=$(abs_srcdir)
-	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      firefly=$(abs_srcdir)/tests

--- a/src/sst/elements/hermes/Makefile.am
+++ b/src/sst/elements/hermes/Makefile.am
@@ -25,4 +25,3 @@ libhermes_la_LDFLAGS = -module -avoid-version
 
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     hermes=$(abs_srcdir)
-	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      hermes=$(abs_srcdir)/tests

--- a/src/sst/elements/thornhill/Makefile.am
+++ b/src/sst/elements/thornhill/Makefile.am
@@ -24,4 +24,3 @@ libthornhill_la_LDFLAGS = -module -avoid-version
 
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     thornhill=$(abs_srcdir)
-	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      thornhill=$(abs_srcdir)/tests

--- a/src/sst/elements/zodiac/Makefile.am
+++ b/src/sst/elements/zodiac/Makefile.am
@@ -79,4 +79,4 @@ endif
 
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     zodiac=$(abs_srcdir)
-	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      zodiac=$(abs_srcdir)/tests
+	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      zodiac=$(abs_srcdir)/test


### PR DESCRIPTION
Firefly, hermes, thornhill do not have test directories and should not register the test dir path.

zodiac uses the non-standard test (should be tests) directory, changing registration to point to the correct path.