### PR TITLE
memH ELI fix for FlagMemBackendConvertor

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/flagMemBackendConvertor.h
+++ b/src/sst/elements/memHierarchy/membackend/flagMemBackendConvertor.h
@@ -28,7 +28,7 @@ public:
     SST_ELI_REGISTER_SUBCOMPONENT_DERIVED_API(SST::MemHierarchy::FlagMemBackendConvertor, SST::MemHierarchy::MemBackendConvertor, MemBackend*, uint32_t)
 
     SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(FlagMemBackendConvertor, "memHierarchy", "flagMemBackendConvertor", SST_ELI_ELEMENT_VERSION(1,0,0),
-            "Convert MemEventBase* for a FlagMemBackend - accepts and returns the 'flags' field", SST::MemHierarchy::MemBackendConvertor)
+            "Convert MemEventBase* for a FlagMemBackend - accepts and returns the 'flags' field", SST::MemHierarchy::FlagMemBackendConvertor)
 
     SST_ELI_DOCUMENT_PARAMS( MEMBACKENDCONVERTOR_ELI_PARAMS )
 


### PR DESCRIPTION
Changed FlagMemBackendConvertor to use itself as the subcomp API instead of MemBackendConvertor.
