### PR TITLE
Fix warning in Opal relating to type in output statement

### DIFF
--- a/src/sst/elements/Opal/Opal.cc
+++ b/src/sst/elements/Opal/Opal.cc
@@ -421,7 +421,7 @@ REQRESPONSE Opal::allocateFromReservedMemory(int node, uint64_t reserved_vAddres
 	}
 	else
 	{
-		output->fatal(CALL_INFO, -1, "Opal: address :%llu requested with fileId:%d has no space left\n", vAddress, fileID);
+		output->fatal(CALL_INFO, -1, "Opal: address :%" PRIu64 " requested with fileId:%d has no space left\n", vAddress, fileID);
 	}
 
 	return response;


### PR DESCRIPTION
Fix a type warning in an output statement. Generates a warning during compile.