### PR TITLE
Update for Vanadis to correct potential bugs in immediate offsets for branches and jumps 

### DIFF
--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -747,14 +747,14 @@ protected:
 					switch( func_mask ) {
 					case MIPS_SPEC_OP_MASK_ADD:
 						{
-							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, VANADIS_FORMAT_INT32 ) );
+							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
 							insertDecodeFault = false;
 						}
 						break;
 
 					case MIPS_SPEC_OP_MASK_ADDU:
 						{
-							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, VANADIS_FORMAT_INT32 ) );
+							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
 							insertDecodeFault = false;
 						}
 						break;

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -1014,11 +1014,9 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_REGIMM:
 			{
-				const uint16_t offset_value_16 = (uint16_t) (next_ins & MIPS_IMM_MASK);
-				const uint64_t offset_value_64 = vanadis_sign_extend( offset_value_16 ) << 2;
+				const uint64_t offset_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );;
 
-				output->verbose(CALL_INFO, 16, 0, "[decoder/REGIMM] -> offset-16: %" PRIu16 " shifted: %" PRIu64 "\n", offset_value_16,
-					offset_value_64);
+				output->verbose(CALL_INFO, 16, 0, "[decoder/REGIMM] -> imm: %" PRIu64 "\n", offset_value_64);
 				output->verbose(CALL_INFO, 16, 0, "[decoder]        -> rt: 0x%08x\n", (next_ins & MIPS_RT_MASK));
 
 				switch( ( next_ins & MIPS_RT_MASK ) ) {
@@ -1050,9 +1048,7 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_LUI:
 			{
-				const int32_t ins_imm      = (int32_t)( next_ins & 0xFFFF );
-				const int64_t ins_imm_64   = (int64_t)( ins_imm << 16 );
-				const int64_t imm_value_64 = ins_imm_64 & 0xFFFFFFFFFFFF0000;
+				const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 16 );
 
 				output->verbose(CALL_INFO, 16, 0, "[decoder/LUI] -> reg: %" PRIu16 " / imm=%" PRId64 "\n",
 					rt, imm_value_64);
@@ -1433,18 +1429,18 @@ protected:
 
 				if( ( next_ins & 0x3E30000 ) == 0x1010000 ) {
 					// this decodes to a BRANCH on TRUE
-					const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins );
+					const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 					bundle->addInstruction( new VanadisBranchFPInstruction(
-						ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, (imm_value_64 << 2),
+						ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, imm_value_64,
 						/* branch on true */ true, VANADIS_SINGLE_DELAY_SLOT ) );
 					insertDecodeFault = false;
 				} else if( ( next_ins & 0x3E30000 ) == 0x1000000 ) {
 					// this decodes to a BRANCH on FALSE
-					const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins );
+					const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 					bundle->addInstruction( new VanadisBranchFPInstruction(
-						ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, (imm_value_64 << 2),
+						ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, imm_value_64,
 						/* branch on false */ false, VANADIS_SINGLE_DELAY_SLOT ) );
 					insertDecodeFault = false;
 				} else {

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -1257,7 +1257,7 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_BEQ:
 			{
-				const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins << 2 );
+				const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 				output->verbose(CALL_INFO, 16, 0, "[decoder/BEQ]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64 "\n",
                                         rt, rs, imm_value_64 );
@@ -1269,7 +1269,7 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_BGTZ:
 			{
-				const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins << 2 );
+				const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 				output->verbose(CALL_INFO, 16, 0, "[decoder/BGTZ]: -> r1: %" PRIu16 " offset: %" PRId64 "\n",
                                         rs, imm_value_64);
@@ -1281,7 +1281,7 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_BLEZ:
 			{
-				const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins << 2 );
+				const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 				output->verbose(CALL_INFO, 16, 0, "[decoder/BLEZ]: -> r1: %" PRIu16 " offset: %" PRId64 "\n",
                                         rs, imm_value_64);
@@ -1293,7 +1293,7 @@ protected:
 
 		case MIPS_SPEC_OP_MASK_BNE:
 			{
-				const int64_t imm_value_64 = vanadis_sign_extend_offset_16( next_ins << 2 );
+				const int64_t imm_value_64 = vanadis_sign_extend_offset_16_and_shift( next_ins, 2 );
 
 				output->verbose(CALL_INFO, 16, 0, "[decoder/BNE]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64 "\n",
                                         rt, rs, imm_value_64 );

--- a/src/sst/elements/vanadis/inst/vaddi.h
+++ b/src/sst/elements/vanadis/inst/vaddi.h
@@ -57,7 +57,7 @@ public:
 		case VANADIS_FORMAT_INT32:
 			{
 		                const int32_t src_1 = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
-				regFile->setIntReg<int32_t>( phys_int_regs_out[0], src_1 + imm_value );
+				regFile->setIntReg<int32_t>( phys_int_regs_out[0], src_1 + static_cast<int32_t>(imm_value) );
 			}
 			break;
 		default:

--- a/src/sst/elements/vanadis/inst/vandi.h
+++ b/src/sst/elements/vanadis/inst/vandi.h
@@ -47,7 +47,7 @@ public:
 			phys_int_regs_in[0], imm_value,
 			isa_int_regs_out[0], isa_int_regs_in[0] );
 
-		const int64_t src_1 = regFile->getIntReg<uint64_t>( phys_int_regs_in[0] );
+		const uint64_t src_1 = regFile->getIntReg<uint64_t>( phys_int_regs_in[0] );
 		regFile->setIntReg<uint64_t>( phys_int_regs_out[0], (src_1 & imm_value) );
 
 		markExecuted();

--- a/src/sst/elements/vanadis/inst/vdecodefaultinst.h
+++ b/src/sst/elements/vanadis/inst/vdecodefaultinst.h
@@ -37,7 +37,7 @@ public:
 	}
 
 	virtual void execute( SST::Output* output, VanadisRegisterFile* regFile ) {
-		
+
 	}
 
 };

