### PR TITLE
Vanadis add check for Endian in ELF Format Checks

### DIFF
--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -388,6 +388,11 @@ public:
             vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getAlignment());
         }
 
+	// Check endian-ness
+	if( elf_info->getEndian() != 1 ) {
+	    output->fatal(CALL_INFO, -1, "Error: binary executable ELF information shows this was not compiled for little-endian processors (\"mipsel\"), please recompile to a supported format.\n");
+	}
+
         const uint64_t phdr_address = params.find<uint64_t>("program_header_address", 0x60000000);
 
         std::vector<uint8_t> random_values_data_block;

--- a/src/sst/elements/vanadis/velf/velfinfo.h
+++ b/src/sst/elements/vanadis/velf/velfinfo.h
@@ -560,6 +560,7 @@ public:
     const char* getBinaryPath() const { return bin_path; }
 
     uint64_t getEntryPoint() const { return elf_entry_point; }
+    uint8_t  getEndian() const { return elf_endian; }
     uint64_t getProgramHeaderOffset() const { return elf_prog_header_start; }
     uint64_t getSectionHeaderOffset() const { return elf_prog_section_start; }
 


### PR DESCRIPTION
Perform a check for the endianness of the executable during ELF load. If this is not a supported type, then fatal. 

This is reported by @calewis in PR #1693.