### PR TITLE
Optimize Micro-op Definitions with Templates instead of Parameters for Known Characteristics

### DIFF
--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -1027,21 +1027,21 @@ protected:
                         output->verbose(CALL_INFO, 16, 0,
                                         "[decode] -> rs is also zero, implies truncate "
                                         "(generate: 64 to 32 truncate)\n");
-                        bundle->addInstruction(new VanadisTruncateInstruction(
-                            ins_addr, hw_thr, options, rd, rt, VANADIS_FORMAT_INT64, VANADIS_FORMAT_INT32));
+                        bundle->addInstruction(new VanadisTruncateInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                            ins_addr, hw_thr, options, rd, rt));
                         insertDecodeFault = false;
                     } else {
                         switch (func_mask) {
                         case MIPS_SPEC_OP_MASK_ADD: {
-                            bundle->addInstruction(new VanadisAddInstruction(ins_addr, hw_thr, options, rd, rs, rt,
-                                                                             true, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(ins_addr, hw_thr, options, rd, rs, rt
+                                                                            ));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_add);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_ADDU: {
-                            bundle->addInstruction(new VanadisAddInstruction(ins_addr, hw_thr, options, rd, rs, rt,
-                                                                             true, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(ins_addr, hw_thr, options, rd, rs, rt
+                                                                             ));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_addu);
                         } break;
@@ -1068,16 +1068,16 @@ protected:
 
                         case MIPS_SPEC_OP_MASK_DIV: {
                             bundle->addInstruction(
-                                new VanadisDivideRemainderInstruction(ins_addr, hw_thr, options, MIPS_REG_LO,
-                                                                      MIPS_REG_HI, rs, rt, true, VANADIS_FORMAT_INT32));
+                                new VanadisDivideRemainderInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(ins_addr, hw_thr, options, MIPS_REG_LO,
+                                                                      MIPS_REG_HI, rs, rt));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_div);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_DIVU: {
-                            bundle->addInstruction(new VanadisDivideRemainderInstruction(
-                                ins_addr, hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt, false,
-                                VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisDivideRemainderInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(
+                                ins_addr, hw_thr, options, MIPS_REG_LO, MIPS_REG_HI, rs, rt
+                                ));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_divu);
                         } break;
@@ -1120,16 +1120,16 @@ protected:
 
                         case MIPS_SPEC_OP_MASK_MFHI: {
                             // Special instruction_, 32 is LO, 33 is HI
-                            bundle->addInstruction(new VanadisAddImmInstruction(ins_addr, hw_thr, options, rd,
-                                                                                MIPS_REG_HI, 0, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisAddImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rd,
+                                                                                MIPS_REG_HI, 0));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_mfhi);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_MFLO: {
                             // Special instruction, 32 is LO, 33 is HI
-                            bundle->addInstruction(new VanadisAddImmInstruction(ins_addr, hw_thr, options, rd,
-                                                                                MIPS_REG_LO, 0, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisAddImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rd,
+                                                                                MIPS_REG_LO, 0));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_mflo);
                         } break;
@@ -1153,17 +1153,15 @@ protected:
                             break;
 
                         case MIPS_SPEC_OP_MASK_MULT: {
-                            bundle->addInstruction(new VanadisMultiplySplitInstruction(ins_addr, hw_thr, options,
-                                                                                       MIPS_REG_LO, MIPS_REG_HI, rs, rt,
-                                                                                       true, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisMultiplySplitInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(ins_addr, hw_thr, options,
+                                                                                       MIPS_REG_LO, MIPS_REG_HI, rs, rt));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_mult);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_MULTU: {
-                            bundle->addInstruction(new VanadisMultiplySplitInstruction(ins_addr, hw_thr, options,
-                                                                                       MIPS_REG_LO, MIPS_REG_HI, rs, rt,
-                                                                                       false, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisMultiplySplitInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(ins_addr, hw_thr, options,
+                                                                                       MIPS_REG_LO, MIPS_REG_HI, rs, rt));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_multu);;
                         } break;
@@ -1181,50 +1179,50 @@ protected:
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SLLV: {
-                            bundle->addInstruction(new VanadisShiftLeftLogicalInstruction(
-                                ins_addr, hw_thr, options, rd, rt, rs, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisShiftLeftLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                                ins_addr, hw_thr, options, rd, rt, rs));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_sllv);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SLT: {
-                            bundle->addInstruction(new VanadisSetRegCompareInstruction(
-                                ins_addr, hw_thr, options, rd, rs, rt, true, REG_COMPARE_LT, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(
+                                ins_addr, hw_thr, options, rd, rs, rt));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_slt);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SLTU: {
-                            bundle->addInstruction(new VanadisSetRegCompareInstruction(
-                                ins_addr, hw_thr, options, rd, rs, rt, false, REG_COMPARE_LT, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(
+                                ins_addr, hw_thr, options, rd, rs, rt));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_sltu);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SRAV: {
-                            bundle->addInstruction(new VanadisShiftRightArithmeticInstruction(
-                                ins_addr, hw_thr, options, rd, rt, rs, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisShiftRightArithmeticInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                                ins_addr, hw_thr, options, rd, rt, rs));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_srav);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SRLV: {
-                            bundle->addInstruction(new VanadisShiftRightLogicalInstruction(
-                                ins_addr, hw_thr, options, rd, rt, rs, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisShiftRightLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                                ins_addr, hw_thr, options, rd, rt, rs));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_srlv);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SUB: {
-                            bundle->addInstruction(new VanadisSubInstruction(ins_addr, hw_thr, options, rd, rs, rt,
-                                                                             true, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rd, rs, rt,
+                                                                             true));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_sub);
                         } break;
 
                         case MIPS_SPEC_OP_MASK_SUBU: {
-                            bundle->addInstruction(new VanadisSubInstruction(ins_addr, hw_thr, options, rd, rs, rt,
-                                                                             false, VANADIS_FORMAT_INT32));
+                            bundle->addInstruction(new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rd, rs, rt,
+                                                                             false));
                             insertDecodeFault = false;
 			    MIPS_INC_DECODE_STAT(stat_decode_subu);
                         } break;
@@ -1258,8 +1256,8 @@ protected:
                                         "[decode/SLL]-> out: %" PRIu16 " / in: %" PRIu16 " shft: %" PRIu64 "\n", rd, rt,
                                         shf_amnt);
 
-                        bundle->addInstruction(new VanadisShiftLeftLogicalImmInstruction(
-                            ins_addr, hw_thr, options, rd, rt, shf_amnt, VANADIS_FORMAT_INT32));
+                        bundle->addInstruction(new VanadisShiftLeftLogicalImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                            ins_addr, hw_thr, options, rd, rt, shf_amnt));
                         insertDecodeFault = false;
                         MIPS_INC_DECODE_STAT(stat_decode_sll);
                     } break;
@@ -1271,8 +1269,8 @@ protected:
                                         "[decode/SRL]-> out: %" PRIu16 " / in: %" PRIu16 " shft: %" PRIu64 "\n", rd, rt,
                                         shf_amnt);
 
-                        bundle->addInstruction(new VanadisShiftRightLogicalImmInstruction(
-                            ins_addr, hw_thr, options, rd, rt, shf_amnt, VANADIS_FORMAT_INT32));
+                        bundle->addInstruction(new VanadisShiftRightLogicalImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                            ins_addr, hw_thr, options, rd, rt, shf_amnt));
                         insertDecodeFault = false;
                         MIPS_INC_DECODE_STAT(stat_decode_srl);
                     } break;
@@ -1280,8 +1278,8 @@ protected:
                     case MIPS_SPEC_OP_MASK_SRA: {
                         const uint64_t shf_amnt = ((uint64_t)(next_ins & MIPS_SHFT_MASK)) >> 6;
 
-                        bundle->addInstruction(new VanadisShiftRightArithmeticImmInstruction(
-                            ins_addr, hw_thr, options, rd, rt, shf_amnt, VANADIS_FORMAT_INT32));
+                        bundle->addInstruction(new VanadisShiftRightArithmeticImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                            ins_addr, hw_thr, options, rd, rt, shf_amnt));
                         insertDecodeFault = false;
                         MIPS_INC_DECODE_STAT(stat_decode_sra);
                     } break;
@@ -1487,23 +1485,21 @@ protected:
 
                 switch ((next_ins & MIPS_RT_MASK)) {
                 case MIPS_SPEC_OP_MASK_BLTZ: {
-                    bundle->addInstruction(new VanadisBranchRegCompareImmInstruction(
-                        ins_addr, hw_thr, options, rs, 0, offset_value_64, VANADIS_SINGLE_DELAY_SLOT, REG_COMPARE_LT,
-                        VANADIS_FORMAT_INT32));
+                    bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_LT>(
+                        ins_addr, hw_thr, options, rs, 0, offset_value_64, VANADIS_SINGLE_DELAY_SLOT));
                     insertDecodeFault = false;
 		    MIPS_INC_DECODE_STAT(stat_decode_bltz);
                 } break;
                 case MIPS_SPEC_OP_MASK_BGEZAL: {
-                    bundle->addInstruction(new VanadisBranchRegCompareImmLinkInstruction(
-                        ins_addr, hw_thr, options, rs, 0, offset_value_64, (uint16_t)31, VANADIS_SINGLE_DELAY_SLOT,
-                        REG_COMPARE_GTE, VANADIS_FORMAT_INT32));
+                    bundle->addInstruction(new VanadisBranchRegCompareImmLinkInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_GTE>(
+                        ins_addr, hw_thr, options, rs, 0, offset_value_64, (uint16_t)31, VANADIS_SINGLE_DELAY_SLOT
+                        ));
                     insertDecodeFault = false;
 		    MIPS_INC_DECODE_STAT(stat_decode_bgezal);
                 } break;
                 case MIPS_SPEC_OP_MASK_BGEZ: {
-                    bundle->addInstruction(new VanadisBranchRegCompareImmInstruction(
-                        ins_addr, hw_thr, options, rs, 0, offset_value_64, VANADIS_SINGLE_DELAY_SLOT, REG_COMPARE_GTE,
-                        VANADIS_FORMAT_INT32));
+                    bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_GTE>(
+                        ins_addr, hw_thr, options, rs, 0, offset_value_64, VANADIS_SINGLE_DELAY_SLOT));
                     insertDecodeFault = false;
 		    MIPS_INC_DECODE_STAT(stat_decode_bgez);
                 } break;
@@ -1517,8 +1513,8 @@ protected:
                 //				output->verbose(CALL_INFO, 16, 0,
                 //"[decoder/LUI] -> reg: %" PRIu16 " / imm=%" PRId64 "\n", 					rt,
                 // imm_value_64);
-                bundle->addInstruction(new VanadisSetRegisterInstruction(ins_addr, hw_thr, options, rt, imm_value_64,
-                                                                         VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisSetRegisterInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rt, imm_value_64
+                                                                         ));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_lui);
             } break;
@@ -1528,8 +1524,8 @@ protected:
                 //				output->verbose(CALL_INFO, 16, 0,
                 //"[decoder/ADDIU]: -> reg: %" PRIu16 " rs=%" PRIu16 " / imm=%" PRId64
                 //"\n", 					rt, rs, imm_value_64);
-                bundle->addInstruction(new VanadisAddImmInstruction(ins_addr, hw_thr, options, rt, rs, imm_value_64,
-                                                                    VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisAddImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, rt, rs, imm_value_64
+                                                                    ));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_addiu);
             } break;