--- a/src/sst/elements/vanadis/inst/vdivmod.h
+++ b/src/sst/elements/vanadis/inst/vdivmod.h
@@ -84,7 +84,7 @@ public:
 						const int32_t quo = (src_1) / (src_2);
 						const int32_t mod = (src_1) % (src_2);
 
-						output->verbose(CALL_INFO, 16, 0, "--> Execute: (detailed, signed, DIVREM32) %" PRId64 " / %" PRId64 " = (q: %" PRId64 ", r: %" PRId64 ")\n",
+						output->verbose(CALL_INFO, 16, 0, "--> Execute: (detailed, signed, DIVREM32) %" PRId32 " / %" PRId32 " = (q: %" PRId32 ", r: %" PRId32 ")\n",
 							src_1, src_2, quo, mod);
 
 						regFile->setIntReg<int32_t>( phys_int_regs_out[0], quo, true );
@@ -132,7 +132,7 @@ public:
 						const uint32_t quo = (src_1) / (src_2);
 						const uint32_t mod = (src_1) % (src_2);
 
-						output->verbose(CALL_INFO, 16, 0, "--> Execute: (detailed, unsigned, DIVREM32) %" PRIu64 " / %" PRIu64 " = (q: %" PRIu64 ", r: %" PRIu64 ")\n",
+						output->verbose(CALL_INFO, 16, 0, "--> Execute: (detailed, unsigned, DIVREM32) %" PRIu32 " / %" PRIu32 " = (q: %" PRIu32 ", r: %" PRIu32 ")\n",
 							src_1, src_2, quo, mod);
 
 						regFile->setIntReg<uint32_t>( phys_int_regs_out[0], quo, false );

--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -74,22 +74,22 @@ public:
 		case VANADIS_FORMAT_INT32:
 		case VANADIS_FORMAT_FP32:
 			{
-				const uint32_t fp_v = regFile->getFPReg<uint32_t>( phys_fp_regs_in[0] );
-				regFile->setFPReg<uint32_t>( phys_fp_regs_out[0], fp_v );
+				const int32_t fp_v = regFile->getFPReg<int32_t>( phys_fp_regs_in[0] );
+				regFile->setFPReg<int32_t>( phys_fp_regs_out[0], fp_v );
 			}
 			break;
 		case VANADIS_FORMAT_INT64:
 		case VANADIS_FORMAT_FP64:
 			{
 				if( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
-					const uint32_t v_0 = regFile->getFPReg<uint32_t>( phys_fp_regs_in[0] );
-					regFile->setFPReg<uint32_t>( phys_fp_regs_out[0], v_0 );
+					const int32_t v_0 = regFile->getFPReg<int32_t>( phys_fp_regs_in[0] );
+					regFile->setFPReg<int32_t>( phys_fp_regs_out[0], v_0 );
 
-					const uint32_t v_1 = regFile->getFPReg<uint32_t>( phys_fp_regs_in[1] );
-					regFile->setFPReg<uint32_t>( phys_fp_regs_out[1], v_1 );
+					const int32_t v_1 = regFile->getFPReg<int32_t>( phys_fp_regs_in[1] );
+					regFile->setFPReg<int32_t>( phys_fp_regs_out[1], v_1 );
 				} else {
-					const uint64_t fp_v = regFile->getFPReg<uint64_t>( phys_fp_regs_in[0] );
-					regFile->setFPReg<uint64_t>( phys_fp_regs_out[0], fp_v );
+					const int64_t fp_v = regFile->getFPReg<int64_t>( phys_fp_regs_in[0] );
+					regFile->setFPReg<int64_t>( phys_fp_regs_out[0], fp_v );
 				}
 			}
 			break;

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -137,7 +137,7 @@ public:
 					break;
 				case VANADIS_FORMAT_FP64:
 					{
-						const double fp_v = (float)( regFile->getFPReg<float>( phys_fp_regs_in[0] ) );
+						const double fp_v = (double)( regFile->getFPReg<float>( phys_fp_regs_in[0] ) );
 
 						if( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
 							fractureToRegisters<double>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v );
@@ -149,7 +149,7 @@ public:
 				case VANADIS_FORMAT_INT32:
 					{
 						const int32_t i_v = (int32_t)( regFile->getFPReg<float>( phys_fp_regs_in[0] ) );
-						regFile->setFPReg( phys_fp_regs_out[0], i_v );
+						regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 					}
 					break;
 				case VANADIS_FORMAT_INT64:
@@ -178,7 +178,7 @@ public:
 							regFile->setFPReg<float>( phys_fp_regs_out[0], fp_v );
 						} else {
 							const float fp_v = (float)( regFile->getFPReg<double>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<float>( phys_fp_regs_out[0], fp_v );
 						}
 					}
 					break;
@@ -189,7 +189,7 @@ public:
 							fractureToRegisters<double>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v );
 						} else {
 							const double fp_v = (double)( regFile->getFPReg<double>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<double>( phys_fp_regs_out[0], fp_v );
 						}
 					}
 					break;
