### PR TITLE
Add llvm-config Check to Builder

### DIFF
--- a/config/sst_check_llvm_config.m4
+++ b/config/sst_check_llvm_config.m4
@@ -1,0 +1,28 @@
+AC_DEFUN([SST_CHECK_LLVM_CONFIG],
+[
+    sst_check_llvm_config_happy="no"
+
+    AC_ARG_WITH([llvm-config],
+                [AS_HELP_STRING([--with-llvm-config],
+                    [llvm-config must be in the PATH])],
+    )
+
+    AC_MSG_CHECKING(for llvm-config)
+    llvm_config_test=$(llvm-config --version 2> /dev/null || echo no)
+    if test ! -z x"$llvm_config_test" -a x"$llvm_config_test" != x"no"; then
+        AC_MSG_RESULT([yes])
+        LLVM_CFLAGS="`llvm-config --cflags`"
+        LLVM_CPPFLAGS="`llvm-config --cxxflags`"
+        LLVM_LDFLAGS="`llvm-config --ldflags --libs`"
+    else
+        AC_MSG_RESULT([no])
+    fi
+
+    LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/\n//g'`"
+    LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/-lgtest_main -lgtest//g'`"
+
+    AC_SUBST(LLVM_CFLAGS)
+    AC_SUBST(LLVM_CPPFLAGS)
+    AC_SUBST(LLVM_LDFLAGS)
+])
+

--- a/config/sst_check_llvm_config.m4
+++ b/config/sst_check_llvm_config.m4
@@ -1,28 +1,32 @@
 AC_DEFUN([SST_CHECK_LLVM_CONFIG],
 [
-    sst_check_llvm_config_happy="no"
+   sst_check_llvm_config_happy="yes"
+   AS_IF([test "$with_llvm_config" = "no"], [sst_check_llvm_config_happy="no"])
 
-    AC_ARG_WITH([llvm-config],
-                [AS_HELP_STRING([--with-llvm-config],
-                    [llvm-config must be in the PATH])],
-    )
+   AC_ARG_WITH([llvm-config],
+               [AS_HELP_STRING([--with-llvm-config],
+                  [llvm-config must be in the PATH])],
+   )
 
-    AC_MSG_CHECKING(for llvm-config)
-    llvm_config_test=$(llvm-config --version 2> /dev/null || echo no)
-    if test ! -z x"$llvm_config_test" -a x"$llvm_config_test" != x"no"; then
-        AC_MSG_RESULT([yes])
-        LLVM_CFLAGS="`llvm-config --cflags`"
-        LLVM_CPPFLAGS="`llvm-config --cxxflags`"
-        LLVM_LDFLAGS="`llvm-config --ldflags --libs`"
-    else
-        AC_MSG_RESULT([no])
-    fi
+   AC_MSG_CHECKING(for llvm-config)
+   llvm_config_test=$(llvm-config --version 2> /dev/null || echo no)
+   if test ! -z x"$llvm_config_test" -a x"$llvm_config_test" != x"no"; then
+      AC_MSG_RESULT([yes])
+      LLVM_CFLAGS="`llvm-config --cflags`"
+      LLVM_CPPFLAGS="`llvm-config --cxxflags`"
+      LLVM_LDFLAGS="`llvm-config --ldflags --libs`"
+   else
+      sst_check_llvm_config_happy="no"
+      AC_MSG_RESULT([no])
+   fi
 
-    LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/\n//g'`"
-    LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/-lgtest_main -lgtest//g'`"
+   LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/\n//g'`"
+   LLVM_LDFLAGS="`echo ${LLVM_LDFLAGS} | sed 's/-lgtest_main -lgtest//g'`"
 
-    AC_SUBST(LLVM_CFLAGS)
-    AC_SUBST(LLVM_CPPFLAGS)
-    AC_SUBST(LLVM_LDFLAGS)
+   AC_SUBST(LLVM_CFLAGS)
+   AC_SUBST(LLVM_CPPFLAGS)
+   AC_SUBST(LLVM_LDFLAGS)
+
+   AS_IF([test "$sst_check_llvm_config_happy" = "yes"], [$1], [$2])
 ])
 

--- a/config/sst_check_llvm_config.m4
+++ b/config/sst_check_llvm_config.m4
@@ -1,16 +1,20 @@
 AC_DEFUN([SST_CHECK_LLVM_CONFIG],
 [
    sst_check_llvm_config_happy="yes"
-   AS_IF([test "$with_llvm_config" = "no"], [sst_check_llvm_config_happy="no"])
 
    AC_ARG_WITH([llvm-config],
                [AS_HELP_STRING([--with-llvm-config],
                   [llvm-config must be in the PATH])],
    )
 
+   AS_IF([test ! -z "$with_llvm_config" -a "$with_llvm_config" = "yes"],
+         [],
+         [sst_check_llvm_config_happy="no"]
+         )
+
    AC_MSG_CHECKING(for llvm-config)
    llvm_config_test=$(llvm-config --version 2> /dev/null || echo no)
-   if test ! -z x"$llvm_config_test" -a x"$llvm_config_test" != x"no"; then
+   if test ! -z "$llvm_config_test" -a "$llvm_config_test" != "no" -a "$with_llvm_config" = "yes"; then
       AC_MSG_RESULT([yes])
       LLVM_CFLAGS="`llvm-config --cflags`"
       LLVM_CPPFLAGS="`llvm-config --cxxflags`"


### PR DESCRIPTION
Added flag, --with-llvm-config to build system

-llvm-config must be in user path
-calls llvm-config to add CFLAGS, CXXFLAGS, and LDFLAGS