### PR TITLE
Improve compare diff testing

### DIFF
--- a/src/sst/elements/CramSim/tests/testsuite_default_CramSim.py
+++ b/src/sst/elements/CramSim/tests/testsuite_default_CramSim.py
@@ -122,7 +122,7 @@ class testcase_CramSim_Component(SSTTestCase):
         #       testing_compare_diff will always fail, so all it looks for is the
         #       "Simulation complete" message to decide pass/fail
         #       This should be improved upon to check for real data...
-        cmp_result = testing_compare_diff(outfile, reffile)
+        cmp_result = testing_compare_diff(testDataFileName, outfile, reffile)
         if not cmp_result:
             cmd = 'grep -q "Simulation is complete" {0} '.format(outfile)
             grep_result = os.system(cmd) == 0

--- a/src/sst/elements/Samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/Samba/tests/testsuite_default_Samba.py
@@ -40,23 +40,18 @@ class testcase_Samba_Component(SSTTestCase):
 
 #####
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "Samba: test_Samba_gupsgen_mmu skipped if ranks > 2")
     def test_Samba_gupsgen_mmu(self):
         self.Samba_test_template("gupsgen_mmu")
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "Samba: test_Samba_gupsgen_mmu_4KB skipped if ranks > 2")
     def test_Samba_gupsgen_mmu_4KB(self):
         self.Samba_test_template("gupsgen_mmu_4KB")
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "Samba: test_Samba_gupsgen_mmu_three_levels skipped if ranks > 2")
     def test_Samba_gupsgen_mmu_three_levels(self):
         self.Samba_test_template("gupsgen_mmu_three_levels")
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "Samba: test_Samba_stencil3dbench_mmu skipped if ranks > 2")
     def test_Samba_stencil3dbench_mmu(self):
         self.Samba_test_template("stencil3dbench_mmu")
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "Samba: test_Samba_streambench_mmu skipped if ranks > 2")
     def test_Samba_streambench_mmu(self):
         self.Samba_test_template("streambench_mmu")
 
@@ -82,8 +77,7 @@ class testcase_Samba_Component(SSTTestCase):
 
         self.run_sst(sdlfile, outfile, errfile, mpi_out_files=mpioutfiles)
 
-#        # This may be needed in the future
-#        remove_component_warning()
+        testing_remove_component_warning_from_file(outfile)
 
         # NOTE: THE PASS / FAIL EVALUATIONS ARE PORTED FROM THE SQE BAMBOO
         #       BASED testSuite_XXX.sh THESE SHOULD BE RE-EVALUATED BY THE
@@ -92,6 +86,9 @@ class testcase_Samba_Component(SSTTestCase):
 
         cmp_result = testing_compare_diff(testDataFileName, outfile, reffile)
         if cmp_result != True:
+            diff_data = testing_get_diff_data(testDataFileName)
+            log_debug("{0} - DIFF DATA =\n{1}".format(self.get_testcase_name(), diff_data))
+
             # We need to use some bailing wire to allow serialization
             # branch to work with same reference files
             cmd = "sed s/' (.*)'// {0} > {1}".format(reffile, newreffile)
@@ -103,8 +100,9 @@ class testcase_Samba_Component(SSTTestCase):
             out_wc_data = self._get_file_data_counts(newoutfile)
 
             cmp_result = ref_wc_data == out_wc_data
+            if not cmp_result:
+                log_debug("{0} - DIFF DATA\nref_wc_data = {1}\nout_wc_data = {2}".format(self.get_testcase_name(), ref_wc_data, out_wc_data))
             self.assertTrue(cmp_result, "Output file {0} word/line count does NOT match Reference file {1} word/line count".format(outfile, reffile))
-
         else:
             self.assertTrue(cmp_result, "Diffed compared Output file {0} does not match Reference File {1}".format(outfile, reffile))
 

--- a/src/sst/elements/Samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/Samba/tests/testsuite_default_Samba.py
@@ -90,7 +90,7 @@ class testcase_Samba_Component(SSTTestCase):
         #       DEVELOPER AGAINST THE LATEST VERSION OF SST TO SEE IF THE
         #       TESTS & RESULT FILES ARE STILL VALID
 
-        cmp_result = testing_compare_diff(outfile, reffile)
+        cmp_result = testing_compare_diff(testDataFileName, outfile, reffile)
         if cmp_result != True:
             # We need to use some bailing wire to allow serialization
             # branch to work with same reference files

--- a/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
+++ b/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
@@ -106,6 +106,6 @@ class testcase_cacheTracer_Component(SSTTestCase):
         #       TESTS & RESULT FILES ARE STILL VALID
 
         # Perform the test
-        cmp_result = testing_compare_diff(out_memRefFile, reffile, ignore_ws=True)
+        cmp_result = testing_compare_diff(testDataFileName, out_memRefFile, reffile, ignore_ws=True)
         self.assertTrue(cmp_result, "File {0} does not match Reference File {1} ignoring whitespace".format(out_memRefFile, reffile))
 