@@ -1541,9 +1537,9 @@ protected:
                 //"[decoder/BEQ]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64
                 //"\n",
                 //                                        rt, rs, imm_value_64 );
-                bundle->addInstruction(new VanadisBranchRegCompareInstruction(ins_addr, hw_thr, options, rt, rs,
-                                                                              imm_value_64, VANADIS_SINGLE_DELAY_SLOT,
-                                                                              REG_COMPARE_EQ, VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisBranchRegCompareInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_EQ>(ins_addr, hw_thr, options, rt, rs,
+                                                                              imm_value_64, VANADIS_SINGLE_DELAY_SLOT
+                                                                              ));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_beq);
             } break;
@@ -1554,9 +1550,8 @@ protected:
                 //				output->verbose(CALL_INFO, 16, 0,
                 //"[decoder/BGTZ]: -> r1: %" PRIu16 " offset: %" PRId64 "\n",
                 //                                        rs, imm_value_64);
-                bundle->addInstruction(new VanadisBranchRegCompareImmInstruction(
-                    ins_addr, hw_thr, options, rs, 0, imm_value_64, VANADIS_SINGLE_DELAY_SLOT, REG_COMPARE_GT,
-                    VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_GT>(
+                    ins_addr, hw_thr, options, rs, 0, imm_value_64, VANADIS_SINGLE_DELAY_SLOT));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_bgtz);
             } break;
@@ -1567,9 +1562,8 @@ protected:
                 //				output->verbose(CALL_INFO, 16, 0,
                 //"[decoder/BLEZ]: -> r1: %" PRIu16 " offset: %" PRId64 "\n",
                 //                                        rs, imm_value_64);
-                bundle->addInstruction(new VanadisBranchRegCompareImmInstruction(
-                    ins_addr, hw_thr, options, rs, 0, imm_value_64, VANADIS_SINGLE_DELAY_SLOT, REG_COMPARE_LTE,
-                    VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_LTE>(
+                    ins_addr, hw_thr, options, rs, 0, imm_value_64, VANADIS_SINGLE_DELAY_SLOT));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_blez);
             } break;
@@ -1581,9 +1575,9 @@ protected:
                 //"[decoder/BNE]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64
                 //"\n",
                 //                                        rt, rs, imm_value_64 );
-                bundle->addInstruction(new VanadisBranchRegCompareInstruction(ins_addr, hw_thr, options, rt, rs,
-                                                                              imm_value_64, VANADIS_SINGLE_DELAY_SLOT,
-                                                                              REG_COMPARE_NEQ, VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisBranchRegCompareInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, REG_COMPARE_NEQ>(ins_addr, hw_thr, options, rt, rs,
+                                                                              imm_value_64, VANADIS_SINGLE_DELAY_SLOT
+                                                                              ));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_bne);
             } break;
@@ -1595,8 +1589,8 @@ protected:
                 //"[decoder/SLTI]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64
                 //"\n",
                 //                                        rt, rs, imm_value_64 );
-                bundle->addInstruction(new VanadisSetRegCompareImmInstruction(
-                    ins_addr, hw_thr, options, rt, rs, imm_value_64, true, REG_COMPARE_LT, VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisSetRegCompareImmInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(
+                    ins_addr, hw_thr, options, rt, rs, imm_value_64));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_slti);
             } break;
@@ -1608,8 +1602,8 @@ protected:
                 //"[decoder/SLTIU]: -> r1: %" PRIu16 " r2: %" PRIu16 " offset: %" PRId64
                 //"\n",
                 //                                        rt, rs, imm_value_64 );
-                bundle->addInstruction(new VanadisSetRegCompareImmInstruction(
-                    ins_addr, hw_thr, options, rt, rs, imm_value_64, false, REG_COMPARE_LT, VANADIS_FORMAT_INT32));
+                bundle->addInstruction(new VanadisSetRegCompareImmInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(
+                    ins_addr, hw_thr, options, rt, rs, imm_value_64));
                 insertDecodeFault = false;
                 MIPS_INC_DECODE_STAT(stat_decode_sltiu);
             } break;
@@ -1717,11 +1711,11 @@ protected:
                     case 0: {
                         if ((0 == fd) && (MIPS_SPEC_COP_MASK_MTC == fr)) {
                             bundle->addInstruction(
-                                new VanadisGPR2FPInstruction(ins_addr, hw_thr, options, fs, rt, VANADIS_FORMAT_FP32));
+                                new VanadisGPR2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fs, rt));
                             insertDecodeFault = false;
                         } else if ((0 == fd) && (MIPS_SPEC_COP_MASK_MFC == fr)) {
                             bundle->addInstruction(
-                                new VanadisFP2GPRInstruction(ins_addr, hw_thr, options, rt, fs, VANADIS_FORMAT_FP32));
+                                new VanadisFP2GPRInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, rt, fs));
                             insertDecodeFault = false;
                         } else if ((0 == fd) && (MIPS_SPEC_COP_MASK_CF == fr)) {
                             uint16_t fp_ctrl_reg = 0;
@@ -1741,8 +1735,8 @@ protected:
                             }
 
                             if (fp_matched) {
-                                bundle->addInstruction(new VanadisFP2GPRInstruction(ins_addr, hw_thr, options, rt,
-                                                                                    fp_ctrl_reg, VANADIS_FORMAT_FP32));
+                                bundle->addInstruction(new VanadisFP2GPRInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, rt,
+                                                                                    fp_ctrl_reg));
                                 insertDecodeFault = false;
                             }
                         } else if ((0 == fd) && (MIPS_SPEC_COP_MASK_CT == fr)) {
@@ -1763,37 +1757,34 @@ protected:
                             }
 
                             if (fp_matched) {
-                                bundle->addInstruction(new VanadisGPR2FPInstruction(
-                                    ins_addr, hw_thr, options, fp_ctrl_reg, rt, VANADIS_FORMAT_FP32));
+                                bundle->addInstruction(new VanadisGPR2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
+                                    ins_addr, hw_thr, options, fp_ctrl_reg, rt));
                                 insertDecodeFault = false;
                             }
                         } else {
-                            // assume this is an FADD and begin decode
-                            VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                            bool format_fault = false;
-
                             switch (fr) {
                             case 16:
-                                input_format = VANADIS_FORMAT_FP32;
+                                bundle->addInstruction(
+                                    new VanadisFPAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs, ft));
+                                insertDecodeFault = false;
                                 break;
                             case 17:
-                                input_format = VANADIS_FORMAT_FP64;
+                                bundle->addInstruction(
+                                    new VanadisFPAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs, ft));
+                                insertDecodeFault = false;
                                 break;
                             case 20:
-                                input_format = VANADIS_FORMAT_INT32;
+                                bundle->addInstruction(
+                                    new VanadisFPAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs, ft));
+                                insertDecodeFault = false;
                                 break;
                             case 21:
-                                input_format = VANADIS_FORMAT_INT64;
+                                bundle->addInstruction(
+                                    new VanadisFPAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(ins_addr, hw_thr, options, fd, fs, ft));
+                                insertDecodeFault = false;
                                 break;
                             default:
-                                format_fault = true;
                                 break;
-                            }
-
-                            if (!format_fault) {
-                                bundle->addInstruction(
-                                    new VanadisFPAddInstruction(ins_addr, hw_thr, options, fd, fs, ft, input_format));
-                                insertDecodeFault = false;
                             }
                         }
                     } break;
@@ -1803,12 +1794,12 @@ protected:
                         switch (fr) {
                         case 16: {
                             bundle->addInstruction(
-                                new VanadisFP2FPInstruction(ins_addr, hw_thr, options, fd, fs, VANADIS_FORMAT_FP32));
+                                new VanadisFP2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs));
                             insertDecodeFault = false;
                         } break;
                         case 17: {
                             bundle->addInstruction(
-                                new VanadisFP2FPInstruction(ins_addr, hw_thr, options, fd, fs, VANADIS_FORMAT_FP64));
+                                new VanadisFP2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs));
                             insertDecodeFault = false;
                         } break;
                         }
@@ -1817,175 +1808,150 @@ protected:
                     } break;
 
                     case MIPS_SPEC_COP_MASK_MUL: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(
+                                new VanadisFPMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(
+                                new VanadisFPMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(
+                                new VanadisFPMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(
+                                new VanadisFPMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(
-                                new VanadisFPMultiplyInstruction(ins_addr, hw_thr, options, fd, fs, ft, input_format));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_mul);
                     } break;
 
                     case MIPS_SPEC_COP_MASK_DIV: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(
+                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(
+                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(
+                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(
+                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
+
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(
-                                new VanadisFPDivideInstruction(ins_addr, hw_thr, options, fd, fs, ft, input_format));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_div);
                     } break;
 
                     case MIPS_SPEC_COP_MASK_SUB: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(
+                                new VanadisFPSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(
+                                new VanadisFPSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(
+                                new VanadisFPSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(
+                                new VanadisFPSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(ins_addr, hw_thr, options, fd, fs, ft));
+                            insertDecodeFault = false;
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(
-                                new VanadisFPSubInstruction(ins_addr, hw_thr, options, fd, fs, ft, input_format));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_sub);
                     } break;
 
                     case MIPS_SPEC_COP_MASK_CVTS: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP32;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(new VanadisFPConvertInstruction(ins_addr, hw_thr, options, fd, fs,
-                                                                                   input_format, VANADIS_FORMAT_FP32));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_cvts);
                     } break;
 
                     case MIPS_SPEC_COP_MASK_CVTD: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs
+                                                                                   ));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs
+                                                                                   ));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs
+                                                                                   ));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64,
+											VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_addr, hw_thr, options, fd, fs
+                                                                                   ));
+                            insertDecodeFault = false;
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(new VanadisFPConvertInstruction(ins_addr, hw_thr, options, fd, fs,
-                                                                                   input_format, VANADIS_FORMAT_FP64));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_cvtd);
@@ -1994,35 +1960,29 @@ protected:
                     break;
 
                     case MIPS_SPEC_COP_MASK_CVTW: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
                         switch (fr) {
                         case 16:
-                            input_format = VANADIS_FORMAT_FP32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32,
+											VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 17:
-                            input_format = VANADIS_FORMAT_FP64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64,
+											VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 20:
-                            input_format = VANADIS_FORMAT_INT32;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32,
+											VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         case 21:
-                            input_format = VANADIS_FORMAT_INT64;
+                            bundle->addInstruction(new VanadisFPConvertInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64,
+											VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_addr, hw_thr, options, fd, fs));
+                            insertDecodeFault = false;
                             break;
                         default:
-                            format_fault = true;
                             break;
-                        }
-
-                        if (!format_fault) {
-                            bundle->addInstruction(new VanadisFPConvertInstruction(ins_addr, hw_thr, options, fd, fs,
-                                                                                   input_format, VANADIS_FORMAT_INT32));
-                            insertDecodeFault = false;
-                        } else {
-                            //							output->verbose(CALL_INFO,
-                            // 16, 0, "[decoder] ---> convert function failed because of
-                            // input-format error (fmt: %" PRIu16 ")\n", fr);
                         }
 
                         MIPS_INC_DECODE_STAT(stat_decode_cop1_cvtw);
