### PR TITLE
Vanadis - Detect and Error on Dynamic Linked Executables

### DIFF
--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -41,6 +41,12 @@ VanadisComponent::VanadisComponent(SST::ComponentId_t id, SST::Params& params) :
 		output->verbose(CALL_INFO, 2, 0, "Executable: %s\n", binary_img.c_str());
 		binary_elf_info = readBinaryELFInfo( output, binary_img.c_str() );
 		binary_elf_info->print( output );
+
+		if( binary_elf_info->isDynamicExecutable() ) {
+                        output->fatal( CALL_INFO, -1, "--> error - executable is dynamically linked. Only static executables are currently supported for simulation.\n");
+                } else {
+                        output->verbose(CALL_INFO, 2, 0, "--> executable is identified as static linked\n");
+                }
 	}
 
 	std::string clock_rate = params.find<std::string>("clock", "1GHz");

--- a/src/sst/elements/vanadis/velf/velfinfo.h
+++ b/src/sst/elements/vanadis/velf/velfinfo.h
@@ -625,6 +625,19 @@ public:
 		progRelDyn.push_back( new_rel );
 	}
 
+	bool isDynamicExecutable() const {
+		bool found_interp = false;
+
+		for( VanadisELFProgramHeaderEntry* next_entry : progHeaders ) {
+			if( PROG_HEADER_INTERPRETER == next_entry->getHeaderType() ) {
+				found_interp = true;
+				break;
+			}
+		}
+
+		return found_interp;
+	}
+
 	~VanadisELFInfo() {
 		if( nullptr != bin_path ) {
 			delete[] bin_path;


### PR DESCRIPTION
Adds support to detect dynamically linked executables and fatal if found. Vanadis only supported statically linked executables currently. Issue #1584.