@@ -201,7 +201,7 @@ public:
 							regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 						} else {
 							const int32_t i_v = (int32_t)( regFile->getFPReg<double>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 						}
 					}
 					break;
@@ -213,7 +213,7 @@ public:
 							fractureToRegisters<int64_t>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], i_v );
 						} else {
 							const int64_t i_v = (int64_t)( regFile->getFPReg<double>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int64_t>( phys_fp_regs_out[0], i_v );
 						}
 					}
 					break;
@@ -227,7 +227,7 @@ public:
 				case VANADIS_FORMAT_FP32:
 					{
 						const float fp_v = (float)( regFile->getFPReg<int32_t>( phys_fp_regs_in[0] ) );
-						regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+						regFile->setFPReg<float>( phys_fp_regs_out[0], fp_v );
 					}
 					break;
 				case VANADIS_FORMAT_FP64:
@@ -237,14 +237,14 @@ public:
 							fractureToRegisters<double>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v );
 						} else {
 							const double fp_v = (double)( regFile->getFPReg<int32_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<double>( phys_fp_regs_out[0], fp_v );
 						}
 					}
 					break;
 				case VANADIS_FORMAT_INT32:
 					{
 						const int32_t i_v = (int32_t)( regFile->getFPReg<int32_t>( phys_fp_regs_in[0] ) );
-						regFile->setFPReg( phys_fp_regs_out[0], i_v );
+						regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 					}
 					break;
 				case VANADIS_FORMAT_INT64:
@@ -254,7 +254,7 @@ public:
 							fractureToRegisters<int64_t>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], i_v );
 						} else {
 							const int64_t i_v = (int64_t)( regFile->getFPReg<int32_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int64_t>( phys_fp_regs_out[0], i_v );
 						}
 					}
 					break;
@@ -270,10 +270,10 @@ public:
 						if( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
 							const int64_t input_v = combineFromRegisters<int64_t>( regFile, phys_fp_regs_in[0], phys_fp_regs_in[1] );
 							const float   fp_v    = static_cast<float>( input_v );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<float>( phys_fp_regs_out[0], fp_v );
 						} else {
 							const float fp_v = (float)( regFile->getFPReg<int64_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<float>( phys_fp_regs_out[0], fp_v );
 						}
 					}
 					break;
