### PR TITLE
Merlin python prefixed params fix

### DIFF
--- a/src/sst/elements/merlin/pymerlin-base.py
+++ b/src/sst/elements/merlin/pymerlin-base.py
@@ -319,6 +319,10 @@ class _SubAttributeManager(_AttributeManager):
         for var in plist:
             self._addVariable(var,group_dict,prefix)
 
+    def _createPrefixedParams(self,name):
+        self._addDirectAttribute(name,_SubAttributeManager(self._parent))
+        return self.__dict__[name]
+
 
 class TemplateBase(_AttributeManager):
     def __init__(self):


### PR DESCRIPTION
Re-enabled _createPrefixedParams in _SubAttributeManager.  It only got moved to TemplateBase in the last code restructuring.

