### PR TITLE
Initial vanadis

### DIFF
--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -69,6 +69,8 @@ public:
 		case VANADIS_FORMAT_FP64:
 			return "FP2FP64";
 		}
+
+		return "FPUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -69,6 +69,8 @@ public:
 		case VANADIS_FORMAT_FP64:
 			return "FP2GPR64";
 		}
+
+		return "FPGPRUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -73,6 +73,8 @@ public:
 		case VANADIS_FORMAT_INT32:
 			return "FPINT32ADD";
 		}
+
+		return "FPUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -123,6 +123,8 @@ public:
 			}
 			break;
 		}
+
+		return "FPCONVUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -73,6 +73,8 @@ public:
                 case VANADIS_FORMAT_INT32:
                         return "FPINT32DIV";
                 }
+
+		return "FPUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -73,6 +73,8 @@ public:
 		case VANADIS_FORMAT_INT64:
 			return "FPINT64ADD";
 		}
+
+		return "FPUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -114,6 +114,8 @@ public:
 		case VANADIS_FORMAT_INT32:
 			return "FPINT32CMP";
 		}
+
+		return "FPCNVUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size ) {

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -73,6 +73,8 @@ public:
                 case VANADIS_FORMAT_INT32:
                         return "FPINT32SUB";
                 }
+
+		return "FPUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -68,6 +68,8 @@ public:
 		case VANADIS_FORMAT_FP64:
 			return "GPR2FP64";
 		}
+
+		return "GPRCONVUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/inst/vload.h
+++ b/src/sst/elements/vanadis/inst/vload.h
@@ -91,6 +91,8 @@ public:
 				return "LOADFP";
 			}
 		}
+
+		return "LOADUNK";
 	}
 
 	uint16_t getMemoryAddressRegister() const { return phys_int_regs_in[1]; }

--- a/src/sst/elements/vanadis/inst/vstore.h
+++ b/src/sst/elements/vanadis/inst/vstore.h
@@ -111,6 +111,8 @@ public:
 				}
 			}
 		}
+
+		return "STOREUNK";
 	}
 
 	virtual void printToBuffer(char* buffer, size_t buffer_size) {

--- a/src/sst/elements/vanadis/lsq/vlsqseq.h
+++ b/src/sst/elements/vanadis/lsq/vlsqseq.h
@@ -759,7 +759,7 @@ public:
 protected:
 	void writeTrace( VanadisInstruction* ins, SimpleMem::Request* req ) {
 		if( nullptr != address_trace_file ) {
-			char* req_type = nullptr;
+			const char* req_type = nullptr;
 
 			switch( req->cmd ) {
 			case SimpleMem::Request::Read:   req_type = "READ";    break;
@@ -767,7 +767,7 @@ protected:
 			default:     			 req_type = "UNKNOWN"; break;
 			}
 
-			char* sub_type = "";
+			const char* sub_type = "";
 			if( (req->flags & Interfaces::SimpleMem::Request::F_LLSC) != 0 ) {
 				sub_type = "LLSC";
 			}

--- a/src/sst/elements/vanadis/tools/tracediff/tracediff.cc
+++ b/src/sst/elements/vanadis/tools/tracediff/tracediff.cc
@@ -42,7 +42,7 @@ void read_line( FILE* input_file, char* buffer ) {
 	buffer[next_index] = '\0';
 };
 
-void generate_error( int left_line, int right_line, char* error_msg ) {
+void generate_error( int left_line, int right_line, const char* error_msg ) {
 	fprintf(stderr, "Error left-line: %d, right-line: %d, cause: %s\n",
 		left_line, right_line, error_msg);
 }


### PR DESCRIPTION
FIx up compiler warnings reported by @allevin. These occur in GCC but should be harmless as the enums should include all options.