### PR TITLE
Fix missing Python files for make dist in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -127,9 +127,7 @@ libvanadis_la_SOURCES = \
 	vinsbundle.h \
 	vinsloader.h
 
-EXTRA_DIST = \
-	tests/basic_miranda.py \
-	tests/hierarchy_test.py
+EXTRA_DIST =
 
 libvanadis_la_LDFLAGS = -module -avoid-version
 


### PR DESCRIPTION
Remove reference to Python files in Vanadis `Makefile.am`. This has caused failure in `make dist` testing.