@@ -2033,55 +1993,137 @@ protected:
                     case MIPS_SPEC_COP_MASK_CMP_LT:
                     case MIPS_SPEC_COP_MASK_CMP_LTE:
                     case MIPS_SPEC_COP_MASK_CMP_EQ: {
-                        VanadisRegisterFormat input_format = VANADIS_FORMAT_FP64;
-                        bool format_fault = false;
-
-                        switch (fr) {
-                        case 16:
-                            input_format = VANADIS_FORMAT_FP32;
-                            break;
-                        case 17:
-                            input_format = VANADIS_FORMAT_FP64;
-                            break;
-                        case 20:
-                            input_format = VANADIS_FORMAT_INT32;
-                            break;
-                        case 21:
-                            input_format = VANADIS_FORMAT_INT64;
-                            break;
-                        default:
-                            format_fault = true;
-                            break;
-                        }
-
-                        VanadisRegisterCompareType compare_type = REG_COMPARE_EQ;
-                        bool compare_fault = false;
-
-                        switch (next_ins & 0xF) {
-                        case 0x2:
-                            compare_type = REG_COMPARE_EQ;
-                            MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
-                            break;
-                        case 0xC:
-                            compare_type = REG_COMPARE_LT;
-                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
-                            break;
-                        case 0xE:
-                            compare_type = REG_COMPARE_LTE;
-                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
-                            break;
-                        default:
-                            compare_fault = true;
-                            break;
-                        }
-
                         // if neither are true, then we have a good decode, otherwise a
                         // problem. register 31 is where condition codes and rounding modes
                         // are kept
-                        if (!(format_fault | compare_fault)) {
-                            bundle->addInstruction(new VanadisFPSetRegCompareInstruction(
-                                ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft, input_format, compare_type));
-                            insertDecodeFault = false;
+
+                        switch (fr) {
+                        case 16:
+									 {
+ 		                        switch (next_ins & 0xF) {
+		                        case 0x2:
+  	   		                      MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xC:
+ 		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xE:
+		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        default:
+		                            break;
+			                     }
+                           } break;
+                        case 17:
+									 {
+ 		                        switch (next_ins & 0xF) {
+		                        case 0x2:
+  	   		                      MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xC:
+ 		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xE:
+		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        default:
+		                            break;
+			                     }
+									} break;
+                        case 20:
+									{
+ 		                        switch (next_ins & 0xF) {
+		                        case 0x2:
+  	   		                      MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xC:
+ 		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xE:
+		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        default:
+		                            break;
+			                     }
+									} break;
+                        case 21:
+									{
+ 		                        switch (next_ins & 0xF) {
+		                        case 0x2:
+  	   		                      MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xC:
+ 		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        case 0xE:
+		                            MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
+
+			                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+			                         	ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
+			                         insertDecodeFault = false;
+
+		                            break;
+		                        default:
+		                            break;
+			                     }
+									} break;
+                        default:
+                            break;
                         }
                     } break;
                     }
@@ -2104,9 +2146,8 @@ protected:
 
                     switch (rd) {
                     case 29:
-                        bundle->addInstruction(new VanadisSetRegisterInstruction(
-                            ins_addr, hw_thr, options, target_reg, (int64_t)getThreadLocalStoragePointer(),
-                            VANADIS_FORMAT_INT32));
+                        bundle->addInstruction(new VanadisSetRegisterInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
+                            ins_addr, hw_thr, options, target_reg, (int64_t)getThreadLocalStoragePointer()));
                         insertDecodeFault = false;
                         break;
                     }

--- a/src/sst/elements/vanadis/inst/vadd.h
+++ b/src/sst/elements/vanadis/inst/vadd.h
@@ -21,23 +21,22 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format, bool perform_signed>
 class VanadisAddInstruction : public VanadisInstruction {
 public:
     VanadisAddInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                          const uint16_t dest, const uint16_t src_1, const uint16_t src_2, const bool signd,
-                          VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), perform_signed(signd), reg_format(fmt) {
+                          const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisAddInstruction* clone() { return new VanadisAddInstruction(*this); }
+    VanadisAddInstruction* clone() override { return new VanadisAddInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const {
+    const char* getInstCode() const override {
         if (perform_signed) {
             return "ADD";
         } else {
@@ -45,7 +44,7 @@ public:
         }
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%s    %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16
                  ")",
@@ -53,7 +52,7 @@ public:
                  phys_int_regs_in[0], phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
@@ -62,44 +61,37 @@ public:
                         phys_int_regs_in[1], isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
-            if (perform_signed) {
-                const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
-                const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
+		if( VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format ) {
+			if(perform_signed) {
+         	const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
+         	const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
 
-                regFile->setIntReg<int64_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
-            } else {
-                const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
-                const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
+            regFile->setIntReg<int64_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
+			} else {
+            const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
+            const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
 
-                regFile->setIntReg<uint64_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
-            }
-        } break;
-        case VANADIS_FORMAT_INT32: {
-            if (perform_signed) {
-                const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
-                const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
+         	regFile->setIntReg<uint64_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
+			}
+	   } else if( VanadisRegisterFormat::VANADIS_FORMAT_INT32 == register_format ) {
+			if(perform_signed) {
+            const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
+            const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
 
-                regFile->setIntReg<int32_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
-            } else {
-                const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
-                const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]);
+            regFile->setIntReg<int32_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
+			} else {
+            const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
+            const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]);
 
-                regFile->setIntReg<uint32_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
-            }
-        } break;
-        default: {
-            flagError();
-        } break;
-        }
+            regFile->setIntReg<uint32_t>(phys_int_regs_out[0], ((src_1) + (src_2)));
+			}
+		} else {
+			flagError();
+      }
 
-        markExecuted();
+	   markExecuted();
     }
 
-protected:
-    bool perform_signed;
-    VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vaddiu.h
+++ b/src/sst/elements/vanadis/inst/vaddiu.h
@@ -21,31 +21,30 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisAddImmUnsignedInstruction : public VanadisInstruction {
 public:
     VanadisAddImmUnsignedInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                                     const uint16_t dest, const uint16_t src_1, const uint64_t immediate,
-                                     VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), imm_value(immediate), reg_format(fmt) {
+                                     const uint16_t dest, const uint16_t src_1, const uint64_t immediate)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), imm_value(immediate) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisAddImmUnsignedInstruction* clone() { return new VanadisAddImmUnsignedInstruction(*this); }
+    VanadisAddImmUnsignedInstruction* clone() override { return new VanadisAddImmUnsignedInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "ADDIU"; }
 
-    virtual const char* getInstCode() const { return "ADDIU"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(
             buffer, buffer_size,
             "ADDIU   %5" PRIu16 " <- %5" PRIu16 " + imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %" PRId64 ")",
             isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) ADDIU phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
@@ -53,24 +52,21 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
-            const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
-            regFile->setIntReg<uint64_t>(phys_int_regs_out[0], src_1 + imm_value, false);
-        } break;
-        case VANADIS_FORMAT_INT32: {
-            const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
-            regFile->setIntReg<uint32_t>(phys_int_regs_out[0], src_1 + imm_value, false);
-        } break;
-        default: {
-            flagError();
-        } break;
-        }
-        markExecuted();
+
+		if(VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format) {
+         const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
+         regFile->setIntReg<uint64_t>(phys_int_regs_out[0], src_1 + imm_value, false);
+		} else if(VanadisRegisterFormat::VANADIS_FORMAT_INT32 == register_format) {
+         const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
+         regFile->setIntReg<uint32_t>(phys_int_regs_out[0], src_1 + imm_value, false);
+		} else {
+			flagError();
+		}
+
+		markExecuted();
     }
 
 private:
-    VanadisRegisterFormat reg_format;
     const uint64_t imm_value;
 };
 

--- a/src/sst/elements/vanadis/inst/vand.h
+++ b/src/sst/elements/vanadis/inst/vand.h
@@ -32,13 +32,11 @@ public:
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisAndInstruction* clone() { return new VanadisAndInstruction(*this); }
+    VanadisAndInstruction* clone() override { return new VanadisAndInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "AND"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "AND"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "AND     %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16
                  ")",
@@ -46,7 +44,7 @@ public:
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) AND phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16

--- a/src/sst/elements/vanadis/inst/vandi.h
+++ b/src/sst/elements/vanadis/inst/vandi.h
@@ -31,20 +31,18 @@ public:
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisAndImmInstruction* clone() { return new VanadisAndImmInstruction(*this); }
+    VanadisAndImmInstruction* clone() override { return new VanadisAndImmInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const { return "ANDI"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "ANDI"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(
             buffer, buffer_size,
             "ANDI    %5" PRIu16 " <- %5" PRIu16 " + imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %" PRId64 ")",
             isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) ANDI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRIu64

--- a/src/sst/elements/vanadis/inst/vbcmp.h
+++ b/src/sst/elements/vanadis/inst/vbcmp.h
@@ -24,23 +24,22 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format, VanadisRegisterCompareType compare_type>
 class VanadisBranchRegCompareInstruction : public VanadisSpeculatedInstruction {
 public:
     VanadisBranchRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr,
                                        const VanadisDecoderOptions* isa_opts, const uint16_t src_1,
                                        const uint16_t src_2, const int64_t offst,
-                                       const VanadisDelaySlotRequirement delayT, const VanadisRegisterCompareType cType,
-                                       const VanadisRegisterFormat fmt)
-        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 2, 0, 2, 0, 0, 0, 0, 0, delayT), offset(offst),
-          compareType(cType), reg_format(fmt) {
+                                       const VanadisDelaySlotRequirement delayT)
+        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 2, 0, 2, 0, 0, 0, 0, 0, delayT), offset(offst) {
+
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
     }
 
-    VanadisBranchRegCompareInstruction* clone() { return new VanadisBranchRegCompareInstruction(*this); }
-
-    virtual const char* getInstCode() const {
-        switch (compareType) {
+    VanadisBranchRegCompareInstruction* clone() override { return new VanadisBranchRegCompareInstruction(*this); }
+    const char* getInstCode() const override {
+        switch (compare_type) {
         case REG_COMPARE_EQ:
             return "BCMP_EQ";
         case REG_COMPARE_NEQ:
@@ -58,30 +57,30 @@ public:
         }
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16 ", %" PRIu16 " offset: %" PRId64 "\n",
-                 convertCompareTypeToString(compareType), isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_in[0],
+                 convertCompareTypeToString(compare_type), isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_in[0],
                  phys_int_regs_in[1], offset);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16
                         ", %" PRIu16 " offset: %" PRId64 "\n",
-                        getInstructionAddress(), convertCompareTypeToString(compareType), isa_int_regs_in[0],
+                        getInstructionAddress(), convertCompareTypeToString(compare_type), isa_int_regs_in[0],
                         isa_int_regs_in[1], phys_int_regs_in[0], phys_int_regs_in[1], offset);
 #endif
         bool compare_result = false;
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
-            compare_result = registerCompare<int64_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
+            compare_result = registerCompare<compare_type, int64_t>(regFile, this, output, phys_int_regs_in[0],
                                                       phys_int_regs_in[1]);
         } break;
