### PR TITLE
Several Fixes for Vanadis Emulated OS Calls that Improve Quality of Benchmark Timing Output

### DIFF
--- a/src/sst/elements/vanadis/decoder/vdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vdecoder.h
@@ -49,7 +49,7 @@ public:
 		icache_line_width = params.find<uint64_t>("icache_line_width", 64);
 
 		const size_t uop_cache_size          = params.find<size_t>("uop_cache_entries", 128);
-		const size_t predecode_cache_entries = params.find<size_t>("predecode_cache_entries", 32);
+		const size_t predecode_cache_entries = params.find<size_t>("predecode_cache_entries", 4);
 
 		ins_loader = new VanadisInstructionLoader( uop_cache_size, predecode_cache_entries, icache_line_width );
 

--- a/src/sst/elements/vanadis/os/vmipscpuos.h
+++ b/src/sst/elements/vanadis/os/vmipscpuos.h
@@ -380,7 +380,7 @@ public:
                                 const uint16_t phys_reg_5 = isaTable->getIntPhysReg(5);
                                 uint64_t time_addr = regFile->getIntReg<uint64_t>( phys_reg_5 );
 
-				output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to clock_gettime64( %" PRId64 ", %" PRIu64 " )\n",
+				output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to clock_gettime64( %" PRId64 ", 0x%llx )\n",
 					clk_type, time_addr );
 
 				call_ev = new VanadisSyscallGetTime64Event( core_id, hw_thr, clk_type, time_addr );


### PR DESCRIPTION
- Improves quality of clock_gettime64 calls to be accurate (write back of seconds is now 8 bytes, not 4 which causes incorrect values to be used).
- Improves simulation performance by guarding `snprintf` calls in performance critical parts of the pipeline model
- Fixes up some defaults for decoder performance