### PR TITLE
Merlin: Added incast and empty patterns

### DIFF
--- a/src/sst/elements/merlin/Makefile.am
+++ b/src/sst/elements/merlin/Makefile.am
@@ -31,8 +31,12 @@ libmerlin_la_SOURCES = \
 	test/pt2pt/pt2pt_test.cc \
 	test/bisection/bisection_test.h \
 	test/bisection/bisection_test.cc \
+	test/simple_patterns/empty.h \
+	test/simple_patterns/empty.cc \
 	test/simple_patterns/shift.h \
 	test/simple_patterns/shift.cc \
+	test/simple_patterns/incast.h \
+	test/simple_patterns/incast.cc \
 	topology/torus.h \
 	topology/torus.cc \
 	topology/mesh.h \

--- a/src/sst/elements/merlin/pymerlin-endpoint.py
+++ b/src/sst/elements/merlin/pymerlin-endpoint.py
@@ -64,3 +64,24 @@ class OfferedLoadJob(Job):
         return (networkif, portname)
 
 
+class IncastJob(Job):
+    def __init__(self,job_id,size):
+        Job.__init__(self,job_id,size)
+        self._declareParams("main",["num_peers","target_nids","packets_to_send","packet_size"])
+        self.num_peers = size
+        self._lockVariable("num_peers")
+
+    def getName(self):
+        return "Incast Job"
+
+    def build(self, nID, extraKeys):
+        nic = sst.Component("incast.%d"%nID, "merlin.simple_patterns.incast")
+        self._applyStatisticsSettings(nic)
+        nic.addParams(self._getGroupParams("main"))
+        nic.addParams(extraKeys)
+        id = self._nid_map.index(nID)
+
+        #  Add the linkcontrol
+        networkif, port_name = self.network_interface.build(nic,"networkIF",0,self.job_id,self.size,id,True)
+        return (networkif, port_name)
+

--- a/src/sst/elements/merlin/test/simple_patterns/empty.cc
+++ b/src/sst/elements/merlin/test/simple_patterns/empty.cc
@@ -1,0 +1,56 @@
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+#include <sst_config.h>
+#include "sst/elements/merlin/test/simple_patterns/empty.h"
+
+#include <sst/core/interfaces/simpleNetwork.h>
+
+namespace SST {
+using namespace SST::Interfaces;
+
+namespace Merlin {
+
+empty_nic::empty_nic(ComponentId_t cid, Params& params) :
+    Component(cid)
+{
+    link_control = loadUserSubComponent<SST::Interfaces::SimpleNetwork>
+        ("networkIF", ComponentInfo::SHARE_NONE, 1 /* vns */);
+}
+
+empty_nic::~empty_nic()
+{
+    delete link_control;
+}
+
+void empty_nic::finish()
+{
+    link_control->finish();
+}
+
+void
+empty_nic::init(unsigned int phase) {
+    link_control->init(phase);
+}
+
+void
+empty_nic::setup()
+{
+    link_control->setup();
+}
+
+
+} // namespace Merlin
+} // namespace SST
+

--- a/src/sst/elements/merlin/test/simple_patterns/empty.h
+++ b/src/sst/elements/merlin/test/simple_patterns/empty.h
@@ -1,0 +1,68 @@
+// -*- mode: c++ -*-
+
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_NULL_H
+#define COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_NULL_H
+
+#include <sst/core/component.h>
+#include <sst/core/interfaces/simpleNetwork.h>
+
+
+namespace SST {
+
+namespace Merlin {
+
+class empty_nic : public Component {
+
+public:
+
+    SST_ELI_REGISTER_COMPONENT(
+        empty_nic,
+        "merlin",
+        "simple_patterns.empty",
+        SST_ELI_ELEMENT_VERSION(0,9,0),
+        ".",
+        COMPONENT_CATEGORY_NETWORK)
+
+    SST_ELI_DOCUMENT_PARAMS(
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+    )
+
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+        {"networkIF", "Network interface", "SST::Interfaces::SimpleNetwork" }
+    )
+
+    void finish();
+    void init(unsigned int phase);
+    void setup();
+
+    
+private:
+    SST::Interfaces::SimpleNetwork* link_control;
+
+public:
+    empty_nic(ComponentId_t cid, Params& params);
+    ~empty_nic();
+};
+
+}
+}
+
+#endif // COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_SHIFT_H

