### PR TITLE
Optimized memHierarchy:CoherenceController

### DIFF
--- a/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
+++ b/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
@@ -729,18 +729,21 @@ void CoherenceController::removeRequestRecord(SST::Event::id_type id) {
 }
 
 void CoherenceController::recordLatencyType(Event::id_type id, int type) {
-    if (startTimes_.find(id) != startTimes_.end())
-        startTimes_.find(id)->second.missType = type;
+    auto it = startTimes_.find(id);
+    if(it != startTimes_.end())
+        it->second.missType = type;
 }
 
 void CoherenceController::recordMiss(Event::id_type id) {
-    if (startTimes_.find(id) != startTimes_.end())
-        startTimes_.find(id)->second.missType = LatType::MISS;
+    auto it = startTimes_.find(id);
+    if(it != startTimes_.end())
+        it->second.missType = LatType::MISS;
 }
 
 void CoherenceController::recordPrefetchLatency(Event::id_type id, int type) {
-    if (startTimes_.find(id) != startTimes_.end()) {
-        LatencyStat stat = startTimes_.find(id)->second;
+    auto it = startTimes_.find(id);
+    if(it != startTimes_.end()) {
+        LatencyStat stat = it->second;
         recordLatency(stat.cmd, type, timestamp_ - stat.time);
         startTimes_.erase(id);
     }


### PR DESCRIPTION
CoherenceController::recordMiss(...) was on the hot path, specifically
the std::map::find. Old code made 2 calls to find() for each func,
I switched it to make 1 call each time, seems to have 10-15% speedup on
skylake benchmark.

Erase this information and put your Pull Request comments here 
---

Instructions for Issuing a Pull Request to sst-elements
-------------------------------------------------------

1 - Verify that the Pull Request is targeted to the **devel** branch of sstsimulator/sst-elements

2 - Verify that Source branch is up to date with the devel branch of sst-elements

3 - After submitting your Pull Request:
   * Automatic Testing will commence in a short while 
      * Pull Requests will be tested with the devel branches of the sst-core and sst-sqe repositories
         * These branches are syncronized with the devel branch of sst-elements.  This is why is it important to keep your source branch up to date.
      * If testing passes, the source branch will be automatically merged (if possible)
         * Pull Requests from forks will not be automatically tested until the code is inspected.
         * Pull Requests from forks will not be automatically merged into the devel branch.
      * If testing fails, You will be notified of the test results.  
         * The Pull Request will be retested on a regular basis - Changes to the source branch can be made to correct problems
         
4 - DO NOT DELETE THE BRANCH (OR FORKED REPO) UNTIL THE PULL REQUEST IS MERGED.
----
