### PR TITLE
Removes unneeded include in VaultSimC that imports the ELI definition

### DIFF
--- a/src/sst/elements/VaultSimC/app.cpp
+++ b/src/sst/elements/VaultSimC/app.cpp
@@ -25,7 +25,6 @@ static unsigned int missRate[][3] = {{0,51,32},   //app 0
 				     {0,18,15}};  //app 1
 static unsigned int isLoad[] = {3,32}; // out of 64
 
-using namespace SST::MemHierarchy;
 using namespace SST::VaultSim;
 
 MemReqEvent *cpu::getInst(int cacheLevel, int app, int core) {

--- a/src/sst/elements/VaultSimC/memReqEvent.h
+++ b/src/sst/elements/VaultSimC/memReqEvent.h
@@ -17,7 +17,6 @@
 #define _H_SST_VAULTSIM_MEM_EVENT
 
 #include <sst/core/event.h>
-#include <sst/elements/VaultSimC/VaultSimC.h>
 
 namespace SST {
 namespace VaultSim {


### PR DESCRIPTION
Fixes unneeded include in VaultSimC which would import the ELI definition. The result is the memHierarchy loads can fail when dynamically loaded because VaultSimC is also not loaded.

The definitions are not needed and so this removes the load time failure.