### PR TITLE
Fixed downs is undefined error for Fat Tree Topology 

### DIFF
--- a/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
@@ -155,7 +155,7 @@ class topoFatTree(Topology):
             # Create the down links for the routers
             rtr_links = [ [] for index in range(rtrs_in_group) ]
             for i in range(rtrs_in_group):
-                for j in range(downs[level]):
+                for j in range(self._downs[level]):
                     rtr_links[i].append(sst.Link("link_l%d_g%d_r%d_p%d"%(level,group,i,j)));
 
             # Now create group links to pass to lower level groups from router down links
@@ -164,7 +164,7 @@ class topoFatTree(Topology):
                 for j in range(rtrs_in_group):
                     group_links[i].append(rtr_links[j][i])
 
-            for i in range(downs[level]):
+            for i in range(self._downs[level]):
                 fattree_rb(self,level-1,group*self._downs[level]+i,group_links[i])
 
             # Create the routers in this level.


### PR DESCRIPTION
I was running some code provided by @feldergast and got the following error: 

```
Traceback (most recent call last):
  File "/Users/deangchester/models-sst-10/new-ember.py", line 153, in <module>
    system.build()
  File "pymerlin-base.py", line 325, in build
  File "topology/pymerlin-topo-fattree.py", line 209, in build
  File "topology/pymerlin-topo-fattree.py", line 169, in fattree_rb
NameError: name 'downs' is not defined
FATAL: SSTPythonModel Execution of model construction function failed
SST Fatal Backtrace Information:
    0 : 0   sstsim.x                            0x000000010189197c _ZNK3SST6Output5fatalEjPKcS2_iS2_z + 1020
    1 : 1   sstsim.x                            0x00000001018f7ff6 _ZN3SST4Core24SSTPythonModelDefinition17createConfigGraphEv + 342
    2 : 2   sstsim.x                            0x0000000101849ef3 main + 1571
    3 : 3   libdyld.dylib                       0x00007fff5025f015 start + 
```