@@ -285,7 +285,7 @@ public:
 							fractureToRegisters<double>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v );
 						} else {
 							const double fp_v = (double)( regFile->getFPReg<int64_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], fp_v );
+							regFile->setFPReg<double>( phys_fp_regs_out[0], fp_v );
 						}
 					}
 					break;
@@ -294,10 +294,10 @@ public:
 						if( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
 							const int64_t input_v = combineFromRegisters<int64_t>( regFile, phys_fp_regs_in[0], phys_fp_regs_in[1] );
 							const int32_t i_v     = static_cast<int32_t>( input_v );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 						} else {
 							const int32_t i_v = (int32_t)( regFile->getFPReg<int64_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int32_t>( phys_fp_regs_out[0], i_v );
 						}
 					}
 					break;
@@ -308,7 +308,7 @@ public:
 							fractureToRegisters<int64_t>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], input_v );
 						} else {
 							const int64_t i_v = (int64_t)( regFile->getFPReg<int64_t>( phys_fp_regs_in[0] ) );
-							regFile->setFPReg( phys_fp_regs_out[0], i_v );
+							regFile->setFPReg<int64_t>( phys_fp_regs_out[0], i_v );
 						}
 					}
 					break;

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -89,7 +89,7 @@ public:
 
 				output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 / src_2));
 
-				regFile->setFPReg( phys_fp_regs_out[0], src_1 / src_2 );
+				regFile->setFPReg<float>( phys_fp_regs_out[0], src_1 / src_2 );
 			}
 			break;
 		case VANADIS_FORMAT_FP64:
@@ -107,7 +107,7 @@ public:
 
 					output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 / src_2));
 
-					regFile->setFPReg( phys_fp_regs_out[0], src_1 / src_2 );
+					regFile->setFPReg<double>( phys_fp_regs_out[0], src_1 / src_2 );
 				}
 			}
 			break;

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -89,7 +89,7 @@ public:
 
 				output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 * src_2));
 
-				regFile->setFPReg( phys_fp_regs_out[0], (src_1) * (src_2) );
+				regFile->setFPReg<float>( phys_fp_regs_out[0], (src_1) * (src_2) );
 			}
 			break;
 		case VANADIS_FORMAT_FP64:
@@ -107,7 +107,7 @@ public:
 
 					output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 * src_2));
 
-					regFile->setFPReg( phys_fp_regs_out[0], src_1 * src_2 );
+					regFile->setFPReg<double>( phys_fp_regs_out[0], src_1 * src_2 );
 				}
 			}
 			break;

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -89,7 +89,7 @@ public:
 
 				output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 - src_2));
 
-				regFile->setFPReg( phys_fp_regs_out[0], ((src_1) - (src_2)));
+				regFile->setFPReg<float>( phys_fp_regs_out[0], ((src_1) - (src_2)));
 			}
 			break;
 		case VANADIS_FORMAT_FP64:
@@ -107,7 +107,7 @@ public:
 
 					output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 - src_2));
 
-					regFile->setFPReg( phys_fp_regs_out[0], src_1 - src_2 );
+					regFile->setFPReg<double>( phys_fp_regs_out[0], src_1 - src_2 );
 				}
 			}
 			break;

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -74,7 +74,7 @@ public:
 		case VANADIS_FORMAT_FP32:
 			{
 				const int32_t v = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
-				regFile->setFPReg( phys_fp_regs_out[0], v );
+				regFile->setFPReg<int32_t>( phys_fp_regs_out[0], v );
 			}
 			break;
 		case VANADIS_FORMAT_INT64:
@@ -85,7 +85,7 @@ public:
 					fractureToRegisters<int64_t>( regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], v );
 				} else {
 					const int64_t v = regFile->getIntReg<int64_t>( phys_int_regs_in[0] );
-					regFile->setFPReg( phys_fp_regs_out[0], v );
+					regFile->setFPReg<int64_t>( phys_fp_regs_out[0], v );
 				}
 			}
 			break;

--- a/src/sst/elements/vanadis/inst/vjl.h
+++ b/src/sst/elements/vanadis/inst/vjl.h
@@ -25,20 +25,13 @@ public:
 			0,1,0,1,0,0,0,0, delayT ) {
 
 		isa_int_regs_out[0] = link_reg;
-//		result_dir = BRANCH_TAKEN;
-
 		takenAddress = pc;
 	}
 
 	virtual VanadisJumpLinkInstruction* clone() {
 		return new VanadisJumpLinkInstruction( *this );
 	}
