### PR TITLE
Adding skips to openMP and sweep tests if PIN is not loaded

### DIFF
--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
@@ -42,27 +42,37 @@ class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
 
 ####
 
+    pin_loaded = testing_is_PIN_loaded()
+
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompatomic(self):
         self.memH_test_template("ompatomic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompapi(self):
         self.memH_test_template("ompapi")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompbarrier(self):
         self.memH_test_template("ompbarrier")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompcritical(self):
         self.memH_test_template("ompcritical")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompdynamic(self):
         self.memH_test_template("ompdynamic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompreduce(self):
         self.memH_test_template("ompreduce")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_ompthrcount(self):
         self.memH_test_template("ompthrcount")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_dirnoncacheable_omptriangle(self):
         self.memH_test_template("omptriangle")
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
@@ -42,30 +42,41 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
 
 ####
 
+    pin_loaded = testing_is_PIN_loaded()
+
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompatomic(self):
         self.memH_test_template("ompatomic")
-        
+
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompatomicShort(self):
         self.memH_test_template("ompatomicShort")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompapi(self):
         self.memH_test_template("ompapi")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompbarrier(self):
         self.memH_test_template("ompbarrier")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompcritical(self):
         self.memH_test_template("ompcritical")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompdynamic(self):
         self.memH_test_template("ompdynamic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompreduce(self):
         self.memH_test_template("ompreduce")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_ompthrcount(self):
         self.memH_test_template("ompthrcount")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_diropenMP_omptriangle(self):
         self.memH_test_template("omptriangle")
 
@@ -138,7 +149,7 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
                         log_failure("FAILURE: openMP diropenMP Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "openMP diropenMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
@@ -41,28 +41,37 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
         super(type(self), self).tearDown()
 
 ####
+    pin_loaded = testing_is_PIN_loaded()
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompatomic(self):
         self.memH_test_template("ompatomic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompapi(self):
         self.memH_test_template("ompapi")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompbarrier(self):
         self.memH_test_template("ompbarrier")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompcritical(self):
         self.memH_test_template("ompcritical")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompdynamic(self):
         self.memH_test_template("ompdynamic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompreduce(self):
         self.memH_test_template("ompreduce")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_ompthrcount(self):
         self.memH_test_template("ompthrcount")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_noncacheable_omptriangle(self):
         self.memH_test_template("omptriangle")
 
@@ -135,7 +144,7 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
                         log_failure("FAILURE: openMP noncacheable Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "openMP noncacheable testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
@@ -42,30 +42,41 @@ class testcase_memH_openMP_openMP(SSTTestCase):
 
 ####
 
+    pin_loaded = testing_is_PIN_loaded()
+
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompmybarrier(self):
         self.memH_test_template("ompmybarrier")
-        
+
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompatomic(self):
         self.memH_test_template("ompatomic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompapi(self):
         self.memH_test_template("ompapi")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompbarrier(self):
         self.memH_test_template("ompbarrier")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompcritical(self):
         self.memH_test_template("ompcritical")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompdynamic(self):
         self.memH_test_template("ompdynamic")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompreduce(self):
         self.memH_test_template("ompreduce")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_ompthrcount(self):
         self.memH_test_template("ompthrcount")
 
+    @unittest.skipIf(not pin_loaded, "openMP_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
     def test_openMP_omptriangle(self):
         self.memH_test_template("omptriangle")
 
@@ -138,7 +149,7 @@ class testcase_memH_openMP_openMP(SSTTestCase):
                         log_failure("FAILURE: openMP openMP Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "openMP openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
@@ -272,13 +272,18 @@ class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
                         log_failure("FAILURE: Sweep dir3LevelSweep Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "Sweep dir3LevelSweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 
     def _checkSkipConditions(self, testindex):
+        # Check to see if PIN is loaded
+        pin_loaded = testing_is_PIN_loaded()
+        if not pin_loaded:
+            self.skipTest("Skipping Test #{0} - sweep_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.".format(testindex))
+
         # Check to see if Env Var SST_SWEEP_dir3levelsweep_LIST is set limiting which tests to run
         #   An inclusive sub-list may be specified as "first-last"  (e.g. 7-10)
         env_var = 'SST_SWEEP_dir3levelsweep_LIST'

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
@@ -243,13 +243,18 @@ class testcase_memH_sweep_dirsweep(SSTTestCase):
                         log_failure("FAILURE: Sweep dirsweep Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "Sweep dirsweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 
     def _checkSkipConditions(self, testindex):
+        # Check to see if PIN is loaded
+        pin_loaded = testing_is_PIN_loaded()
+        if not pin_loaded:
+            self.skipTest("Skipping Test #{0} - sweep_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.".format(testindex))
+
         # Check to see if Env Var SST_SWEEP_dirsweep_LIST is set limiting which tests to run
         #   An inclusive sub-list may be specified as "first-last"  (e.g. 7-10)
         env_var = 'SST_SWEEP_dirsweep_LIST'

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
@@ -245,13 +245,18 @@ class testcase_memH_sweep_dirsweepB(SSTTestCase):
                         log_failure("FAILURE: Sweep dirsweepB Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "Sweep dirsweepB testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 
     def _checkSkipConditions(self, testindex):
+        # Check to see if PIN is loaded
+        pin_loaded = testing_is_PIN_loaded()
+        if not pin_loaded:
+            self.skipTest("Skipping Test #{0} - sweep_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.".format(testindex))
+
         # Check to see if Env Var SST_SWEEP_dirsweepB_LIST is set limiting which tests to run
         #   An inclusive sub-list may be specified as "first-last"  (e.g. 7-10)
         env_var = 'SST_SWEEP_dirsweepB_LIST'

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
@@ -255,13 +255,18 @@ class testcase_memH_sweep_dirsweepI(SSTTestCase):
                         log_failure("FAILURE: Sweep dirsweepI Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "Sweep dirsweepI testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 
     def _checkSkipConditions(self, testindex):
+        # Check to see if PIN is loaded
+        pin_loaded = testing_is_PIN_loaded()
+        if not pin_loaded:
+            self.skipTest("Skipping Test #{0} - sweep_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.".format(testindex))
+
         # Check to see if Env Var SST_SWEEP_dirsweepI_LIST is set limiting which tests to run
         #   An inclusive sub-list may be specified as "first-last"  (e.g. 7-10)
         env_var = 'SST_SWEEP_dirsweepI_LIST'

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
@@ -243,13 +243,18 @@ class testcase_memH_sweep_openMP(SSTTestCase):
                         log_failure("FAILURE: Sweep openMP Test failed running cmdline {0} - grepping outfile {1}".format(cmd, outfile))
 
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
-                    
+
                     # Compare the count
                     self.assertEquals(outcount, refcount, "Sweep openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 
     def _checkSkipConditions(self, testindex):
+        # Check to see if PIN is loaded
+        pin_loaded = testing_is_PIN_loaded()
+        if not pin_loaded:
+            self.skipTest("Skipping Test #{0} - sweep_memHierarchy: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.".format(testindex))
+
         # Check to see if Env Var SST_SWEEP_openMP_LIST is set limiting which tests to run
         #   An inclusive sub-list may be specified as "first-last"  (e.g. 7-10)
         env_var = 'SST_SWEEP_openMP_LIST'


### PR DESCRIPTION
Fix for issue #1650 

Added checks for PIN on all memH sweep and openMP tests.  These tests are special case tests that are normally only run on a Linux machine with PIN installed.  They are not normally run on other platforms.