### PR TITLE
Fix for gcc version check

### DIFF
--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -19,8 +19,8 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
    ])
    
    #Need compiler versions
-   CC_VERSION=$(gcc -dumpversion)  
-   AC_CHECK_FILE($with_cuda/bin/nvcc, 
+   CC_VERSION=$(CC_TEST=`gcc -dumpversion`; if @<:@ ${#CC_TEST} -gt 1 @:>@; then echo $CC_TEST; else gcc -dumpfullversion; fi)
+   AC_CHECK_FILE($with_cuda/bin/nvcc,
                  [CUDA_VERSION_STRING=$($with_cuda/bin/nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | sed 's/$/ /' | sed 's/\ /0/g')],
                  [CUDA_VERSION_STRING=""]
    )   


### PR DESCRIPTION
Fix for https://github.com/sstsimulator/sst-elements/issues/1464

Note that this is not a complete fix -- this only works for gcc-7+. If an older version of gcc is configured with --with-gcc-major-version-only, the configure will still fail.