-        case VANADIS_FORMAT_INT32: {
-            compare_result = registerCompare<int32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+            compare_result = registerCompare<compare_type, int32_t>(regFile, this, output, phys_int_regs_in[0],
                                                       phys_int_regs_in[1]);
         } break;
         default: {
@@ -107,8 +106,6 @@ public:
 
 protected:
     const int64_t offset;
-    VanadisRegisterFormat reg_format;
-    VanadisRegisterCompareType compareType;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vbcmpi.h
+++ b/src/sst/elements/vanadis/inst/vbcmpi.h
@@ -24,30 +24,29 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format, VanadisRegisterCompareType compareType>
 class VanadisBranchRegCompareImmInstruction : public VanadisSpeculatedInstruction {
 public:
     VanadisBranchRegCompareImmInstruction(const uint64_t addr, const uint32_t hw_thr,
                                           const VanadisDecoderOptions* isa_opts, const uint16_t src_1,
                                           const int64_t imm, const int64_t offst,
-                                          const VanadisDelaySlotRequirement delayT,
-                                          const VanadisRegisterCompareType cType, const VanadisRegisterFormat fmt)
-        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 1, 0, 1, 0, 0, 0, 0, 0, delayT), compareType(cType),
-          imm_value(imm), offset(offst), reg_format(fmt) {
+                                          const VanadisDelaySlotRequirement delayT)
+        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 1, 0, 1, 0, 0, 0, 0, 0, delayT),
+          imm_value(imm), offset(offst) {
 
         isa_int_regs_in[0] = src_1;
     }
 
-    VanadisBranchRegCompareImmInstruction* clone() { return new VanadisBranchRegCompareImmInstruction(*this); }
+    VanadisBranchRegCompareImmInstruction* clone() override { return new VanadisBranchRegCompareImmInstruction(*this); }
+    const char* getInstCode() const override { return "BCMPI"; }
 
-    virtual const char* getInstCode() const { return "BCMPI"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "BCMPI isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64 " / offset: %" PRId64 "\n",
                  isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) BCMPI isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64
@@ -56,13 +55,13 @@ public:
 #endif
         bool compare_result = false;
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             compare_result
-                = registerCompareImm<int64_t>(compareType, regFile, this, output, phys_int_regs_in[0], imm_value);
+                = registerCompareImm<compareType, int64_t>(regFile, this, output, phys_int_regs_in[0], imm_value);
         } break;
-        case VANADIS_FORMAT_INT32: {
-            compare_result = registerCompareImm<int32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+            compare_result = registerCompareImm<compareType, int32_t>(regFile, this, output, phys_int_regs_in[0],
                                                          static_cast<int32_t>(imm_value));
         } break;
         default: {
@@ -85,8 +84,6 @@ public:
 protected:
     const int64_t offset;
     const int64_t imm_value;
-    VanadisRegisterCompareType compareType;
-    VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vbcmpil.h
+++ b/src/sst/elements/vanadis/inst/vbcmpil.h
@@ -24,32 +24,31 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format, VanadisRegisterCompareType compareType>
 class VanadisBranchRegCompareImmLinkInstruction : public VanadisSpeculatedInstruction {
 public:
     VanadisBranchRegCompareImmLinkInstruction(const uint64_t addr, const uint32_t hw_thr,
                                               const VanadisDecoderOptions* isa_opts, const uint16_t src_1,
                                               const int64_t imm, const int64_t offst, const uint16_t link_reg,
-                                              const VanadisDelaySlotRequirement delayT,
-                                              const VanadisRegisterCompareType cType, const VanadisRegisterFormat fmt)
-        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0, delayT), compareType(cType),
-          imm_value(imm), offset(offst), reg_format(fmt) {
+                                              const VanadisDelaySlotRequirement delayT)
+        : VanadisSpeculatedInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0, delayT),
+          imm_value(imm), offset(offst) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_out[0] = link_reg;
     }
 
-    VanadisBranchRegCompareImmLinkInstruction* clone() { return new VanadisBranchRegCompareImmLinkInstruction(*this); }
+    VanadisBranchRegCompareImmLinkInstruction* clone() override { return new VanadisBranchRegCompareImmLinkInstruction(*this); }
+    const char* getInstCode() const override { return "BCMPIL"; }
 
-    virtual const char* getInstCode() const { return "BCMPIL"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "BCMPIL isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64 " / offset: %" PRId64
                  " / isa-link: %" PRIu16 " / phys-link: %" PRIu16 "\n",
                  isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset, isa_int_regs_out[0], phys_int_regs_out[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) BCMPIL isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64
@@ -59,13 +58,13 @@ public:
 #endif
         bool compare_result = false;
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             compare_result
-                = registerCompareImm<int64_t>(compareType, regFile, this, output, phys_int_regs_in[0], imm_value);
+                = registerCompareImm<compareType, int64_t>(regFile, this, output, phys_int_regs_in[0], imm_value);
         } break;
-        case VANADIS_FORMAT_INT32: {
-            compare_result = registerCompareImm<int32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+            compare_result = registerCompareImm<compareType, int32_t>(regFile, this, output, phys_int_regs_in[0],
                                                          static_cast<int32_t>(imm_value));
         } break;
         default: {
@@ -79,7 +78,7 @@ public:
             // Update the link address
             // The link address is the address of the second instruction after the
             // branch (so the instruction after the delay slot)
-            uint64_t link_address = calculateStandardNotTakenAddress();
+            const uint64_t link_address = calculateStandardNotTakenAddress();
             regFile->setIntReg<uint64_t>(phys_int_regs_out[0], link_address);
         } else {
             takenAddress = calculateStandardNotTakenAddress();
@@ -91,8 +90,6 @@ public:
 protected:
     const int64_t offset;
     const int64_t imm_value;
-    VanadisRegisterCompareType compareType;
-    const VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vbfp.h
+++ b/src/sst/elements/vanadis/inst/vbfp.h
@@ -32,9 +32,9 @@ public:
         isa_fp_regs_in[0] = cond_reg;
     }
 
-    VanadisBranchFPInstruction* clone() { return new VanadisBranchFPInstruction(*this); }
+    VanadisBranchFPInstruction* clone() override { return new VanadisBranchFPInstruction(*this); }
 
-    virtual const char* getInstCode() const {
+    const char* getInstCode() const override {
         if (branch_on_true) {
             return "BFPT";
         } else {
@@ -42,12 +42,12 @@ public:
         }
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size, "BFP%c isa-in: %" PRIu16 ", / phys-in: %" PRIu16 " / offset: %" PRId64 "\n",
                  branch_on_true ? 'T' : 'F', isa_fp_regs_in[0], phys_fp_regs_in[0], offset);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
             CALL_INFO, 16, 0,

--- a/src/sst/elements/vanadis/inst/vdivmod.h
+++ b/src/sst/elements/vanadis/inst/vdivmod.h
@@ -21,13 +21,13 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format, bool perform_signed>
 class VanadisDivideRemainderInstruction : public VanadisInstruction {
 public:
     VanadisDivideRemainderInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
                                       const uint16_t quo_dest, const uint16_t remain_dest, const uint16_t src_1,
-                                      const uint16_t src_2, bool treatSignd, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 2, 2, 2, 0, 0, 0, 0), performSigned(treatSignd),
-          reg_format(fmt) {
+                                      const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 2, 2, 2, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
@@ -35,33 +35,31 @@ public:
         isa_int_regs_out[1] = remain_dest;
     }
 
-    VanadisDivideRemainderInstruction* clone() { return new VanadisDivideRemainderInstruction(*this); }
+    VanadisDivideRemainderInstruction* clone() override { return new VanadisDivideRemainderInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_DIV; }
+    const char* getInstCode() const override { return "DIVREM"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_DIV; }
-
-    virtual const char* getInstCode() const { return "DIVREM"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "DIVREM%c q: %5" PRIu16 " r: %" PRIu16 " <- %" PRIu16 " \\ %" PRIu16 ", (phys: q: %" PRIu16
                  " r: %" PRIu16 " r: %" PRIu16 " %" PRIu16 " )\n",
-                 performSigned ? ' ' : 'U', isa_int_regs_out[0], isa_int_regs_out[1], isa_int_regs_in[0],
+                 perform_signed ? ' ' : 'U', isa_int_regs_out[0], isa_int_regs_out[1], isa_int_regs_in[0],
                  isa_int_regs_in[1], phys_int_regs_out[0], phys_int_regs_out[1], phys_int_regs_in[0],
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) DIVREM%c q: %" PRIu16 " r: %" PRIu16 " <- %" PRIu16 " \\ %" PRIu16
                         " (phys: q: %" PRIu16 " r: %" PRIu16 " %" PRIu16 " %" PRIu16 ")\n",
-                        (void*)getInstructionAddress(), performSigned ? ' ' : 'U', isa_int_regs_out[0],
+                        (void*)getInstructionAddress(), perform_signed ? ' ' : 'U', isa_int_regs_out[0],
                         isa_int_regs_out[1], isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_out[0],
                         phys_int_regs_out[1], phys_int_regs_in[0], phys_int_regs_in[1]);
 #endif
-        if (performSigned) {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
+        if (perform_signed) {
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
                 const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
 
@@ -80,7 +78,7 @@ public:
                     regFile->setIntReg<int64_t>(phys_int_regs_out[1], mod, true);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
                 const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
 
@@ -104,8 +102,8 @@ public:
             } break;
             }
         } else {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
                 const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
 
@@ -125,7 +123,7 @@ public:
                     regFile->setIntReg<uint64_t>(phys_int_regs_out[1], mod, false);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
                 const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]);
 
@@ -153,10 +151,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_format;
-    const bool performSigned;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -24,30 +24,29 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisFP2FPInstruction : public VanadisInstruction {
 public:
     VanadisFP2FPInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                            const uint16_t fp_dest, const uint16_t fp_src, VanadisRegisterFormat fp_w)
+                            const uint16_t fp_dest, const uint16_t fp_src)
         : VanadisInstruction(addr, hw_thr, isa_opts, 0, 0, 0, 0,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
-                                 : 1),
-          move_width(fp_w) {
-
-        if ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                                 : 1) {
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
             && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_out[0] = fp_dest;
             isa_fp_regs_out[1] = fp_dest + 1;
@@ -59,30 +58,29 @@ public:
         }
     }
 
-    virtual VanadisFP2FPInstruction* clone() { return new VanadisFP2FPInstruction(*this); }
+    VanadisFP2FPInstruction* clone() override { return new VanadisFP2FPInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_ARITH; }
-
-    virtual const char* getInstCode() const {
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "FP2FP32";
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "FP2FP64";
         }
 
         return "FPUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16 "\n",
                  getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_fp_regs_in[0], phys_fp_regs_in[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute (addr=0x%llx) %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16
@@ -90,14 +88,14 @@ public:
                         getInstructionAddress(), getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0],
                         isa_fp_regs_in[0], phys_fp_regs_in[0]);
 #endif
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const int32_t fp_v = regFile->getFPReg<int32_t>(phys_fp_regs_in[0]);
             regFile->setFPReg<int32_t>(phys_fp_regs_out[0], fp_v);
         } break;
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const int32_t v_0 = regFile->getFPReg<int32_t>(phys_fp_regs_in[0]);
                 regFile->setFPReg<int32_t>(phys_fp_regs_out[0], v_0);
@@ -113,9 +111,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat move_width;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -24,26 +24,26 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisFP2GPRInstruction : public VanadisInstruction {
 public:
     VanadisFP2GPRInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                             const uint16_t int_dest, const uint16_t fp_src, VanadisRegisterFormat fp_w)