--- a/src/sst/elements/merlin/test/simple_patterns/incast.cc
+++ b/src/sst/elements/merlin/test/simple_patterns/incast.cc
@@ -1,0 +1,232 @@
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+#include <sst_config.h>
+#include "sst/elements/merlin/test/simple_patterns/incast.h"
+
+#include <unistd.h>
+
+#include <sst/core/event.h>
+#include <sst/core/params.h>
+#include <sst/core/simulation.h>
+#include <sst/core/timeLord.h>
+#include <sst/core/unitAlgebra.h>
+
+#include <sst/core/interfaces/simpleNetwork.h>
+
+namespace SST {
+using namespace SST::Interfaces;
+
+namespace Merlin {
+
+
+incast_nic::incast_nic(ComponentId_t cid, Params& params) :
+    Component(cid),
+    id(-1),
+    target(false),
+    curr_packets(0),
+    start_time(0),
+    end_time(0),
+    output(Simulation::getSimulation()->getSimulationOutput())
+{
+    num_peers = params.find<int>("num_peers",-1);
+    if ( num_peers == -1 ) {
+    }
+
+    params.find_array<int>("target_nids", targets);
+
+    total_packets = params.find<int>("packets_to_send",10);
+    if ( total_packets != -1 ) {
+        registerAsPrimaryComponent();
+        primaryComponentDoNotEndSim();
+    }
+
+    if ( total_packets == -1 ) {
+        total_packets = std::numeric_limits<int>::max();
+    }
+    else {
+        total_packets *= targets.size();
+    }
+
+    // std::string packet_size_s = params.find<std::string>("packet_size", "64B");
+    // UnitAlgebra packet_size(packet_size_s);
+    UnitAlgebra packet_size = params.find<UnitAlgebra>("packet_size", UnitAlgebra("64B"));
+    if ( packet_size.hasUnits("B") ) {
+        packet_size *= UnitAlgebra("8b/B");
+    }
+
+    packet_size_in_bits = packet_size.getRoundedValue();
+
+    // Create a LinkControl object
+    // First see if it is defined in the python
+    link_control = loadUserSubComponent<SST::Interfaces::SimpleNetwork>
+        ("networkIF", ComponentInfo::SHARE_NONE, 1 /* vns */);
+
+}
+
+
+
+incast_nic::~incast_nic()
+{
+    delete link_control;
+}
+
+void
+incast_nic::init(unsigned int phase) {
+    link_control->init(phase);
+
+    if ( link_control->isNetworkInitialized() && id == -1 ) {
+        id = link_control->getEndpointID();
+
+        // See if I am a target
+        for ( auto x : targets ) {
+            if ( id == x ) {
+                target = true;
+                // Compute total packets to recv          --> because we multiplied by targets.size in const <--
+                total_packets = ( num_peers - targets.size() ) * ( total_packets / targets.size() );                
+            }
+        }
+
+        if ( target ) {
+            UnitAlgebra bw = link_control->getLinkBW();
+            if ( bw.hasUnits("B/s") ) bw *= UnitAlgebra("8b/B");
+            UnitAlgebra size = UnitAlgebra("1 b") * packet_size_in_bits;
+            UnitAlgebra ser_time = size / bw;
+            
+            self_link = configureSelfLink("complete_link", ser_time.toString(), new Event::Handler<incast_nic>(this,&incast_nic::handle_complete));
+            link_control->setNotifyOnReceive(new SST::Interfaces::SimpleNetwork::Handler<incast_nic>(this,&incast_nic::handle_event));
+        }
+        else {
+            link_control->setNotifyOnSend(new SST::Interfaces::SimpleNetwork::Handler<incast_nic>(this,&incast_nic::handle_sends));
+        }
+    }
+}
+
+void incast_nic::setup()
+{
+    link_control->setup();
+
+    if ( !target ) {
+        handle_sends(0);
+    }
+}
+
+void incast_nic::finish()
+{
+    link_control->finish();
+    
+    if ( !target ) return;
+
+    if ( end_time == 0 ) {
+        UnitAlgebra final_time = getFinalSimTime();
+        final_time /= UnitAlgebra("1ns");
+        end_time = final_time.getRoundedValue();
+    }
+    double total_sent = (packet_size_in_bits * curr_packets);
+    double total_time = (double)end_time - (double)start_time;
+    double bw = total_sent / total_time;
+
+    output.output("%d:\n",id);
+    output.output("  Total packets recieved = %d\n",curr_packets);
+    output.output("  Start time = %" PRIu64 "\n",start_time);
+    output.output("  End time = %" PRIu64 "\n",end_time);
+
+    output.output("  Total sent = %lf bits\n",total_sent);
+
+    output.output("  BW = %lf Gbits/sec\n",bw);
+}
+
+// class IncastEvent : public Event {
+// public:
+//     ShiftEvent() {}
+
+//     Event* clone(void) override
+//     {
+//         return new ShiftEvent(*this);
+//     }
+
+//     void serialize_order(SST::Core::Serialization::serializer &ser)  override {
+//         Event::serialize_order(ser);
+//     }
+
+// private:
+
+//     ImplementSerializable(SST::Merlin::IncastEvent);
+
+// };
+
+
+bool
+incast_nic::handle_event(int vn)
+{
+    while ( link_control->requestToReceive(0) ) {
+        SimpleNetwork::Request* req = link_control->recv(0);
+        curr_packets++;
+
+        if ( curr_packets == 1 ) {
+            start_time = getCurrentSimTimeNano();
+        }
+        delete req;
+
+    }
+    if ( curr_packets == total_packets ) {
+        // Send on handle_complete
+        self_link->send( 1, nullptr);
+        return false;
+    }
+
+    return true;
+}
+
+void
+incast_nic::handle_complete(Event* ev) {
+    if ( nullptr != ev ) {
+        delete ev;
+    }
+
+    end_time = getCurrentSimTimeNano();
+
+    primaryComponentOKToEndSim();
+
+}
+
+bool
+incast_nic::handle_sends(int vn)
+{
+    // Check for end case
+    if ( curr_packets == total_packets ) {
+        // Done
+        primaryComponentOKToEndSim();
+        return false;
+    }
+    
+    // Just send until there is no more space
+    while ( link_control->spaceToSend(0,packet_size_in_bits) ) {
+        SimpleNetwork::Request* req = new SimpleNetwork::Request();
+        req->dest = targets[curr_packets % targets.size()];
+        req->src = id;
+        req->vn = 0;
+        req->size_in_bits = packet_size_in_bits;
+
+        link_control->send(req,0);
+
+        curr_packets++;
+    }
+    return true;
+}
+
+
+} // namespace Merlin
+} // namespace SST
+

