### PR TITLE
Fix Shift Left by Zero Immediate Decode Bug in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -744,231 +744,237 @@ protected:
 				if( 0 == (next_ins & MIPS_SHFT_MASK ) ) {
 					output->verbose( CALL_INFO, 16, 0, "[decode] -> special-class, func-mask: 0x%x\n", func_mask);
 
-					switch( func_mask ) {
-					case MIPS_SPEC_OP_MASK_ADD:
-						{
-							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_ADDU:
-						{
-							bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_AND:
-						{
-							bundle->addInstruction( new VanadisAndInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					// _BREAK NEEDS TO GO HERE?
-
-					case MIPS_SPEC_OP_MASK_DADD:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DADDU:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DDIV:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DDIVU:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DIV:
-						{
-							bundle->addInstruction( new VanadisDivideRemainderInstruction( ins_addr,
-								hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt, true, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_DIVU:
-						{
-							bundle->addInstruction( new VanadisDivideRemainderInstruction( ins_addr,
-								hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt, false, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_DMULT:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DMULTU:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DSLLV:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DSRAV:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DSRLV:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DSUB:
-						break;
-
-					case MIPS_SPEC_OP_MASK_DSUBU:
-						break;
-
-					case MIPS_SPEC_OP_MASK_JR:
-						{
-
-							bundle->addInstruction( new VanadisJumpRegInstruction( ins_addr, hw_thr, options, rs,
-								VANADIS_SINGLE_DELAY_SLOT ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_JALR:
-						{
-							bundle->addInstruction( new VanadisJumpRegLinkInstruction( ins_addr, hw_thr, options,
-								rd, rs, VANADIS_SINGLE_DELAY_SLOT ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_MFHI:
-						{
-							// Special instruction_, 32 is LO, 33 is HI
-							bundle->addInstruction( new VanadisAddImmInstruction( ins_addr, hw_thr, options, rd,
-								MIPS_REG_HI, 0, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_MFLO:
-						{
-							// Special instruction, 32 is LO, 33 is HI
-							bundle->addInstruction( new VanadisAddImmInstruction( ins_addr, hw_thr, options, rd,
-								MIPS_REG_LO, 0, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_MOVN:
-						break;
-
-					case MIPS_SPEC_OP_MASK_MOVZ:
-						break;
-
-					case MIPS_SPEC_OP_MASK_MTHI:
-						break;
-
-					case MIPS_SPEC_OP_MASK_MTLO:
-						break;
-
-					case MIPS_SPEC_OP_MASK_MULT:
-						{
-							bundle->addInstruction( new VanadisMultiplySplitInstruction( ins_addr, hw_thr, options,
-								MIPS_REG_LO, MIPS_REG_HI, rs, rt, true, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_MULTU:
-						{
-							bundle->addInstruction( new VanadisMultiplySplitInstruction( ins_addr, hw_thr, options,
-								MIPS_REG_LO, MIPS_REG_HI, rs, rt, false, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_NOR:
-						{
-							bundle->addInstruction( new VanadisNorInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
-                                                        insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_OR:
-						{
-							bundle->addInstruction( new VanadisOrInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SLLV:
-						{
-							bundle->addInstruction( new VanadisShiftLeftLogicalInstruction( ins_addr,
-								hw_thr, options, rd, rt, rs, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SLT:
-						{
-							bundle->addInstruction( new VanadisSetRegCompareInstruction( ins_addr, hw_thr, options,
-								rd, rs, rt, true, REG_COMPARE_LT, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SLTU:
-						{
-							bundle->addInstruction( new VanadisSetRegCompareInstruction( ins_addr, hw_thr, options,
-								rd, rs, rt, false, REG_COMPARE_LT, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SRAV:
-						{
-							bundle->addInstruction( new VanadisShiftRightArithmeticInstruction( ins_addr, hw_thr, options,
-								rd, rt, rs, VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SRLV:
-						{
-							bundle->addInstruction( new VanadisShiftRightLogicalInstruction( ins_addr, hw_thr, options,
-								rd, rt, rs, VANADIS_FORMAT_INT32) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SUB:
-						{
-							bundle->addInstruction( new VanadisSubInstruction( ins_addr, hw_thr, options, rd, rs, rt, true,
-								VANADIS_FORMAT_INT32  ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SUBU:
-						{
-							bundle->addInstruction( new VanadisSubInstruction( ins_addr, hw_thr, options, rd, rs, rt, false,
-								VANADIS_FORMAT_INT32 ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SYSCALL:
-						{
-							bundle->addInstruction( new VanadisSysCallInstruction( ins_addr, hw_thr, options ) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_SYNC:
-						{
-							bundle->addInstruction( new VanadisFenceInstruction( ins_addr, hw_thr, options,
-								VANADIS_LOAD_STORE_FENCE) );
-							insertDecodeFault = false;
-						}
-						break;
-
-					case MIPS_SPEC_OP_MASK_XOR:
-						bundle->addInstruction( new VanadisXorInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
+					if( (0 == func_mask) && (0 == rs) ) {
+						output->verbose( CALL_INFO, 16, 0, "[decode] -> rs is also zero, implies truncate (generate: 64 to 32 truncate)\n");
+						bundle->addInstruction( new VanadisTruncateInstruction( ins_addr, hw_thr, options, rd, rt, VANADIS_FORMAT_INT64, VANADIS_FORMAT_INT32 ) );
 						insertDecodeFault = false;
-						break;
+					} else {
+						switch( func_mask ) {
+						case MIPS_SPEC_OP_MASK_ADD:
+							{
+								bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_ADDU:
+							{
+								bundle->addInstruction( new VanadisAddInstruction( ins_addr, hw_thr, options, rd, rs, rt, true, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_AND:
+							{
+								bundle->addInstruction( new VanadisAndInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						// _BREAK NEEDS TO GO HERE?
+
+						case MIPS_SPEC_OP_MASK_DADD:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DADDU:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DDIV:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DDIVU:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DIV:
+							{
+								bundle->addInstruction( new VanadisDivideRemainderInstruction( ins_addr,
+									hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt, true, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_DIVU:
+							{
+								bundle->addInstruction( new VanadisDivideRemainderInstruction( ins_addr,
+									hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt, false, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_DMULT:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DMULTU:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DSLLV:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DSRAV:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DSRLV:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DSUB:
+							break;
+
+						case MIPS_SPEC_OP_MASK_DSUBU:
+							break;
+
+						case MIPS_SPEC_OP_MASK_JR:
+							{
+
+								bundle->addInstruction( new VanadisJumpRegInstruction( ins_addr, hw_thr, options, rs,
+									VANADIS_SINGLE_DELAY_SLOT ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_JALR:
+							{
+								bundle->addInstruction( new VanadisJumpRegLinkInstruction( ins_addr, hw_thr, options,
+									rd, rs, VANADIS_SINGLE_DELAY_SLOT ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_MFHI:
+							{
+								// Special instruction_, 32 is LO, 33 is HI
+								bundle->addInstruction( new VanadisAddImmInstruction( ins_addr, hw_thr, options, rd,
+									MIPS_REG_HI, 0, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_MFLO:
+							{
+								// Special instruction, 32 is LO, 33 is HI
+								bundle->addInstruction( new VanadisAddImmInstruction( ins_addr, hw_thr, options, rd,
+									MIPS_REG_LO, 0, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_MOVN:
+							break;
+
+						case MIPS_SPEC_OP_MASK_MOVZ:
+							break;
+
+						case MIPS_SPEC_OP_MASK_MTHI:
+							break;
+
+						case MIPS_SPEC_OP_MASK_MTLO:
+							break;
+
+						case MIPS_SPEC_OP_MASK_MULT:
+							{
+								bundle->addInstruction( new VanadisMultiplySplitInstruction( ins_addr, hw_thr, options,
+									MIPS_REG_LO, MIPS_REG_HI, rs, rt, true, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_MULTU:
+							{
+								bundle->addInstruction( new VanadisMultiplySplitInstruction( ins_addr, hw_thr, options,
+									MIPS_REG_LO, MIPS_REG_HI, rs, rt, false, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_NOR:
+							{
+								bundle->addInstruction( new VanadisNorInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
+															insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_OR:
+							{
+								bundle->addInstruction( new VanadisOrInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SLLV:
+							{
+								bundle->addInstruction( new VanadisShiftLeftLogicalInstruction( ins_addr,
+									hw_thr, options, rd, rt, rs, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SLT:
+							{
+								bundle->addInstruction( new VanadisSetRegCompareInstruction( ins_addr, hw_thr, options,
+									rd, rs, rt, true, REG_COMPARE_LT, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SLTU:
+							{
+								bundle->addInstruction( new VanadisSetRegCompareInstruction( ins_addr, hw_thr, options,
+									rd, rs, rt, false, REG_COMPARE_LT, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SRAV:
+							{
+								bundle->addInstruction( new VanadisShiftRightArithmeticInstruction( ins_addr, hw_thr, options,
+									rd, rt, rs, VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SRLV:
+							{
+								bundle->addInstruction( new VanadisShiftRightLogicalInstruction( ins_addr, hw_thr, options,
+									rd, rt, rs, VANADIS_FORMAT_INT32) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SUB:
+							{
+								bundle->addInstruction( new VanadisSubInstruction( ins_addr, hw_thr, options, rd, rs, rt, true,
+									VANADIS_FORMAT_INT32  ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SUBU:
+							{
+								bundle->addInstruction( new VanadisSubInstruction( ins_addr, hw_thr, options, rd, rs, rt, false,
+									VANADIS_FORMAT_INT32 ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SYSCALL:
+							{
+								bundle->addInstruction( new VanadisSysCallInstruction( ins_addr, hw_thr, options ) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_SYNC:
+							{
+								bundle->addInstruction( new VanadisFenceInstruction( ins_addr, hw_thr, options,
+									VANADIS_LOAD_STORE_FENCE) );
+								insertDecodeFault = false;
+							}
+							break;
+
+						case MIPS_SPEC_OP_MASK_XOR:
+							bundle->addInstruction( new VanadisXorInstruction( ins_addr, hw_thr, options, rd, rs, rt ) );
+							insertDecodeFault = false;
+							break;
+						}
 					}
 				} else {
 					switch( func_mask ) {

--- a/src/sst/elements/vanadis/inst/vinstall.h
+++ b/src/sst/elements/vanadis/inst/vinstall.h
@@ -73,4 +73,7 @@
 #include "inst/vfpscmp.h"
 #include "inst/vfpdiv.h"
 
+// Truncate
+#include "inst/vtrunc.h"
+
 #endif

--- a/src/sst/elements/vanadis/inst/vtrunc.h
+++ b/src/sst/elements/vanadis/inst/vtrunc.h
@@ -1,0 +1,118 @@
+
+#ifndef _H_VANADIS_TRUNCATE
+#define _H_VANADIS_TRUNCATE
+
+#include "inst/vinst.h"
+
+namespace SST {
+namespace Vanadis {
+
+class VanadisTruncateInstruction : public VanadisInstruction {
+public:
+	VanadisTruncateInstruction(
+		const uint64_t addr,
+		const uint32_t hw_thr,
+		const VanadisDecoderOptions* isa_opts,
+		const uint16_t dest,
+		const uint16_t src,
+		VanadisRegisterFormat input_fmt,
+		VanadisRegisterFormat output_fmt) :
+		VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0),
+			reg_input_format(input_fmt),
+			reg_output_format(output_fmt) {
+
+		isa_int_regs_in[0]  = src;
+		isa_int_regs_out[0] = dest;
+	}
+
+	VanadisTruncateInstruction* clone() {
+		return new VanadisTruncateInstruction( *this );
+	}
+
+	virtual VanadisFunctionalUnitType getInstFuncType() const {
+		return INST_INT_ARITH;
+	}
+
+	virtual const char* getInstCode() const {
+		return "TRUNC";
+	}
+
+	virtual void printToBuffer(char* buffer, size_t buffer_size) {
+		snprintf(buffer, buffer_size, "%s    %5" PRIu16 " <- %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 ")\n",
+			getInstCode(), isa_int_regs_out[0], isa_int_regs_in[0],
+			phys_int_regs_out[0], phys_int_regs_in[0]);
+        }
+
+	virtual void execute( SST::Output* output, VanadisRegisterFile* regFile ) {
+		output->verbose(CALL_INFO, 16, 0, "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 ", isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
+			(void*) getInstructionAddress(), getInstCode(),
+			phys_int_regs_out[0], phys_int_regs_in[0],
+			isa_int_regs_out[0], isa_int_regs_in[0] );
+
+		switch( reg_input_format ) {
+		case VANADIS_FORMAT_INT64:
+			{
+				switch( reg_output_format ) {
+				case VANADIS_FORMAT_INT64:
+					{
+						const int64_t src = regFile->getIntReg<int64_t>( phys_int_regs_in[0] );
+						regFile->setIntReg<int64_t>( phys_int_regs_out[0], src );
+					}
+					break;
+				case VANADIS_FORMAT_INT32:
+					{
+						const uint32_t src = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
+						regFile->setIntReg<int32_t>( phys_int_regs_out[0], src );
+					}
+					break;
+				default:
+					{
+						flagError();
+					}
+					break;
+				}
+			}
+			break;
+		case VANADIS_FORMAT_INT32:
+			{
+				switch( reg_output_format ) {
+				case VANADIS_FORMAT_INT64:
+					{
+						const int64_t src = regFile->getIntReg<int64_t>( phys_int_regs_in[0] );
+						regFile->setIntReg<int64_t>( phys_int_regs_out[0], src );
+					}
+					break;
+				case VANADIS_FORMAT_INT32:
+					{
+						const int32_t src = regFile->getIntReg<int32_t>( phys_int_regs_in[0] );
+						regFile->setIntReg<int32_t>( phys_int_regs_out[0], src );
+					}
+					break;
+				default:
+					{
+						flagError();
+					}
+					break;
+				}
+			}
+			break;
+		default:
+			{
+				flagError();
+			}
+			break;
+		}
+
+		markExecuted();
+	}
+
+protected:
+	VanadisRegisterFormat reg_input_format;
+	VanadisRegisterFormat reg_output_format;
+
+};
+
+}
+}
+
+#endif


### PR DESCRIPTION
Fixes an bug in decoding of `SLL` by zero instructions that should create a truncation operation.
