### PR TITLE
Fix gcc Version Check in GPGPUSim Macro

### DIFF
--- a/config/sst_check_gpgpusim.m4
+++ b/config/sst_check_gpgpusim.m4
@@ -19,7 +19,7 @@ AC_DEFUN([SST_CHECK_GPGPUSIM],
    ])
    
    #Need compiler versions
-   CC_VERSION=$(CC_TEST=`gcc -dumpversion`; if @<:@ ${#CC_TEST} -gt 1 @:>@; then echo $CC_TEST; else gcc -dumpfullversion; fi)
+   CC_VERSION=$($CC --version | head -1 | sed 's/\(@<:@0-9@:>@.@<:@0-9@:>@.@<:@0-9@:>@\).*/\1/' | sed 's/.* //')
    AC_CHECK_FILE($with_cuda/bin/nvcc,
                  [CUDA_VERSION_STRING=$($with_cuda/bin/nvcc --version | grep -o "release .*" | sed 's/ *,.*//' | sed 's/release //g' | sed 's/\./ /g' | sed 's/$/ /' | sed 's/\ /0/g')],
                  [CUDA_VERSION_STRING=""]


### PR DESCRIPTION
Moves to sed and --version instead of dumpversion, which is finicky.