### PR TITLE
Fixes for Vanadis for Branch on Floating Point True and Makefile.am

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -81,6 +81,7 @@ inst/vsrli.h \
 inst/vstore.h \
 inst/vsub.h \
 inst/vsyscall.h \
+inst/vtrunc.h \
 inst/vxor.h \
 inst/vxori.h \
 lsq/vlsq.h \

--- a/src/sst/elements/vanadis/inst/vbfp.h
+++ b/src/sst/elements/vanadis/inst/vbfp.h
@@ -51,7 +51,7 @@ public:
 		uint32_t fp_cond_val = regFile->getFPReg<uint32_t>( fp_cond_reg );
 
 		// is the CC code set on the compare bit in the status register?
-		const bool compare_result = ((fp_cond_val & 0x800000) == (branch_on_true ? 1 : 0) );
+		const bool compare_result = ((fp_cond_val & 0x800000) == (branch_on_true ? 0x800000 : 0) );
 
 		if( compare_result ) {
 			takenAddress = (uint64_t) ( ((int64_t) getInstructionAddress()) +  offset + VANADIS_SPECULATE_JUMP_ADDR_ADD );

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -56,9 +56,45 @@ public:
 	virtual const char* getInstCode() const {
 		switch( reg_fmt ) {
 		case VANADIS_FORMAT_FP64:
-			return "FP64CMP";
+			{
+				switch( compareType ) {
+				case REG_COMPARE_EQ:
+					return "FP64CMPEQ";
+				case REG_COMPARE_NEQ:
+					return "FP64CMPNEQ";
+				case REG_COMPARE_LT:
+					return "FP64CMPLT";
+				case REG_COMPARE_LTE:
+					return "FP64CMPLTE";
+				case REG_COMPARE_GT:
+					return "FP64CMPGT";
+				case REG_COMPARE_GTE:
+					return "FP64CMPGTE";
+				default:
+					return "FP64CMPUKN";
+				}
+			}
+			break;
 		case VANADIS_FORMAT_FP32:
-			return "FP32CMP";
+			{
+				switch( compareType ) {
+				case REG_COMPARE_EQ:
+					return "FP32CMPEQ";
+				case REG_COMPARE_NEQ:
+					return "FP32CMPNEQ";
+				case REG_COMPARE_LT:
+					return "FP32CMPLT";
+				case REG_COMPARE_LTE:
+					return "FP32CMPLTE";
+				case REG_COMPARE_GT:
+					return "FP32CMPGT";
+				case REG_COMPARE_GTE:
+					return "FP32CMPGTE";
+				default:
+					return "FP32CMPUKN";
+				}
+			}
+			break;
 		case VANADIS_FORMAT_INT64:
 			return "FPINT64ACMP";
 		case VANADIS_FORMAT_INT32:


### PR DESCRIPTION
Provides fixes for:

- Branch on true for floating-point compare (previously always evaluates to false)
- Fixes `Makefile.am` missing truncation instructions
- Cleans instruction code string floating-point compare to make more readable

