### PR TITLE
SST::Fifrefly::Nic::dmaSend uses incorrect notify*Done callback

### DIFF
--- a/src/sst/elements/firefly/nic.cc
+++ b/src/sst/elements/firefly/nic.cc
@@ -454,7 +454,7 @@ void Nic::handleVnicEvent2( Event* ev, int id )
 
 void Nic::dmaSend( NicCmdEvent *e, int vNicNum )
 {
-    std::function<void(void*)> callback = std::bind( &Nic::notifySendPioDone, this, vNicNum, _1 );
+    std::function<void(void*)> callback = std::bind( &Nic::notifySendDmaDone, this, vNicNum, _1 );
 
     CmdSendEntry* entry = new CmdSendEntry( vNicNum, e, callback );
 


### PR DESCRIPTION
Disclaimer: I do not know how to test if this change is correct, but:

By chance, when working on extending Firefly, I found this.

`Nic::dmaSend` uses the same callback as `Nic::pioSend` even though there is a matching callback in the `Nic::notify*Done` member functions. This does feel unintentional and looks like a bug.

Thank for looking into it. It does not affect me, but possibly someone else.