### PR TITLE
memH: fix mmap based backing to memory_file

### DIFF
--- a/src/sst/elements/memHierarchy/membackend/backing.h
+++ b/src/sst/elements/memHierarchy/membackend/backing.h
@@ -27,7 +27,7 @@ namespace Backend {
 class Backing {
 public:
     Backing( ) { }
-    ~Backing() { }
+    virtual ~Backing() { }
 
     virtual void set( Addr addr, uint8_t value ) = 0;
     virtual void set( Addr addr, size_t size, std::vector<uint8_t>& data) = 0;
@@ -39,7 +39,7 @@ public:
 class BackingMMAP : public Backing {
 public:
     BackingMMAP(std::string memoryFile, size_t size, size_t offset = 0) : Backing(), m_fd(-1), m_size(size), m_offset(offset) {
-        int flags = MAP_PRIVATE;
+        int flags = MAP_SHARED;
         if ( ! memoryFile.empty() ) {
             m_fd = open(memoryFile.c_str(), O_RDWR);
             if ( m_fd < 0) {

--- a/src/sst/elements/memHierarchy/memoryCacheController.h
+++ b/src/sst/elements/memHierarchy/memoryCacheController.h
@@ -84,7 +84,10 @@ public:
 
 protected:
     MemCacheController();  // for serialization only
-    ~MemCacheController() {}
+    ~MemCacheController() {
+        if (backing_)
+            delete backing_;
+    }
 
     /*
      *  HIT: When the response comes back we're done (tag + data or just data)

--- a/src/sst/elements/memHierarchy/memoryController.h
+++ b/src/sst/elements/memHierarchy/memoryController.h
@@ -96,7 +96,10 @@ public:
 
 protected:
     MemController();  // for serialization only
-    ~MemController() {}
+    ~MemController() {
+        if (backing_)
+            delete backing_;
+    }
 
     void notifyListeners( MemEvent* ev ) {
         if (  ! listeners_.empty()) {

--- a/src/sst/elements/memHierarchy/scratchpad.h
+++ b/src/sst/elements/memHierarchy/scratchpad.h
@@ -91,7 +91,10 @@ public:
 
 private:
 
-    ~Scratchpad() {}
+    ~Scratchpad() {
+        if (backing_)
+            delete backing_;
+    }
 
     // Parameters - scratchpad
     uint64_t scratchSize_;      // Size of the total scratchpad in bytes - any address above this is assumed to address remote memory


### PR DESCRIPTION
The 'memory_file' parameter description on some components in
memH suggests support for 'storing resulting state' through
to the specified file. This fix mmap's as MAP_SHARED, and ensures munmap/close gets called.
