### PR TITLE
Update contributing info to ssh methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@
 
 * **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/sstsimulator/sst-elements/issues).
 
-* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/sstsimulator/sst-elements/issues/new). Be sure to include: 
-   * A **title and clear description** 
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/sstsimulator/sst-elements/issues/new). Be sure to include:
+   * A **title and clear description**
    * As much relevant information as possible
    * A **code sample** or an **executable test case** demonstrating the unexpected behavior.
-   
+
 ---
 
 #### **Forked Development**
@@ -41,7 +41,7 @@ my fork of that repo is here:
 The way to create your own fork is to click the fork button in the upper right while you are at the official repo. Once you have done that you can simply clone
 
 ```
-git clone https://github.com/fryeguy52/sst-elements
+git clone git@github.com:fryeguy52/sst-elements.git
 ```
 
 ##### Getting updates from the official repo to your local clone
@@ -50,7 +50,7 @@ Your fork will not automatically get updates from the official repo but you will
 
 ```
 git checkout devel
-git remote add sst-official https://github.com/sstsimulator/sst-elements
+git remote add sst-official git@github.com:sstsimulator/sst-elements.git
 git pull --all
 git branch devel --set-upstream-to sst-official/devel
 ```
@@ -58,10 +58,10 @@ You can verify that things are setup correctly
 
 ```
 git remote -vv
-origin       https://github.com/fryeguy52/sst-elements (fetch)
-origin       https://github.com/fryeguy52/sst-elements (push)
-sst-official https://github.com/sstsimulator/sst-elements.git (fetch)
-sst-official https://github.com/sstsimulator/sst-elements.git (push)
+origin       git@github.com:fryeguy52/sst-elements.git (fetch)
+origin       git@github.com:fryeguy52/sst-elements.git (push)
+sst-official git@github.com:sstsimulator/sst-elements.git (fetch)
+sst-official git@github.com:sstsimulator/sst-elements.git (push)
 
 git branch -vv
   devel  be1b790 [sst-official/devel: ahead 82, behind 61] Merge pull request #496 from sstsimulator/devel
@@ -112,7 +112,7 @@ git fetch --all --prune
 
 #### **Patches to existing code to fix an issue**
 
-* Create a `issue-fix` branch on your forked repo derived from the **sst-elements/devel** branch  
+* Create a `issue-fix` branch on your forked repo derived from the **sst-elements/devel** branch
 * Make all required changes to correct the issue. All the changes must be commited to the `issue-fix` branch.
 * Open a new GitHub pull request from the `issue-fix` branch to the **sst-elements/devel** branch.
    * **CRITICAL: ENSURE THAT PULL REQUEST IS TARGETED TO THE `sst-elements/devel` BRANCH.**
@@ -125,7 +125,7 @@ git fetch --all --prune
 
 #### **New Feature**
 
-* Create a `new-feature` branch on your forked repo derived from the **sst-elements/devel** branch  
+* Create a `new-feature` branch on your forked repo derived from the **sst-elements/devel** branch
 * Make all required changes to implement the new feature(s). All the changes must be commited to the `new-feature` branch.
 * Open a new GitHub pull request from the `new-feature` branch to the **sst-elements/devel** branch.
    * **CRITICAL: ENSURE THAT PULL REQUEST IS TARGETED TO THE `sst-elements/devel` BRANCH.**
@@ -138,12 +138,12 @@ git fetch --all --prune
 
 #### **SST AutoTester (CI Testing)**
 
-* When a Pull Request is created against the **sst-elements/devel** branch, the SST AutoTester application will automatically run (usually within 30 minutes) and will build and test the source branch of the Pull Request.  
+* When a Pull Request is created against the **sst-elements/devel** branch, the SST AutoTester application will automatically run (usually within 30 minutes) and will build and test the source branch of the Pull Request.
    * Testing is performed across a number of different platforms
-   * If the test suites pass, then the Pull Request will be automatically merged.  
+   * If the test suites pass, then the Pull Request will be automatically merged.
       * Pull Requests from forks will not be automatially merged unless they are from a trusted user.
    * The testing is not all inclusive, it is possible for a bug related to a specific platform to slip in.  See Nightly Testing below.
-   
+
 ---
 
 #### **Nightly Testing**


### PR DESCRIPTION
Updating the CONTRIBUTING.md file to reflect using ssh clones.  https clones authentication will be unsupported by Github in Aug 2021.