-/*
-	virtual uint64_t calculateAddress( SST::Output* output, VanadisRegisterFile* reg_file, const uint64_t current_ip ) {
-		output->verbose(CALL_INFO, 16, 0, "[jump-link]: jump-to: %" PRIu64 " / 0x%0llx\n", new_pc, new_pc);
-		return new_pc;
-	}
-*/
+
 	virtual const char* getInstCode() const {
                	return "JL";
        	}

--- a/src/sst/elements/vanadis/inst/vjlr.h
+++ b/src/sst/elements/vanadis/inst/vjlr.h
@@ -26,9 +26,6 @@ public:
 
 			isa_int_regs_in[0]  = jumpToAddrReg;
 			isa_int_regs_out[0] = returnAddrReg;
-
-			// JLR means we will ALWAYS take the branch
-//			result_dir = BRANCH_TAKEN;
 		}
 
 		VanadisJumpRegLinkInstruction* clone() {

--- a/src/sst/elements/vanadis/inst/vjr.h
+++ b/src/sst/elements/vanadis/inst/vjr.h
@@ -19,7 +19,6 @@ public:
 			1, 0, 1, 0, 0, 0, 0, 0, delayT ) {
 
 		isa_int_regs_in[0] = jump_to_reg;
-//		result_dir = BRANCH_TAKEN;
 	}
 
 	VanadisJumpRegInstruction* clone() {

--- a/src/sst/elements/vanadis/inst/vjump.h
+++ b/src/sst/elements/vanadis/inst/vjump.h
@@ -23,19 +23,13 @@ public:
 		VanadisSpeculatedInstruction(addr, hw_thr, isa_opts,
 			0,0,0,0,0,0,0,0, delayT ) {
 
-//		result_dir = BRANCH_TAKEN;
 		takenAddress = pc;
 	}
 
 	virtual VanadisJumpInstruction* clone() {
 		return new VanadisJumpInstruction( *this );
 	}
-/*
-	virtual uint64_t calculateAddress( SST::Output* output, VanadisRegisterFile* reg_file, const uint64_t current_ip ) {
-		output->verbose(CALL_INFO, 16, 0, "[jump]: jump-to: %" PRIu64 " / 0x%0llx\n", new_pc, new_pc);
-		return new_pc;
-	}
-*/
+
 	virtual const char* getInstCode() const {
                	return "JMP";
        	}

--- a/src/sst/elements/vanadis/inst/vscmpi.h
+++ b/src/sst/elements/vanadis/inst/vscmpi.h
@@ -96,9 +96,9 @@ public:
 		}
 
 		if( compare_result ) {
-			regFile->setIntReg<uint64_t>( phys_int_regs_out[0], 1UL );
+			regFile->setIntReg<uint64_t>( phys_int_regs_out[0], static_cast<uint64_t>(1) );
 		} else {
-			regFile->setIntReg<uint64_t>( phys_int_regs_out[0], 0UL );
+			regFile->setIntReg<uint64_t>( phys_int_regs_out[0], static_cast<uint64_t>(0) );
 		}
 
 		markExecuted();

--- a/src/sst/elements/vanadis/inst/vslli.h
+++ b/src/sst/elements/vanadis/inst/vslli.h
@@ -61,7 +61,7 @@ public:
 		case VANADIS_FORMAT_INT32:
 			{
 				const uint32_t src_1 = regFile->getIntReg<uint32_t>( phys_int_regs_in[0] );
-                                regFile->setIntReg<uint64_t>( phys_int_regs_out[0], vanadis_sign_extend( (src_1) << imm_value ) );
+                                regFile->setIntReg<uint32_t>( phys_int_regs_out[0], vanadis_sign_extend( (src_1) << static_cast<uint32_t>(imm_value) ) );
 			}
 			break;
 		case VANADIS_FORMAT_FP32:

--- a/src/sst/elements/vanadis/inst/vsra.h
+++ b/src/sst/elements/vanadis/inst/vsra.h
@@ -63,9 +63,8 @@ public:
 			{
 				const int32_t src_1 = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
                                 const int32_t src_2 = regFile->getIntReg<int32_t>( phys_int_regs_in[1] );
-				const int64_t result = static_cast<int64_t>( (src_1) >> (src_2) );
 
-                                regFile->setIntReg<int64_t>( phys_int_regs_out[0], result );
+                                regFile->setIntReg<int32_t>( phys_int_regs_out[0], (src_1) >> (src_2) );
 			}
 			break;
 		case VANADIS_FORMAT_FP32:

