### PR TITLE
Fixed issue with rxMatchDelay not getting picked up correctly

### DIFF
--- a/src/sst/elements/firefly/pyfirefly.py
+++ b/src/sst/elements/firefly/pyfirefly.py
@@ -105,7 +105,7 @@ class BasicNicConfiguration(TemplateBase):
             "nic2host_lat",
             "numVNs", "getHdrVN", "getRespLargeVN",
             "getRespSmallVN", "getRespSize",
-            "reMatchDelay_ns", "txDelay_ns",
+            "rxMatchDelay_ns", "txDelay_ns",
             "hostReadDelay_ns",
             "tracedPkt", "tracedNode",
             "maxSendMachineQsize", "maxRecvMachineQSize",


### PR DESCRIPTION
This fixes an issue where the rxMatchDelay doesn't get picked up when initialising the NIC in firefly. 