### PR TITLE
Adds Printing of Ariel Page Translation Table (Ariel Simple Memory Manager) when using Verbose Debugging

### DIFF
--- a/src/sst/elements/ariel/arielmemmgr_simple.cc
+++ b/src/sst/elements/ariel/arielmemmgr_simple.cc
@@ -96,6 +96,10 @@ uint64_t ArielMemoryManagerSimple::translateAddress(uint64_t virtAddr) {
         return virtAddr;
     }
 
+    if( output->getVerboseLevel() > 15 ) {
+	printTable();
+    }
+
     // Keep track of how many translations we are performing
     statTranslationQueries->addData(1);
 
@@ -158,4 +162,18 @@ void ArielMemoryManagerSimple::printStats() {
 
     output->output("- Bytes               %" PRIu64 "\n",
         ((uint64_t) pageTable.size()) * ((uint64_t) pageSize));
+}
+
+void ArielMemoryManagerSimple::printTable() {
+
+    	output->output("---------------------------------------------------------------------\n");
+	output->verbose(CALL_INFO, 16, 0, "Page Table Map:\n");
+
+	for( auto table_itr : pageTable ) {
+		output->verbose(CALL_INFO, 16, 0, "-> VA: %15" PRIu64 " -> PA: %15" PRIu64 "\n",
+			table_itr.first, table_itr.second);
+	}
+
+    	output->output("---------------------------------------------------------------------\n");
+
 }

--- a/src/sst/elements/ariel/arielmemmgr_simple.h
+++ b/src/sst/elements/ariel/arielmemmgr_simple.h
@@ -55,6 +55,7 @@ class ArielMemoryManagerSimple : public ArielMemoryManagerCache {
 
     private:
         void allocate(const uint64_t size, const uint32_t level, const uint64_t virtualAddress);
+	void printTable();
 
         uint64_t pageSize;
         std::deque<uint64_t> freePages;


### PR DESCRIPTION
Adds printing of page translation tables for Ariel Simple Memory Manager when verbosity levels >= 16. This will print a lot of translation information to the screen (which will result in large outputs and much slower performance).