--- a/src/sst/elements/vanadis/inst/vsrai.h
+++ b/src/sst/elements/vanadis/inst/vsrai.h
@@ -63,8 +63,7 @@ public:
 				const int32_t src_1 = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
 				const int32_t imm_value_32 = static_cast<int32_t>(imm_value);
 
-				const int64_t result = static_cast<int64_t>( (src_1) >> imm_value_32 );
-                                regFile->setIntReg<int64_t>( phys_int_regs_out[0], result );
+                                regFile->setIntReg<int32_t>( phys_int_regs_out[0], (src_1) >> imm_value_32 );
 			}
 			break;
 		case VANADIS_FORMAT_FP32:

--- a/src/sst/elements/vanadis/lsq/vlsq.h
+++ b/src/sst/elements/vanadis/lsq/vlsq.h
@@ -68,6 +68,8 @@ public:
 	virtual void init( unsigned int phase ) = 0;
 	virtual void setInitialMemory( const uint64_t address, std::vector<uint8_t>& payload ) = 0;
 
+	virtual void printStatus( SST::Output& output ) {}
+
 protected:
 	uint64_t address_mask;
 	std::vector<VanadisRegisterFile*>* registerFiles;

--- a/src/sst/elements/vanadis/util/vsignx.h
+++ b/src/sst/elements/vanadis/util/vsignx.h
@@ -58,9 +58,9 @@ int64_t vanadis_sign_extend_offset_16( const uint32_t value ) {
 	return value_64;
 };
 
-int64_t vanadis_sign_extend_offset_16_and_shift( const uint32_t value, const uint32_t shift ) {
+int64_t vanadis_sign_extend_offset_16_and_shift( const uint32_t value, const int64_t shift ) {
 	int64_t value_64 = vanadis_sign_extend_offset_16( value );
-	value_64 = value_64 << shift;
+	value_64 <<= shift;
 
 	return value_64;
 };

--- a/src/sst/elements/vanadis/util/vsignx.h
+++ b/src/sst/elements/vanadis/util/vsignx.h
@@ -49,20 +49,18 @@ uint64_t vanadis_sign_extend( const uint32_t value ) {
 };
 
 int64_t vanadis_sign_extend_offset_16( const uint32_t value ) {
-//	printf("sign_extend v: %" PRIu32 " / 0x%0x\n", value, value);
-
 	int64_t value_64 = (value & VANADIS_4BYTE_EXTRACT);
 
-//	printf("sign_extend v_64 = %" PRId64 "\n", value_64);
-
 	if( (value_64 & VANADIS_2BYTE_SIGN_MASK) != 0 ) {
-//		printf("sign_extend - 16th bit is not zero\n");
 		value_64 |= VANADIS_EXTEND_2BYTE_SET;
-	} else {
-//		printf("sign_extend - 16th bit is zero\n");
 	}
 
-//	printf("sign_extend result: %" PRId64 "\n", value_64);
+	return value_64;
+};
+
+int64_t vanadis_sign_extend_offset_16_and_shift( const uint32_t value, const uint32_t shift ) {
+	int64_t value_64 = vanadis_sign_extend_offset_16( value );
+	value_64 = value_64 << shift;
 
 	return value_64;
 };

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -1450,6 +1450,7 @@ void VanadisComponent::printStatus( SST::Output& output ) {
 
 	output.verbose(CALL_INFO, 0, 0, "\n");
 	output.verbose(CALL_INFO, 0, 0, "-> LSQ-Size: %" PRIu32 "\n", (uint32_t) (lsq->storeSize() + lsq->loadSize()) );
+	lsq->printStatus( output );
 	output.verbose(CALL_INFO, 0, 0, "----------------------------------------------------------------------------------------------------------------------------\n");
 }
 


### PR DESCRIPTION
Provides several updates

- Immediate extract and shift support is now outlined into a function
- Basic support to process RT_SIGSETMASK, but this may still produce incorrect masks in certain circumstances
- Supports enhanced print outs for LSQ in `printStatus()` (SIGUSR2 calls)
- Tidy up logical and arithmetic shift instructions when sign-extension is required
- Fixes potential bug in 32b register mode for shifts when attempting to write back a 64b value without sign extension
- General tidy up for printStatus() calls in main Vanadis core