### PR TITLE
Added subscribe call to other topologies in Merlin

### DIFF
--- a/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
@@ -27,7 +27,7 @@ class topoFatTree(Topology):
                                      "_total_hosts"])
         self._declareParams("main",["shape","routing_alg","adaptive_threshold"])        
         self._setCallbackOnWrite("shape",self._shape_callback)
-
+        self._subscribeToPlatformParamSet("topology")
 
     def _shape_callback(self,variable_name,value):
         self._lockVariable(variable_name)

--- a/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
@@ -29,6 +29,7 @@ class topoHyperX(Topology):
         self._setCallbackOnWrite("shape",self._shape_callback)
         self._setCallbackOnWrite("width",self._shape_callback)
         self._setCallbackOnWrite("local_ports",self._shape_callback)
+        self._subscribeToPlatformParamSet("topology")
 
     def _shape_callback(self,variable_name,value):
         self._lockVariable(variable_name)

--- a/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
@@ -28,6 +28,7 @@ class _topoMeshBase(Topology):
         self._setCallbackOnWrite("shape",self._shape_callback)
         self._setCallbackOnWrite("width",self._shape_callback)
         self._setCallbackOnWrite("local_ports",self._shape_callback)
+        self._subscribeToPlatformParamSet("topology")
 
     def _shape_callback(self,variable_name,value):
         self._lockVariable(variable_name)


### PR DESCRIPTION
Using the platforms example from @feldergast only Dragonfly topology worked added the subscribe call to the other topologies made this work for other topologies. 