### PR TITLE
Fixing ariel makefile dist for balar

### DIFF
--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -45,7 +45,9 @@ libariel_la_SOURCES = \
 	arieltracegen.h \
 	arieltexttracegen.h \
 	arieltexttracegen.cc \
-	arielfrontend.h
+	arielfrontend.h \
+	gpu_enum.h \
+	arielgpuev.h
 
 EXTRA_DIST = \
 	frontend/pin3/fesimple.cc \


### PR DESCRIPTION
Adding 2 missing files needed for balar in the Ariel distribution.