### PR TITLE
fix a bug about writing data to scratchpad

### DIFF
--- a/src/sst/elements/memHierarchy/scratchpad.cc
+++ b/src/sst/elements/memHierarchy/scratchpad.cc
@@ -1029,7 +1029,7 @@ void Scratchpad::handleRemoteGetResponse(MemEvent * response, SST::Event::id_typ
         // Create write
         uint32_t size = (baseAddr + scratchLineSize_) - addr;
         if (size > bytesLeft) size = bytesLeft;
-        std::vector<uint8_t> data(response->getPayload()[payloadOffset],response->getPayload()[payloadOffset+size]);
+        std::vector<uint8_t> data((response->getPayload()).begin() + payloadOffset, (response->getPayload()).begin() + payloadOffset + size);
         MemEvent * write = new MemEvent(getName(), addr, baseAddr, Command::PutM, data);
         write->setRqstr(request->getRqstr());
         write->setVirtualAddress(request->getDstVirtualAddress());


### PR DESCRIPTION
**Problem:**
After a processor sends a ScratchGet command to the scratchpad and receives a response from the main memory,  the data from the main memory is not written to the scratchpad rightly because of the wrong way of initializing the data vector. 
**Solution:**
The original way of initializing the data vector,
`std::vector<uint8_t> data(response->getPayload()[payloadOffset],response->getPayload()[payloadOffset+size]);` may not copy the response's payload to the data vector correctly.  Because this  form of constructor is matched to the second form, the **fill constructor** about constructing a vector in the [cpp reference about vector](https://www.cplusplus.com/reference/vector/vector/vector/).
So I modified it to match the third one, the **range constructor** in the [cpp reference about vector](https://www.cplusplus.com/reference/vector/vector/vector/).

In this way, it can make my simulation work correct.