### PR TITLE
Change the EXTRA_DIST in the makefile to distribute config directory.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,7 @@ install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_LIBRARY SST_ELEMENT_LIBRARY_LIBDIR=$(pkglibdir)
 
 EXTRA_DIST = \
+	config/ \
 	autogen.sh \
 	CONTRIBUTING.md \
 	CONTRIBUTORS.TXT \

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_LIBRARY SST_ELEMENT_LIBRARY_LIBDIR=$(pkglibdir)
 
 EXTRA_DIST = \
-	config/ \
+	config \
 	autogen.sh \
 	CONTRIBUTING.md \
 	CONTRIBUTORS.TXT \


### PR DESCRIPTION
Change the EXTRA_DIST in the makefile to distribute everything in the config directory.  This should fix the Balar issue in detecting gpgpusim