--- a/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
+++ b/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
@@ -84,7 +84,7 @@ class testcase_cassini_prefetch(SSTTestCase):
         self.assertFalse(os_test_file(errfile, "-s"), "cassini_prefetch test {0} has Non-empty Error File {1}".format(testDataFileName, errfile))
 
         cmp_result = testing_compare_sorted_diff(testcase, outfile, reffile)
-        diff_data = testing_get_sorted_diff_data(testcase)
+        diff_data = testing_get_diff_data(testcase)
         if not cmp_result:
             log_debug("{0} - DIFF DATA =\n{1}".format(self.get_testcase_name(), diff_data))
         self.assertTrue(cmp_result, "Sorted Output file {0} does not match sorted Reference File {1}".format(outfile, reffile))

--- a/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
+++ b/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
@@ -73,6 +73,8 @@ class testcase_cassini_prefetch(SSTTestCase):
 
         self.run_sst(sdlfile, outfile, errfile, mpi_out_files=mpioutfiles)
 
+        testing_remove_component_warning_from_file(outfile)
+
         # NOTE: THE PASS / FAIL EVALUATIONS ARE PORTED FROM THE SQE BAMBOO
         #       BASED testSuite_XXX.sh THESE SHOULD BE RE-EVALUATED BY THE
         #       DEVELOPER AGAINST THE LATEST VERSION OF SST TO SEE IF THE
@@ -82,4 +84,7 @@ class testcase_cassini_prefetch(SSTTestCase):
         self.assertFalse(os_test_file(errfile, "-s"), "cassini_prefetch test {0} has Non-empty Error File {1}".format(testDataFileName, errfile))
 
         cmp_result = testing_compare_sorted_diff(testcase, outfile, reffile)
+        diff_data = testing_get_sorted_diff_data(testcase)
+        if not cmp_result:
+            log_debug("{0} - DIFF DATA =\n{1}".format(self.get_testcase_name(), diff_data))
         self.assertTrue(cmp_result, "Sorted Output file {0} does not match sorted Reference File {1}".format(outfile, reffile))

--- a/src/sst/elements/ember/tests/testsuite_default_embernightly.py
+++ b/src/sst/elements/ember/tests/testsuite_default_embernightly.py
@@ -83,7 +83,7 @@ class testcase_EmberNightly(SSTTestCase):
         #       TESTS & RESULT FILES ARE STILL VALID
 
         if testoutput:
-            cmp_result = testing_compare_diff(outfile, reffile)
+            cmp_result = testing_compare_diff(testDataFileName, outfile, reffile)
             self.assertTrue(cmp_result, "Diffed compared Output file {0} does not match Reference File {1}".format(outfile, reffile))
 
         self.assertFalse(os_test_file(errfile, "-s"), "Ember Nightly Test {0} has Non-empty Error File {1}".format(testDataFileName, errfile))

--- a/src/sst/elements/ember/tests/testsuite_default_qos.py
+++ b/src/sst/elements/ember/tests/testsuite_default_qos.py
@@ -100,7 +100,7 @@ class testcase_QOS(SSTTestCase):
 
 
         # Look for a direct match
-        cmp_result = testing_compare_diff(outfile, reffile)
+        cmp_result = testing_compare_diff(testDataFileName, outfile, reffile)
         if cmp_result:
             # Is it a direct match
             log_debug("Direct Match\n")

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -39,13 +39,16 @@ class testcase_miranda_Component(SSTTestCase):
 
 #####
 
-    @unittest.skipIf(testing_check_get_num_ranks() > 2, "miranda: test_miranda_singlestream skipped if ranks > 2")
+    @unittest.skipIf(testing_check_get_num_ranks() > 1, "miranda: test_miranda_singlestream skipped if ranks > 1")
+    @unittest.skipIf(testing_check_get_num_threads() > 1, "miranda: test_miranda_singlestream skipped if threads > 1")
     def test_miranda_singlestream(self):
         self.miranda_test_template("singlestream")
 
     def test_miranda_revsinglestream(self):
         self.miranda_test_template("revsinglestream")
 
+    @unittest.skipIf(testing_check_get_num_ranks() > 1, "miranda: test_miranda_randomgen skipped if ranks > 1")
+    @unittest.skipIf(testing_check_get_num_threads() > 1, "miranda: test_miranda_randomgen skipped if threads > 1")
     def test_miranda_randomgen(self):
         self.miranda_test_template("randomgen", timeout=360)
 

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -47,7 +47,7 @@ class testcase_miranda_Component(SSTTestCase):
         self.miranda_test_template("revsinglestream")
 
     def test_miranda_randomgen(self):
-        self.miranda_test_template("randomgen", timeout=3500)
+        self.miranda_test_template("randomgen", timeout=360)
 
     def test_miranda_stencil3dbench(self):
         self.miranda_test_template("stencil3dbench")


### PR DESCRIPTION
Core Test frameworks modified the compare_diff routines and provided a get diff results function.  This PR resolves the issues some tests had when running a 2 rank + 2 thread test.