### PR TITLE
Fix Build Error for Serrano Test Examples

### DIFF
--- a/src/sst/elements/serrano/Makefile.am
+++ b/src/sst/elements/serrano/Makefile.am
@@ -19,7 +19,7 @@ libserrano_la_SOURCES = \
 
 EXTRA_DIST = \
 	tests/test_serrano.py \
-	tests/graph/sum.graph
+	tests/graphs/sum.graph
 
 libserrano_la_LDFLAGS = -module -avoid-version
 


### PR DESCRIPTION
Addresses a build error for Serrano's test examples.

```
make[10]: *** No rule to make target 'tests/graph/sum.graph', needed by 'distdir-am'.  Stop.
```
