### PR TITLE
Fix Vanadis Compiler Warning on MacOS

### DIFF
--- a/src/sst/elements/vanadis/inst/vmulsplit.h
+++ b/src/sst/elements/vanadis/inst/vmulsplit.h
@@ -96,7 +96,7 @@ public:
 					const int32_t result_lo       = (int32_t)( multiply_result & 0xFFFFFFFF );
 					const int32_t result_hi       = (int32_t)( multiply_result >> 32UL );
 
-					output->verbose(CALL_INFO, 16, 0, "-> Execute: (detail, signed, MULSPLIT32) %" PRId64 " * %" PRId64 " = %" PRId64 " = (lo: %" PRId64 ", hi: %" PRId64 " )\n",
+					output->verbose(CALL_INFO, 16, 0, "-> Execute: (detail, signed, MULSPLIT32) %" PRId32 " * %" PRId32 " = %" PRId64 " = (lo: %" PRId32 ", hi: %" PRId32 " )\n",
 						src_1, src_2, multiply_result, result_lo, result_hi );
 
 					regFile->setIntReg<int32_t>( phys_int_regs_out[0], result_lo );
@@ -136,7 +136,7 @@ public:
 					const uint32_t result_lo       = (uint32_t)( multiply_result & 0xFFFFFFFF );
 					const uint32_t result_hi       = (uint32_t)( multiply_result >> 32UL );
 
-					output->verbose(CALL_INFO, 16, 0, "-> Execute: (detail, unsigned, MULSPLIT32) %" PRIu64 " * %" PRIu64 " = %" PRIu64 " = (lo: %" PRIu64 ", hi: %" PRIu64 " )\n",
+					output->verbose(CALL_INFO, 16, 0, "-> Execute: (detail, unsigned, MULSPLIT32) %" PRIu32 " * %" PRIu32 " = %" PRIu64 " = (lo: %" PRIu32 ", hi: %" PRIu32 " )\n",
 							src_1, src_2, multiply_result, result_lo, result_hi );
 
 					regFile->setIntReg<uint32_t>( phys_int_regs_out[0], result_lo );

--- a/src/sst/elements/vanadis/os/node/vnodeoswritevh.h
+++ b/src/sst/elements/vanadis/os/node/vnodeoswritevh.h
@@ -107,7 +107,7 @@ public:
                         {
                                 // Write out the payload
 				output->verbose(CALL_INFO, 16, 0, "--> update buffer data-offset: %" PRIu64 " + payload: %" PRIu64 " (iovec-data-len: %" PRIu64 ")\n",
-					current_offset, req->size, current_iovec_length );
+					current_offset, (uint64_t) req->size, current_iovec_length );
 
 				merge_to_buffer( req->data );
                                 current_offset += req->size;

--- a/src/sst/elements/vanadis/os/vnodeoshandler.h
+++ b/src/sst/elements/vanadis/os/vnodeoshandler.h
@@ -552,7 +552,7 @@ public:
 				uint64_t sim_seconds = (uint64_t)( sim_time_ns / 1000000000ULL );
 				uint32_t sim_ns      = (uint32_t)( sim_time_ns % 1000000000ULL );
 
-				output->verbose(CALL_INFO, 16, 0, "[syscall-gettime64] --> sim-time: %" PRIu64 " ns -> %" PRIu32 " secs + %" PRIu32 " us\n",
+				output->verbose(CALL_INFO, 16, 0, "[syscall-gettime64] --> sim-time: %" PRIu64 " ns -> %" PRIu64 " secs + %" PRIu32 " us\n",
 					sim_time_ns, sim_seconds, sim_ns);
 
 				std::vector<uint8_t> seconds_payload;


### PR DESCRIPTION
Fixes compiler warnings for mostly formatting issues in Vanadis when compiling on macOS.
