### PR TITLE
Changed name in ember python module initialization that matched a nam…

### DIFF
--- a/src/sst/elements/ember/ember.cc
+++ b/src/sst/elements/ember/ember.cc
@@ -56,7 +56,10 @@
  */
 #include <sst/core/model/element_python.h>
 
-char pymerlin[] = {
+namespace SST {
+namespace Ember {
+
+char pyember[] = {
 #include "pyember.inc"
     0x00};
 
@@ -65,12 +68,14 @@ public:
     EmberPyModule(std::string library) :
         SSTElementPythonModule(library)
     {
-        auto primary_module = createPrimaryModule(pymerlin,"pyember.py");
+        auto primary_module = createPrimaryModule(pyember,"pyember.py");
     }
 
     SST_ELI_REGISTER_PYTHON_MODULE(
-        EmberPyModule,
+        SST::Ember::EmberPyModule,
         "ember",
         SST_ELI_ELEMENT_VERSION(1,0,0)
     )
 };
+}
+}

--- a/src/sst/elements/merlin/merlin.cc
+++ b/src/sst/elements/merlin/merlin.cc
@@ -19,7 +19,7 @@
 
 
 /*
-  This are header file only classes, so need to be included here to
+  These are header file only classes, so need to be included here to
   get compiled.
  */
 #include "hr_router/xbar_arb_rr.h"
@@ -35,6 +35,9 @@
   Install the python library
  */
 #include <sst/core/model/element_python.h>
+
+namespace SST {
+namespace Merlin {
 
 char pymerlin[] = {
 #include "pymerlin.inc"
@@ -79,11 +82,14 @@ public:
     }
 
     SST_ELI_REGISTER_PYTHON_MODULE(
-        MerlinPyModule,
+        SST::Merlin::MerlinPyModule,
         "merlin",
         SST_ELI_ELEMENT_VERSION(1,0,0)
     )
 };
+
+}
+}
 
 /*
   Needed temporarily because the Factory doesn't know if this is an


### PR DESCRIPTION
…e in merlin.  Also put all the python module code into library specific namespaces for good measure.

This issue cause segfaults with newer compilers.