--- a/src/sst/elements/merlin/test/simple_patterns/incast.h
+++ b/src/sst/elements/merlin/test/simple_patterns/incast.h
@@ -1,0 +1,103 @@
+// -*- mode: c++ -*-
+
+// Copyright 2009-2020 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2020, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+
+#ifndef COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_INCAST_H
+#define COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_INCAST_H
+
+#include <sst/core/component.h>
+#include <sst/core/event.h>
+#include <sst/core/link.h>
+#include <sst/core/timeConverter.h>
+#include <sst/core/interfaces/simpleNetwork.h>
+
+
+namespace SST {
+
+namespace Merlin {
+
+class incast_nic : public Component {
+
+public:
+
+    SST_ELI_REGISTER_COMPONENT(
+        incast_nic,
+        "merlin",
+        "simple_patterns.incast",
+        SST_ELI_ELEMENT_VERSION(0,9,0),
+        "Simple pattern NIC doing an incast pattern.",
+        COMPONENT_CATEGORY_NETWORK)
+
+    SST_ELI_DOCUMENT_PARAMS(
+        {"num_peers",       "Total number of endpoints in network."},
+        {"target_nids",     "List of NIDs to target incast to.  All other nids will round robin packets to target nids"},
+        {"packets_to_send", "Number of packets to send to each target nid.  If set to -1, it will send continuously, but won't register as a primary component","10"},
+        {"packet_size",     "Packet size specified in either b or B (can include SI prefix).","64B"},
+        {"start_delay",     "How long to wait before sending first message","0ns"},
+    )
+
+    SST_ELI_DOCUMENT_PORTS(
+    )
+
+    SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS(
+        {"networkIF", "Network interface", "SST::Interfaces::SimpleNetwork" }
+    )
+
+
+private:
+
+    int id;
+    int num_peers;
+    std::vector<int> targets;
+    bool target;
+
+    int packet_size_in_bits;
+
+    int curr_packets;
+    int total_packets;
+
+    SST::Interfaces::SimpleNetwork* link_control;
+    Link* self_link;
+
+    SimTime_t start_time;
+    SimTime_t end_time;
+    
+    Output& output;
+
+public:
+    incast_nic(ComponentId_t cid, Params& params);
+    ~incast_nic();
+
+    void init(unsigned int phase);
+    void setup();
+    void finish();
+
+
+private:
+    // for targets
+    bool handle_event(int vn);
+    void handle_complete(Event* ev);
+
+    // for sources
+    bool handle_sends(int vn);
+
+};
+
+}
+}
+
+#endif // COMPONENTS_MERLIN_TEST_SIMPLE_PATTERNS_SHIFT_H


### PR DESCRIPTION
Added incast and empty patterns. In the system object, unallocated nodes will automatically use the EmptyJob class.