+                             const uint16_t int_dest, const uint16_t fp_src)
         : VanadisInstruction(addr, hw_thr, isa_opts, 0, 1, 0, 1,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
                              0,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
-                             0),
-          move_width(fp_w) {
+                             0) {
 
         isa_int_regs_out[0] = int_dest;
 
-        if (((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+        if (((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
              && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))) {
             isa_fp_regs_in[0] = fp_src;
             isa_fp_regs_in[1] = fp_src + 1;
@@ -52,30 +52,29 @@ public:
         }
     }
 
-    virtual VanadisFP2GPRInstruction* clone() { return new VanadisFP2GPRInstruction(*this); }
+    VanadisFP2GPRInstruction* clone() override { return new VanadisFP2GPRInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const {
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "FP2GPR32";
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "FP2GPR64";
         }
 
         return "FPGPRUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%s int-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16 "\n",
                  getInstCode(), isa_int_regs_out[0], phys_int_regs_out[0], isa_fp_regs_in[0], phys_fp_regs_in[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute (addr=0x%llx) %s int-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16
@@ -83,14 +82,14 @@ public:
                         getInstructionAddress(), getInstCode(), isa_int_regs_out[0], phys_int_regs_out[0],
                         isa_fp_regs_in[0], phys_fp_regs_in[0]);
 #endif
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const int32_t fp_v = regFile->getFPReg<int32_t>(phys_fp_regs_in[0]);
             regFile->setIntReg<int32_t>(phys_int_regs_out[0], fp_v);
         } break;
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const int64_t fp_v = combineFromRegisters<int64_t>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
                 regFile->setIntReg<int64_t>(phys_int_regs_out[0], fp_v);
@@ -103,9 +102,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat move_width;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -23,21 +23,19 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisFPAddInstruction : public VanadisInstruction {
 public:
     VanadisFPAddInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                            const uint16_t dest, const uint16_t src_1, const uint16_t src_2,
-                            const VanadisRegisterFormat input_f)
+                            const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
-                                                                                                                : 1),
-          input_format(input_f) {
-
-        if ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+                                                                                                                : 1) {
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_in[0] = src_1;
             isa_fp_regs_in[1] = src_1 + 1;
             isa_fp_regs_in[2] = src_2;
@@ -51,33 +49,32 @@ public:
         }
     }
 
-    VanadisFPAddInstruction* clone() { return new VanadisFPAddInstruction(*this); }
+    VanadisFPAddInstruction* clone() override { return new VanadisFPAddInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_ARITH; }
-
-    virtual const char* getInstCode() const {
-        switch (input_format) {
-        case VANADIS_FORMAT_FP64:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "FP64ADD";
-        case VANADIS_FORMAT_FP32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "FP32ADD";
-        case VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
             return "FPINT64ADD";
-        case VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
             return "FPINT32ADD";
         }
 
         return "FPUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%8s  %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 ")",
                  getInstCode(), isa_fp_regs_out[0], isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0],
                  phys_fp_regs_in[0], phys_fp_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         char* int_register_buffer = new char[256];
         char* fp_register_buffer = new char[256];
@@ -91,8 +88,8 @@ public:
         delete[] int_register_buffer;
         delete[] fp_register_buffer;
 #endif
-        switch (input_format) {
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const float src_1 = regFile->getFPReg<float>(phys_fp_regs_in[0]);
             const float src_2 = regFile->getFPReg<float>(phys_fp_regs_in[1]);
 
@@ -100,7 +97,7 @@ public:
 
             regFile->setFPReg(phys_fp_regs_out[0], ((src_1) + (src_2)));
         } break;
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const double src_1 = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
                 const double src_2 = combineFromRegisters<double>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
@@ -125,9 +122,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat input_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -23,29 +23,28 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat input_format, VanadisRegisterFormat output_format>
 class VanadisFPConvertInstruction : public VanadisInstruction {
 public:
     VanadisFPConvertInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                                const uint16_t fp_dest, const uint16_t fp_src, VanadisRegisterFormat input_f,
-                                VanadisRegisterFormat output_f)
+                                const uint16_t fp_dest, const uint16_t fp_src)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
-            ((output_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+            ((input_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
+            ((output_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
                                                                                                                  : 1,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
-            ((output_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
-                                                                                                                 : 1),
-          input_format(input_f), output_format(output_f) {
+            ((input_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
+            ((output_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+                                                                                                                 : 1) {
 
-        if ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+        if ((input_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_in[0] = fp_src;
             isa_fp_regs_in[1] = fp_src + 1;
         } else {
             isa_fp_regs_in[0] = fp_src;
         }
 
-        if ((output_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+        if ((output_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_out[0] = fp_dest;
             isa_fp_regs_out[1] = fp_dest + 1;
         } else {
@@ -53,57 +52,56 @@ public:
         }
     }
 
-    virtual VanadisFPConvertInstruction* clone() { return new VanadisFPConvertInstruction(*this); }
+    VanadisFPConvertInstruction* clone() override { return new VanadisFPConvertInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_ARITH; }
-
-    virtual const char* getInstCode() const {
+    const char* getInstCode() const override {
         switch (input_format) {
-        case VANADIS_FORMAT_FP32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
                 return "F32F32CNV";
-            case VANADIS_FORMAT_FP64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
                 return "F32F64CNV";
-            case VANADIS_FORMAT_INT32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
                 return "FP32I32CNV";
-            case VANADIS_FORMAT_INT64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
                 return "FP32I64CNV";
             }
         } break;
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
                 return "F64F32CNV";
-            case VANADIS_FORMAT_FP64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
                 return "F64F64CNV";
-            case VANADIS_FORMAT_INT32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
                 return "FP64I32CNV";
-            case VANADIS_FORMAT_INT64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
                 return "F64I64CNV";
             }
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
                 return "I32F32CNV";
-            case VANADIS_FORMAT_FP64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
                 return "I32F64CNV";
-            case VANADIS_FORMAT_INT32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
                 return "I32I32CNV";
-            case VANADIS_FORMAT_INT64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
                 return "I32I64CNV";
             }
         } break;
-        case VANADIS_FORMAT_INT64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
                 return "I64F32CNV";
-            case VANADIS_FORMAT_FP64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
                 return "I64F64CNV";
-            case VANADIS_FORMAT_INT32:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
                 return "I64I32CNV";
-            case VANADIS_FORMAT_INT64:
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
                 return "I64I64CNV";
             }
         } break;
@@ -112,13 +110,13 @@ public:
         return "FPCONVUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16 "\n",
                  getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_fp_regs_in[0], phys_fp_regs_in[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute (addr=0x%llx) %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16
@@ -128,13 +126,13 @@ public:
 #endif
         switch (input_format) {
 
-        case VANADIS_FORMAT_FP32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
                 const float fp_v = (float)(regFile->getFPReg<float>(phys_fp_regs_in[0]));
                 regFile->setFPReg(phys_fp_regs_out[0], fp_v);
             } break;
-            case VANADIS_FORMAT_FP64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
                 const double fp_v = (double)(regFile->getFPReg<float>(phys_fp_regs_in[0]));
 
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
@@ -143,11 +141,11 @@ public:
                     regFile->setFPReg<double>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const int32_t i_v = (int32_t)(regFile->getFPReg<float>(phys_fp_regs_in[0]));
                 regFile->setFPReg<int32_t>(phys_fp_regs_out[0], i_v);
             } break;
-            case VANADIS_FORMAT_INT64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 const int64_t i_v = (int64_t)(regFile->getFPReg<float>(phys_fp_regs_in[0]));
 
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
@@ -159,9 +157,9 @@ public:
             }
         } break;
 
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const double input_v
                         = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -172,7 +170,7 @@ public:
                     regFile->setFPReg<float>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_FP64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const double fp_v = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
                     fractureToRegisters<double>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v);
@@ -181,7 +179,7 @@ public:
                     regFile->setFPReg<double>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const double input_v
                         = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -192,7 +190,7 @@ public:
                     regFile->setFPReg<int32_t>(phys_fp_regs_out[0], i_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const double input_v
                         = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -206,13 +204,13 @@ public:
             }
         } break;
 
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
                 const float fp_v = (float)(regFile->getFPReg<int32_t>(phys_fp_regs_in[0]));
                 regFile->setFPReg<float>(phys_fp_regs_out[0], fp_v);
             } break;
-            case VANADIS_FORMAT_FP64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const double fp_v = (double)(regFile->getFPReg<int32_t>(phys_fp_regs_in[0]));
                     fractureToRegisters<double>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], fp_v);
@@ -221,11 +219,11 @@ public:
                     regFile->setFPReg<double>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const int32_t i_v = (int32_t)(regFile->getFPReg<int32_t>(phys_fp_regs_in[0]));
                 regFile->setFPReg<int32_t>(phys_fp_regs_out[0], i_v);
             } break;
-            case VANADIS_FORMAT_INT64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const int64_t i_v = (int64_t)(regFile->getFPReg<int32_t>(phys_fp_regs_in[0]));
                     fractureToRegisters<int64_t>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], i_v);
@@ -237,9 +235,9 @@ public:
             }
         } break;
 
-        case VANADIS_FORMAT_INT64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             switch (output_format) {
-            case VANADIS_FORMAT_FP32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const int64_t input_v
                         = combineFromRegisters<int64_t>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -250,7 +248,7 @@ public:
                     regFile->setFPReg<float>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_FP64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const int64_t input_v
                         = combineFromRegisters<int64_t>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -261,7 +259,7 @@ public:
                     regFile->setFPReg<double>(phys_fp_regs_out[0], fp_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const int64_t input_v
                         = combineFromRegisters<int64_t>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -272,7 +270,7 @@ public:
                     regFile->setFPReg<int32_t>(phys_fp_regs_out[0], i_v);
                 }
             } break;
-            case VANADIS_FORMAT_INT64: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                     const int64_t input_v
                         = combineFromRegisters<int64_t>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
