### PR TITLE
Either a typo or a duplicate key

### DIFF
--- a/src/sst/elements/ember/test/defaultParams.py
+++ b/src/sst/elements/ember/test/defaultParams.py
@@ -120,7 +120,7 @@ hermesParams = {
     "hermesParams.ctrlMsg.txMemcpyModParams.range.0" : "0-:344ps",
 
     "hermesParams.ctrlMsg.rxMemcpyMod" : "firefly.LatencyMod",
-    "hermesParams.ctrlMsg.txMemcpyModParams.op" : "Mult",
+    "hermesParams.ctrlMsg.rxMemcpyModParams.op" : "Mult",
     "hermesParams.ctrlMsg.rxMemcpyModParams.range.0" : "0-:344ps",
 
     "hermesParams.ctrlMsg.sendAckDelay_ns" : 0,


### PR DESCRIPTION
Either the definition of this value is a typo (rxMemcpyModParams instead of txMemcpyModParams) or the definition of this key is duplicate of the one line 119 above.
I do suspect the first is the case.