@@ -288,10 +286,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat input_format;
-    VanadisRegisterFormat output_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -23,24 +23,23 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisFPDivideInstruction : public VanadisInstruction {
 public:
     VanadisFPDivideInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                               const uint16_t dest, const uint16_t src_1, const uint16_t src_2,
-                               const VanadisRegisterFormat r_format)
+                               const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((r_format == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4
                                                                                                                  : 2,
-            ((r_format == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
                                                                                                                  : 1,
-            ((r_format == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4
                                                                                                                  : 2,
-            ((r_format == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
-                                                                                                                 : 1),
-          input_format(r_format) {
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+                                                                                                                 : 1) {
 
-        if ((r_format == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_in[0] = src_1;
             isa_fp_regs_in[1] = src_1 + 1;
             isa_fp_regs_in[2] = src_2;
@@ -54,26 +53,25 @@ public:
         }
     }
 
-    VanadisFPDivideInstruction* clone() { return new VanadisFPDivideInstruction(*this); }
+    VanadisFPDivideInstruction* clone() override { return new VanadisFPDivideInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_DIV; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_DIV; }
-
-    virtual const char* getInstCode() const {
-        switch (input_format) {
-        case VANADIS_FORMAT_FP64:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "FP64DIV";
-        case VANADIS_FORMAT_FP32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "FP32DIV";
-        case VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
             return "FPINT64DIV";
-        case VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
             return "FPINT32DIV";
         }
 
         return "FPUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "DIV     %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16
                  ")",
@@ -81,7 +79,7 @@ public:
                  phys_fp_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         char* int_register_buffer = new char[256];
         char* fp_register_buffer = new char[256];
@@ -95,8 +93,8 @@ public:
         delete[] int_register_buffer;
         delete[] fp_register_buffer;
 #endif
-        switch (input_format) {
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const float src_1 = regFile->getFPReg<float>(phys_fp_regs_in[0]);
             const float src_2 = regFile->getFPReg<float>(phys_fp_regs_in[1]);
 
@@ -104,7 +102,7 @@ public:
 
             regFile->setFPReg<float>(phys_fp_regs_out[0], src_1 / src_2);
         } break;
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const double src_1 = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
                 const double src_2 = combineFromRegisters<double>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
@@ -129,9 +127,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat input_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -27,20 +27,19 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterCompareType compare_type, VanadisRegisterFormat register_format>
 class VanadisFPSetRegCompareInstruction : public VanadisInstruction {
 public:
     VanadisFPSetRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                                      const uint16_t dest, const uint16_t src_1, const uint16_t src_2,
-                                      const VanadisRegisterFormat r_fmt, const VanadisRegisterCompareType cType)
+                                      const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((r_fmt == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 5 : 3,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 5 : 3,
             1,
-            ((r_fmt == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 5 : 3,
-            1),
-          reg_fmt(r_fmt), compareType(cType) {
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 5 : 3,
+            1) {
 
-        if ((r_fmt == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_in[0] = src_1;
             isa_fp_regs_in[1] = src_1 + 1;
             isa_fp_regs_in[2] = src_2;
@@ -60,9 +59,9 @@ public:
     virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_ARITH; }
 
     virtual const char* getInstCode() const {
-        switch (reg_fmt) {
-        case VANADIS_FORMAT_FP64: {
-            switch (compareType) {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
+            switch (compare_type) {
             case REG_COMPARE_EQ:
                 return "FP64CMPEQ";
             case REG_COMPARE_NEQ:
@@ -79,8 +78,8 @@ public:
                 return "FP64CMPUKN";
             }
         } break;
-        case VANADIS_FORMAT_FP32: {
-            switch (compareType) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
+            switch (compare_type) {
             case REG_COMPARE_EQ:
                 return "FP32CMPEQ";
             case REG_COMPARE_NEQ:
@@ -97,20 +96,20 @@ public:
                 return "FP32CMPUKN";
             }
         } break;
-        case VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
             return "FPINT64ACMP";
-        case VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
             return "FPINT32CMP";
+		  default:
+	         return "FPCNVUNK";
         }
-
-        return "FPCNVUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "FPCMPST (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16 ", %" PRIu16 " / phys-out: %" PRIu16
                  " phys-in: %" PRIu16 ", %" PRIu16 "\n",
-                 convertCompareTypeToString(compareType), registerFormatToString(reg_fmt), isa_fp_regs_out[0],
+                 convertCompareTypeToString(compare_type), registerFormatToString(register_format), isa_fp_regs_out[0],
                  isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0], phys_fp_regs_in[0], phys_fp_regs_in[1]);
     }
 
@@ -122,7 +121,7 @@ public:
                                   ? combineFromRegisters<T>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3])
                                   : regFile->getFPReg<T>(phys_fp_regs_in[1]);
 
-        switch (compareType) {
+        switch (compare_type) {
         case REG_COMPARE_EQ:
             return (left_value == right_value);
         case REG_COMPARE_NEQ:
@@ -141,7 +140,7 @@ public:
         }
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         char* int_register_buffer = new char[256];
         char* fp_register_buffer = new char[256];
@@ -150,7 +149,7 @@ public:
         writeFPRegs(fp_register_buffer, 256);
 
         output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s (%s) int: %s / fp: %s\n", getInstructionAddress(),
-                        getInstCode(), convertCompareTypeToString(compareType), int_register_buffer,
+                        getInstCode(), convertCompareTypeToString(compare_type), int_register_buffer,
                         fp_register_buffer);
 
         delete[] int_register_buffer;
@@ -159,18 +158,18 @@ public:
         bool compare_result = false;
         bool byte8_type = false;
 
-        switch (reg_fmt) {
-        case VANADIS_FORMAT_FP32:
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             compare_result = performCompare<float>(output, regFile);
             break;
-        case VANADIS_FORMAT_FP64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             compare_result = performCompare<double>(output, regFile);
             byte8_type = true;
             break;
-        case VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
             compare_result = performCompare<int32_t>(output, regFile);
             break;
-        case VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
             compare_result = performCompare<int64_t>(output, regFile);
             byte8_type = true;
             break;
@@ -195,10 +194,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_fmt;
-    VanadisRegisterCompareType compareType;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -23,21 +23,19 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisFPSubInstruction : public VanadisInstruction {
 public:
     VanadisFPSubInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                            const uint16_t dest, const uint16_t src_1, const uint16_t src_2,
-                            const VanadisRegisterFormat input_f)
+                            const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
-            ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
-                                                                                                                : 1),
-          input_format(input_f) {
-
-        if ((input_f == VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2
+                                                                                                                : 1) {
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
             isa_fp_regs_in[0] = src_1;
             isa_fp_regs_in[1] = src_1 + 1;
             isa_fp_regs_in[2] = src_2;
@@ -51,26 +49,26 @@ public:
         }
     }
 
-    VanadisFPSubInstruction* clone() { return new VanadisFPSubInstruction(*this); }
+    VanadisFPSubInstruction* clone() override { return new VanadisFPSubInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FP_ARITH; }
-
-    virtual const char* getInstCode() const {
-        switch (input_format) {
-        case VANADIS_FORMAT_FP64:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "FP64SUB";
-        case VANADIS_FORMAT_FP32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "FP32SUB";
-        case VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
             return "FPINT64SUB";
-        case VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
             return "FPINT32SUB";
+		  default:
+            return "FPUNK";
         }
 
-        return "FPUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "FPSUB   %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16
                  ")",
@@ -78,7 +76,7 @@ public:
                  phys_fp_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         char* int_register_buffer = new char[256];
         char* fp_register_buffer = new char[256];
@@ -92,8 +90,8 @@ public:
         delete[] int_register_buffer;
         delete[] fp_register_buffer;
 #endif
-        switch (input_format) {
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const float src_1 = regFile->getFPReg<float>(phys_fp_regs_in[0]);
             const float src_2 = regFile->getFPReg<float>(phys_fp_regs_in[1]);
 
@@ -101,7 +99,7 @@ public:
 
             regFile->setFPReg<float>(phys_fp_regs_out[0], ((src_1) - (src_2)));
         } break;
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const double src_1 = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
                 const double src_2 = combineFromRegisters<double>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
@@ -126,9 +124,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat input_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -22,25 +22,24 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisGPR2FPInstruction : public VanadisInstruction {
 public:
     VanadisGPR2FPInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                             const uint16_t fp_dest, const uint16_t int_src, VanadisRegisterFormat fp_w)
+                             const uint16_t fp_dest, const uint16_t int_src)
         : VanadisInstruction(addr, hw_thr, isa_opts, 1, 0, 1, 0, 0,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
                                  : 1,
                              0,
-                             ((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+                             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
                               && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                                  ? 2
-                                 : 1),
-          move_width(fp_w) {
-
+                                 : 1) {
         isa_int_regs_in[0] = int_src;
 
-        if (((fp_w == VANADIS_FORMAT_FP64 || fp_w == VANADIS_FORMAT_INT64)
+        if (((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 || register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64)
              && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))) {
 
             isa_fp_regs_out[0] = fp_dest;
@@ -50,30 +49,29 @@ public:
         }
     }
 
-    virtual VanadisGPR2FPInstruction* clone() { return new VanadisGPR2FPInstruction(*this); }
+    VanadisGPR2FPInstruction* clone() override { return new VanadisGPR2FPInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const {
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32:
+    const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
             return "GPR2FP32";
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
             return "GPR2FP64";
         }
 
         return "GPRCONVUNK";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "%s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- int-src: isa: %" PRIu16 " phys: %" PRIu16 "\n",
                  getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_int_regs_in[0], phys_int_regs_in[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute (addr=0x%llx) %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- int-src: isa: %" PRIu16
@@ -81,14 +79,14 @@ public:
                         getInstructionAddress(), getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0],
                         isa_int_regs_in[0], phys_int_regs_in[0]);
 #endif
-        switch (move_width) {
-        case VANADIS_FORMAT_INT32:
-        case VANADIS_FORMAT_FP32: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
             const int32_t v = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
             regFile->setFPReg<int32_t>(phys_fp_regs_out[0], v);
         } break;
-        case VANADIS_FORMAT_INT64:
-        case VANADIS_FORMAT_FP64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
             if (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) {
                 const int64_t v = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
                 fractureToRegisters<int64_t>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], v);
@@ -101,9 +99,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat move_width;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vmul.h
+++ b/src/sst/elements/vanadis/inst/vmul.h
@@ -21,25 +21,24 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisMultiplyInstruction : public VanadisInstruction {
 public:
     VanadisMultiplyInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                               const uint16_t dest, const uint16_t src_1, const uint16_t src_2,
-                               VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), reg_format(fmt) {
+                               const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisMultiplyInstruction* clone() { return new VanadisMultiplyInstruction(*this); }
+    VanadisMultiplyInstruction* clone() override { return new VanadisMultiplyInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "MUL"; }
 
-    virtual const char* getInstCode() const { return "MUL"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "MUL     %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16
                  ")",
@@ -47,7 +46,7 @@ public:
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) MUL phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
@@ -55,14 +54,14 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                         isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
             const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
 
             regFile->setIntReg<int64_t>(phys_int_regs_out[0], (src_1) * (src_2));
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
             const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
 
@@ -72,11 +71,9 @@ public:
             flagError();
         } break;
         }
+
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vregfmt.h
+++ b/src/sst/elements/vanadis/inst/vregfmt.h
@@ -19,18 +19,18 @@
 namespace SST {
 namespace Vanadis {
 
-enum VanadisRegisterFormat { VANADIS_FORMAT_FP32, VANADIS_FORMAT_FP64, VANADIS_FORMAT_INT32, VANADIS_FORMAT_INT64 };
+enum class VanadisRegisterFormat { VANADIS_FORMAT_FP32, VANADIS_FORMAT_FP64, VANADIS_FORMAT_INT32, VANADIS_FORMAT_INT64 };
 
 const char*
 registerFormatToString(const VanadisRegisterFormat fmt) {
     switch (fmt) {
-    case VANADIS_FORMAT_FP32:
+    case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
         return "F32";
-    case VANADIS_FORMAT_FP64:
+    case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
         return "F64";
-    case VANADIS_FORMAT_INT32:
+    case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
         return "I32";
-    case VANADIS_FORMAT_INT64:
+    case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
         return "I64";
     default:
         return "UNK";

--- a/src/sst/elements/vanadis/inst/vscmp.h
+++ b/src/sst/elements/vanadis/inst/vscmp.h
@@ -24,52 +24,51 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterCompareType compare_type, VanadisRegisterFormat register_format, bool perform_signed>
 class VanadisSetRegCompareInstruction : public VanadisInstruction {
 public:
     VanadisSetRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                                    const uint16_t dest, const uint16_t src_1, const uint16_t src_2, const bool sgnd,
-                                    const VanadisRegisterCompareType cType, const VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), performSigned(sgnd), compareType(cType),
-          reg_format(fmt) {
+                                    const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisSetRegCompareInstruction* clone() { return new VanadisSetRegCompareInstruction(*this); }
+    VanadisSetRegCompareInstruction* clone() override { return new VanadisSetRegCompareInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-    virtual const char* getInstCode() const { return "CMPSET"; }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "CMPSET"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "CMPSET (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16 ", %" PRIu16 " / phys-out: %" PRIu16
                  " phys-in: %" PRIu16 ", %" PRIu16 "\n",
-                 convertCompareTypeToString(compareType), performSigned ? "signed" : "unsigned", isa_int_regs_out[0],
+                 convertCompareTypeToString(compare_type), perform_signed ? "signed" : "unsigned", isa_int_regs_out[0],
                  isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_out[0], phys_int_regs_in[0],
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) CMPSET (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16 ", %" PRIu16
                         " / phys-out: %" PRIu16 " phys-in: %" PRIu16 ", %" PRIu16 "\n",
-                        getInstructionAddress(), convertCompareTypeToString(compareType),
-                        performSigned ? "signed" : "unsigned", isa_int_regs_out[0], isa_int_regs_in[0],
+                        getInstructionAddress(), convertCompareTypeToString(compare_type),
+                        perform_signed ? "signed" : "unsigned", isa_int_regs_out[0], isa_int_regs_in[0],
                         isa_int_regs_in[1], phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1]);
 #endif
         bool compare_result = false;
 
-        if (performSigned) {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
-                compare_result = registerCompare<int64_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+        if (perform_signed) {
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
+                compare_result = registerCompare<compare_type, int64_t>(regFile, this, output, phys_int_regs_in[0],
                                                           phys_int_regs_in[1]);
             } break;
-            case VANADIS_FORMAT_INT32: {
-                compare_result = registerCompare<int32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+                compare_result = registerCompare<compare_type, int32_t>(regFile, this, output, phys_int_regs_in[0],
                                                           phys_int_regs_in[1]);
             } break;
             default: {
@@ -77,13 +76,13 @@ public:
             } break;
             }
         } else {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
-                compare_result = registerCompare<uint64_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
+                compare_result = registerCompare<compare_type, uint64_t>(regFile, this, output, phys_int_regs_in[0],
                                                            phys_int_regs_in[1]);
             } break;
-            case VANADIS_FORMAT_INT32: {
-                compare_result = registerCompare<uint32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+                compare_result = registerCompare<compare_type, uint32_t>(regFile, this, output, phys_int_regs_in[0],
                                                            phys_int_regs_in[1]);
             } break;
             default: {
@@ -104,11 +103,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    const bool performSigned;
-    const VanadisRegisterCompareType compareType;
-    const VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vscmpi.h
+++ b/src/sst/elements/vanadis/inst/vscmpi.h
@@ -24,51 +24,50 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterCompareType compare_type, VanadisRegisterFormat register_format, bool perform_signed>
 class VanadisSetRegCompareImmInstruction : public VanadisInstruction {
 public:
     VanadisSetRegCompareImmInstruction(const uint64_t addr, const uint32_t hw_thr,
                                        const VanadisDecoderOptions* isa_opts, const uint16_t dest, const uint16_t src_1,
-                                       const int64_t imm, const bool sgnd, const VanadisRegisterCompareType cType,
-                                       const VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), performSigned(sgnd), compareType(cType),
-          imm_value(imm), reg_format(fmt) {
+                                       const int64_t imm)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), imm_value(imm) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisSetRegCompareImmInstruction* clone() { return new VanadisSetRegCompareImmInstruction(*this); }
+    VanadisSetRegCompareImmInstruction* clone() override { return new VanadisSetRegCompareImmInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-    virtual const char* getInstCode() const { return "CMPSETI"; }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "CMPSETI"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "CMPSETI (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16 " / phys-out: %" PRIu16
                  " phys-in: %" PRIu16 " / imm: %" PRId64 "\n",
-                 convertCompareTypeToString(compareType), performSigned ? "signed" : "unsigned", isa_int_regs_out[0],
+                 convertCompareTypeToString(compare_type), perform_signed ? "signed" : "unsigned", isa_int_regs_out[0],
                  isa_int_regs_in[0], phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) CMPSET (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16
                         " / phys-out: %" PRIu16 " phys-in: %" PRIu16 " / imm: %" PRId64 "\n",
-                        getInstructionAddress(), convertCompareTypeToString(compareType),
-                        performSigned ? "signed" : "unsigned", isa_int_regs_out[0], isa_int_regs_in[0],
+                        getInstructionAddress(), convertCompareTypeToString(compare_type),
+                        perform_signed ? "signed" : "unsigned", isa_int_regs_out[0], isa_int_regs_in[0],
                         phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
 #endif
         bool compare_result = false;
 
-        if (performSigned) {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
+        if (perform_signed) {
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 compare_result
-                    = registerCompareImm<int64_t>(compareType, regFile, this, output, phys_int_regs_in[0], imm_value);
+                    = registerCompareImm<compare_type, int64_t>(regFile, this, output, phys_int_regs_in[0], imm_value);
             } break;
-            case VANADIS_FORMAT_INT32: {
-                compare_result = registerCompareImm<int32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+                compare_result = registerCompareImm<compare_type, int32_t>(regFile, this, output, phys_int_regs_in[0],
                                                              static_cast<int32_t>(imm_value));
             } break;
             default: {
@@ -76,13 +75,13 @@ public:
             } break;
             }
         } else {
-            switch (reg_format) {
-            case VANADIS_FORMAT_INT64: {
-                compare_result = registerCompareImm<uint64_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            switch (register_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
+                compare_result = registerCompareImm<compare_type, uint64_t>(regFile, this, output, phys_int_regs_in[0],
                                                               static_cast<uint64_t>(imm_value));
             } break;
-            case VANADIS_FORMAT_INT32: {
-                compare_result = registerCompareImm<uint32_t>(compareType, regFile, this, output, phys_int_regs_in[0],
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+                compare_result = registerCompareImm<compare_type, uint32_t>(regFile, this, output, phys_int_regs_in[0],
                                                               static_cast<uint32_t>(imm_value));
             } break;
             default: {
@@ -101,9 +100,6 @@ public:
     }
 
 protected:
-    const bool performSigned;
-    VanadisRegisterCompareType compareType;
-    const VanadisRegisterFormat reg_format;
     const int64_t imm_value;
 };
 

--- a/src/sst/elements/vanadis/inst/vsetreg.h
+++ b/src/sst/elements/vanadis/inst/vsetreg.h
@@ -21,38 +21,37 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisSetRegisterInstruction : public VanadisInstruction {
 public:
     VanadisSetRegisterInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                                  const uint16_t dest, const int64_t immediate, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 0, 1, 0, 1, 0, 0, 0, 0), reg_format(fmt) {
+                                  const uint16_t dest, const int64_t immediate)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 0, 1, 0, 1, 0, 0, 0, 0) {
 
         isa_int_regs_out[0] = dest;
         imm_value = immediate;
     }
 
-    VanadisSetRegisterInstruction* clone() { return new VanadisSetRegisterInstruction(*this); }
+    VanadisSetRegisterInstruction* clone() override { return new VanadisSetRegisterInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SETREG"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "SETREG"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size, "SETREG  %5" PRIu16 " <- imm=%" PRId64 " (phys: %5" PRIu16 " <- %" PRId64 ")",
                  isa_int_regs_out[0], imm_value, phys_int_regs_out[0], imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) SETREG phys: out=%" PRIu16 " imm=%" PRId64 ", isa: out=%" PRIu16 "\n",
                         getInstructionAddress(), phys_int_regs_out[0], imm_value, isa_int_regs_out[0]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             regFile->setIntReg<int64_t>(phys_int_regs_out[0], imm_value);
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             regFile->setIntReg<int32_t>(phys_int_regs_out[0], static_cast<int32_t>(imm_value));
         } break;
         default: {
@@ -66,7 +65,6 @@ public:
     }
 
 private:
-    VanadisRegisterFormat reg_format;
     int64_t imm_value;
 };
 

--- a/src/sst/elements/vanadis/inst/vsll.h
+++ b/src/sst/elements/vanadis/inst/vsll.h
@@ -22,25 +22,24 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisShiftLeftLogicalInstruction : public VanadisInstruction {
 public:
     VanadisShiftLeftLogicalInstruction(const uint64_t addr, const uint32_t hw_thr,
                                        const VanadisDecoderOptions* isa_opts, const uint16_t dest, const uint16_t src_1,
-                                       const uint16_t src_2, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), reg_format(fmt) {
+                                       const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    virtual VanadisShiftLeftLogicalInstruction* clone() { return new VanadisShiftLeftLogicalInstruction(*this); }
+    VanadisShiftLeftLogicalInstruction* clone() override { return new VanadisShiftLeftLogicalInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SLL"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "SLL"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "SLL     %5" PRIu16 " <- %5" PRIu16 " << %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " << %5" PRIu16
                  ")",
@@ -48,7 +47,7 @@ public:
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) SLL phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
@@ -56,8 +55,8 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                         isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
             const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
 
@@ -69,7 +68,7 @@ public:
             }
         } break;
 
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
             const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]) & 0x1F;
             //                                const uint32_t src_2 =
@@ -90,9 +89,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vsrai.h
+++ b/src/sst/elements/vanadis/inst/vsrai.h
@@ -22,12 +22,13 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisShiftRightArithmeticImmInstruction : public VanadisInstruction {
 public:
     VanadisShiftRightArithmeticImmInstruction(const uint64_t addr, const uint32_t hw_thr,
                                               const VanadisDecoderOptions* isa_opts, const uint16_t dest,
-                                              const uint16_t src_1, const int64_t immediate, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), reg_format(fmt) {
+                                              const uint16_t src_1, const int64_t immediate)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_out[0] = dest;
@@ -35,15 +36,14 @@ public:
         imm_value = immediate;
     }
 
-    virtual VanadisShiftRightArithmeticImmInstruction* clone() {
+    VanadisShiftRightArithmeticImmInstruction* clone() override {
         return new VanadisShiftRightArithmeticImmInstruction(*this);
     }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SRAI"; }
 
-    virtual const char* getInstCode() const { return "SRAI"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "SRAI    %5" PRIu16 " <- %5" PRIu16 " >> imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
                  " >> %" PRId64 ")",
@@ -51,7 +51,7 @@ public:
                  imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) SRAI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
@@ -61,19 +61,18 @@ public:
 #endif
         assert(imm_value > 0);
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
             regFile->setIntReg<int64_t>(phys_int_regs_out[0], src_1 >> imm_value);
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
             const int32_t imm_value_32 = static_cast<int32_t>(imm_value);
 
             regFile->setIntReg<int32_t>(phys_int_regs_out[0], src_1 >> imm_value_32);
         } break;
-        case VANADIS_FORMAT_FP32:
-        case VANADIS_FORMAT_FP64: {
+		  default: {
             flagError();
         } break;
         }
@@ -82,7 +81,6 @@ public:
     }
 
 protected:
-    VanadisRegisterFormat reg_format;
     int64_t imm_value;
 };
 

--- a/src/sst/elements/vanadis/inst/vsrl.h
+++ b/src/sst/elements/vanadis/inst/vsrl.h
@@ -22,25 +22,24 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisShiftRightLogicalInstruction : public VanadisInstruction {
 public:
     VanadisShiftRightLogicalInstruction(const uint64_t addr, const uint32_t hw_thr,
                                         const VanadisDecoderOptions* isa_opts, const uint16_t dest,
-                                        const uint16_t src_1, const uint16_t src_2, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), reg_format(fmt) {
+                                        const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0)  {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    virtual VanadisShiftRightLogicalInstruction* clone() { return new VanadisShiftRightLogicalInstruction(*this); }
+    VanadisShiftRightLogicalInstruction* clone() override { return new VanadisShiftRightLogicalInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SRL"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "SRL"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "SRL     %5" PRIu16 " <- %5" PRIu16 " >> %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " >> %5" PRIu16
                  ")",
@@ -48,7 +47,7 @@ public:
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) SRL phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
@@ -56,8 +55,8 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                         isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
             const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
 
@@ -68,7 +67,7 @@ public:
                 regFile->setIntReg<uint64_t>(phys_int_regs_out[0], src_1 >> src_2);
             }
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
             const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]) & 0x1F;
             //                                const uint32_t src_2 =
@@ -81,17 +80,13 @@ public:
                 regFile->setIntReg<uint32_t>(phys_int_regs_out[0], src_1 >> src_2);
             }
         } break;
-        case VANADIS_FORMAT_FP32:
-        case VANADIS_FORMAT_FP64: {
+		  default: {
             flagError();
         } break;
         }
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vsrli.h
+++ b/src/sst/elements/vanadis/inst/vsrli.h
@@ -22,12 +22,13 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisShiftRightLogicalImmInstruction : public VanadisInstruction {
 public:
     VanadisShiftRightLogicalImmInstruction(const uint64_t addr, const uint32_t hw_thr,
                                            const VanadisDecoderOptions* isa_opts, const uint16_t dest,
-                                           const uint16_t src_1, const uint64_t immediate, VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), reg_format(fmt) {
+                                           const uint16_t src_1, const uint64_t immediate)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_out[0] = dest;
@@ -35,15 +36,14 @@ public:
         imm_value = immediate;
     }
 
-    virtual VanadisShiftRightLogicalImmInstruction* clone() {
+    VanadisShiftRightLogicalImmInstruction* clone() override {
         return new VanadisShiftRightLogicalImmInstruction(*this);
     }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SRLI"; }
 
-    virtual const char* getInstCode() const { return "SRLI"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) {
         snprintf(buffer, buffer_size,
                  "SRLI    %5" PRIu16 " <- %5" PRIu16 " >> imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
                  " >> %" PRId64 ")",
@@ -51,7 +51,7 @@ public:
                  imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) SRLI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
@@ -61,19 +61,18 @@ public:
 #endif
         assert(imm_value > 0);
 
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
             regFile->setIntReg<uint64_t>(phys_int_regs_out[0], src_1 >> imm_value);
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
             const uint32_t imm_value_32 = static_cast<uint32_t>(imm_value);
 
             regFile->setIntReg<uint32_t>(phys_int_regs_out[0], src_1 >> imm_value_32);
         } break;
-        case VANADIS_FORMAT_FP32:
-        case VANADIS_FORMAT_FP64: {
+		  default: {
             flagError();
         } break;
         }
@@ -82,7 +81,6 @@ public:
     }
 
 protected:
-    VanadisRegisterFormat reg_format;
     uint64_t imm_value;
 };
 

--- a/src/sst/elements/vanadis/inst/vsub.h
+++ b/src/sst/elements/vanadis/inst/vsub.h
@@ -21,26 +21,23 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat register_format>
 class VanadisSubInstruction : public VanadisInstruction {
 public:
     VanadisSubInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                          const uint16_t dest, const uint16_t src_1, const uint16_t src_2, bool trapOverflw,
-                          VanadisRegisterFormat fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), trapOverflow(trapOverflw),
-          reg_format(fmt) {
+                          const uint16_t dest, const uint16_t src_1, const uint16_t src_2, bool trapOverflw)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0), trapOverflow(trapOverflw) {
 
         isa_int_regs_in[0] = src_1;
         isa_int_regs_in[1] = src_2;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisSubInstruction* clone() { return new VanadisSubInstruction(*this); }
+    VanadisSubInstruction* clone() override { return new VanadisSubInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "SUB"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "SUB"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
                  "SUB   %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16
                  ")",
@@ -48,7 +45,7 @@ public:
                  phys_int_regs_in[1]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) SUB phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
@@ -56,14 +53,14 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                         isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
-        switch (reg_format) {
-        case VANADIS_FORMAT_INT64: {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
             const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
             const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
 
             regFile->setIntReg<int64_t>(phys_int_regs_out[0], ((src_1) - (src_2)));
         } break;
-        case VANADIS_FORMAT_INT32: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
             const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
             const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
 
@@ -78,7 +75,6 @@ public:
     }
 
 protected:
-    VanadisRegisterFormat reg_format;
     const bool trapOverflow;
 };
 

--- a/src/sst/elements/vanadis/inst/vtrunc.h
+++ b/src/sst/elements/vanadis/inst/vtrunc.h
@@ -21,30 +21,27 @@
 namespace SST {
 namespace Vanadis {
 
+template<VanadisRegisterFormat input_format, VanadisRegisterFormat output_format>
 class VanadisTruncateInstruction : public VanadisInstruction {
 public:
     VanadisTruncateInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-                               const uint16_t dest, const uint16_t src, VanadisRegisterFormat input_fmt,
-                               VanadisRegisterFormat output_fmt)
-        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0), reg_input_format(input_fmt),
-          reg_output_format(output_fmt) {
+                               const uint16_t dest, const uint16_t src)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 1, 1, 1, 1, 0, 0, 0, 0) {
 
         isa_int_regs_in[0] = src;
         isa_int_regs_out[0] = dest;
     }
 
-    VanadisTruncateInstruction* clone() { return new VanadisTruncateInstruction(*this); }
+    VanadisTruncateInstruction* clone() override { return new VanadisTruncateInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "TRUNC"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "TRUNC"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size, "%s    %5" PRIu16 " <- %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 ")\n",
                  getInstCode(), isa_int_regs_out[0], isa_int_regs_in[0], phys_int_regs_out[0], phys_int_regs_in[0]);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 ", isa: out=%" PRIu16 " / in=%" PRIu16
@@ -52,14 +49,14 @@ public:
                         (void*)getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0],
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
-        switch (reg_input_format) {
-        case VANADIS_FORMAT_INT64: {
-            switch (reg_output_format) {
-            case VANADIS_FORMAT_INT64: {
+        switch (input_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
+            switch (output_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 const int64_t src = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
                 regFile->setIntReg<int64_t>(phys_int_regs_out[0], src);
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const uint32_t src = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
                 regFile->setIntReg<int32_t>(phys_int_regs_out[0], src);
             } break;
@@ -68,13 +65,13 @@ public:
             } break;
             }
         } break;
-        case VANADIS_FORMAT_INT32: {
-            switch (reg_output_format) {
-            case VANADIS_FORMAT_INT64: {
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
+            switch (output_format) {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
                 const int64_t src = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
                 regFile->setIntReg<int64_t>(phys_int_regs_out[0], src);
             } break;
-            case VANADIS_FORMAT_INT32: {
+            case VanadisRegisterFormat::VANADIS_FORMAT_INT32: {
                 const int32_t src = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
                 regFile->setIntReg<int32_t>(phys_int_regs_out[0], src);
             } break;
@@ -90,10 +87,6 @@ public:
 
         markExecuted();
     }
-
-protected:
-    VanadisRegisterFormat reg_input_format;
-    VanadisRegisterFormat reg_output_format;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vxori.h
+++ b/src/sst/elements/vanadis/inst/vxori.h
@@ -33,20 +33,18 @@ public:
         imm_value = immediate;
     }
 
-    VanadisXorImmInstruction* clone() { return new VanadisXorImmInstruction(*this); }
+    VanadisXorImmInstruction* clone() override { return new VanadisXorImmInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
+    const char* getInstCode() const override { return "XORI"; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
-
-    virtual const char* getInstCode() const { return "XORI"; }
-
-    virtual void printToBuffer(char* buffer, size_t buffer_size) {
+    void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(
             buffer, buffer_size,
             "XORI    %5" PRIu16 " <- %5" PRIu16 " ^ imm=%" PRIu64 " (phys: %5" PRIu16 " <- %5" PRIu16 " ^ %" PRIu64 ")",
             isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
     }
 
-    virtual void execute(SST::Output* output, VanadisRegisterFile* regFile) {
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) XORI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRIu64

--- a/src/sst/elements/vanadis/util/vcmpop.h
+++ b/src/sst/elements/vanadis/util/vcmpop.h
@@ -53,6 +53,7 @@ register_compare_values_print_msg(uint64_t line, const char* file, const char* f
                     right_value);
 }
 
+
 template <typename T>
 bool
 registerCompareValues(VanadisRegisterCompareType compareType, VanadisRegisterFile* regFile, VanadisInstruction* ins,
@@ -103,6 +104,57 @@ registerCompareValues(VanadisRegisterCompareType compareType, VanadisRegisterFil
     return compare_result;
 };
 
+template <VanadisRegisterCompareType compareType, typename T>
+bool
+registerCompareValues(VanadisRegisterFile* regFile, VanadisInstruction* ins,
+                      SST::Output* output, T left_value, T right_value) {
+
+    register_compare_values_print_msg(CALL_INFO, output, left_value, right_value);
+
+    bool compare_result = false;
+
+    switch (compareType) {
+    case REG_COMPARE_EQ: {
+        compare_result = (left_value) == (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: equal     / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    case REG_COMPARE_NEQ: {
+        compare_result = (left_value) != (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: not-equal / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    case REG_COMPARE_LT: {
+        compare_result = (left_value) < (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: less-than / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    case REG_COMPARE_LTE: {
+        compare_result = (left_value) <= (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: less-than-eq / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    case REG_COMPARE_GT: {
+        compare_result = (left_value) > (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: greater-than / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    case REG_COMPARE_GTE: {
+        compare_result = (left_value) >= (right_value);
+        output->verbose(CALL_INFO, 16, 0, "-----> compare: greater-than-eq / result: %s\n",
+                        (compare_result ? "true" : "false"));
+    } break;
+    default: {
+        output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%llx\n",
+                        ins->getInstructionAddress());
+        ins->flagError();
+    } break;
+    }
+
+    return compare_result;
+};
+
+
 template <typename T>
 bool
 registerCompare(VanadisRegisterCompareType compareType, VanadisRegisterFile* regFile, VanadisInstruction* ins,
@@ -122,6 +174,27 @@ registerCompareImm(VanadisRegisterCompareType compareType, VanadisRegisterFile* 
     const T left_value = regFile->getIntReg<T>(left);
 
     return registerCompareValues<T>(compareType, regFile, ins, output, left_value, right_value);
+};
+
+template <VanadisRegisterCompareType compareType, typename T>
+bool
+registerCompare(VanadisRegisterFile* regFile, VanadisInstruction* ins,
+                SST::Output* output, uint16_t left, uint16_t right) {
+
+    const T left_value = regFile->getIntReg<T>(left);
+    const T right_value = regFile->getIntReg<T>(right);
+
+    return registerCompareValues<compareType, T>(regFile, ins, output, left_value, right_value);
+};
+
+template <VanadisRegisterCompareType compareType, typename T>
+bool
+registerCompareImm(VanadisRegisterFile* regFile, VanadisInstruction* ins,
+                   SST::Output* output, uint16_t left, T right_value) {
+
+    const T left_value = regFile->getIntReg<T>(left);
+
+    return registerCompareValues<compareType, T>(regFile, ins, output, left_value, right_value);
 };
 
 } // namespace Vanadis


### PR DESCRIPTION
- Replace some known characteristics of micro-ops which are fixed for object lifetimes with templates.
- Adds branch likelihood prediction of `UNLIKELY` to extremely low probability events that would lead to `fatal()` calls so compiler can optimize around these
- Adds branch likelihood prediction of `UNLIKELY` to `SYSCALL` micro-ops since these are infrequent and will be expensive due to event generation and send over a link.
- Guards ISA table printing in retirement which shows on profiling as a high time function
