### PR TITLE
memH: Bug fix for incorrect prefetch latency statistics

### DIFF
--- a/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen.out
+++ b/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen.out
@@ -108,8 +108,8 @@ After initialization
  l1cache.evict_IM : Accumulator : Sum.u64 = 71; SumSQ.u64 = 71; Count.u64 = 71; Min.u64 = 1; Max.u64 = 1; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 1104; SumSQ.u64 = 1212210; Count.u64 = 2; Min.u64 = 3; Max.u64 = 1101; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 106818375; SumSQ.u64 = 1174505083469; Count.u64 = 9998; Min.u64 = 168; Max.u64 = 21670; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 16071; SumSQ.u64 = 169577625; Count.u64 = 9; Min.u64 = 1; Max.u64 = 12793; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 160991686; SumSQ.u64 = 1789627521620; Count.u64 = 14901; Min.u64 = 89; Max.u64 = 21670; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 29241; SumSQ.u64 = 87723; Count.u64 = 9747; Min.u64 = 3; Max.u64 = 3; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 3102927; SumSQ.u64 = 39898307565; Count.u64 = 253; Min.u64 = 859; Max.u64 = 23655; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen_2RANKS.out
+++ b/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen_2RANKS.out
@@ -108,8 +108,8 @@ After initialization
  l1cache.evict_IM : Accumulator : Sum.u64 = 83; SumSQ.u64 = 83; Count.u64 = 83; Min.u64 = 1; Max.u64 = 1; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 858; SumSQ.u64 = 731034; Count.u64 = 2; Min.u64 = 3; Max.u64 = 855; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 105713427; SumSQ.u64 = 1153312533653; Count.u64 = 9998; Min.u64 = 688; Max.u64 = 20608; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 28282; SumSQ.u64 = 280831162; Count.u64 = 10; Min.u64 = 1; Max.u64 = 11367; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 159577986; SumSQ.u64 = 1761000419038; Count.u64 = 14912; Min.u64 = 87; Max.u64 = 20608; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 29229; SumSQ.u64 = 87687; Count.u64 = 9743; Min.u64 = 3; Max.u64 = 3; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 3089995; SumSQ.u64 = 39219641985; Count.u64 = 257; Min.u64 = 87; Max.u64 = 21833; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen_fastNVM.out
+++ b/src/sst/elements/Messier/tests/refFiles/test_Messier_gupsgen_fastNVM.out
@@ -108,8 +108,8 @@ After initialization
  l1cache.evict_IM : Accumulator : Sum.u64 = 73; SumSQ.u64 = 73; Count.u64 = 73; Min.u64 = 1; Max.u64 = 1; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 248; SumSQ.u64 = 60034; Count.u64 = 2; Min.u64 = 3; Max.u64 = 245; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 22064351; SumSQ.u64 = 49810655805; Count.u64 = 9998; Min.u64 = 208; Max.u64 = 4038; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 5647; SumSQ.u64 = 11832047; Count.u64 = 7; Min.u64 = 1; Max.u64 = 2701; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 33266355; SumSQ.u64 = 75942471741; Count.u64 = 14899; Min.u64 = 57; Max.u64 = 4038; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 29217; SumSQ.u64 = 87651; Count.u64 = 9739; Min.u64 = 3; Max.u64 = 3; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 665727; SumSQ.u64 = 1767367141; Count.u64 = 261; Min.u64 = 493; Max.u64 = 4637; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/Messier/tests/refFiles/test_Messier_stencil3dbench_messier.out
+++ b/src/sst/elements/Messier/tests/refFiles/test_Messier_stencil3dbench_messier.out
@@ -108,8 +108,8 @@ After initialization
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 4392331; SumSQ.u64 = 5734569969; Count.u64 = 108816; Min.u64 = 3; Max.u64 = 3992; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 24189; SumSQ.u64 = 21031757; Count.u64 = 48; Min.u64 = 88; Max.u64 = 2153; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 4458869; SumSQ.u64 = 5767856883; Count.u64 = 113142; Min.u64 = 1; Max.u64 = 3992; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 510618; SumSQ.u64 = 607414306; Count.u64 = 1063; Min.u64 = 85; Max.u64 = 4030; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 390071; SumSQ.u64 = 363804565; Count.u64 = 3792; Min.u64 = 3; Max.u64 = 2174; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 100907; SumSQ.u64 = 105582051; Count.u64 = 240; Min.u64 = 87; Max.u64 = 2920; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/Messier/tests/refFiles/test_Messier_streambench_messier.out
+++ b/src/sst/elements/Messier/tests/refFiles/test_Messier_streambench_messier.out
@@ -108,8 +108,8 @@ After initialization
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 19581312; SumSQ.u64 = 35281832398; Count.u64 = 15962; Min.u64 = 3; Max.u64 = 4438; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 6124770; SumSQ.u64 = 12341539296; Count.u64 = 4038; Min.u64 = 89; Max.u64 = 4439; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 22771240; SumSQ.u64 = 41046192344; Count.u64 = 19411; Min.u64 = 1; Max.u64 = 4438; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 8515668; SumSQ.u64 = 15827528836; Count.u64 = 6394; Min.u64 = 85; Max.u64 = 4439; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 3079385; SumSQ.u64 = 3698575173; Count.u64 = 8893; Min.u64 = 3; Max.u64 = 2572; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 737664; SumSQ.u64 = 977613914; Count.u64 = 1107; Min.u64 = 87; Max.u64 = 2573; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/cassini/tests/refFiles/test_cassini_prefetch_nbp.out
+++ b/src/sst/elements/cassini/tests/refFiles/test_cassini_prefetch_nbp.out
@@ -91,7 +91,7 @@ Completed @ 11134750 ns
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 53224273; SumSQ.u64 = 74255146559; Count.u64 = 84235; Min.u64 = 3; Max.u64 = 2008; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 11237602; SumSQ.u64 = 22566785090; Count.u64 = 5596; Min.u64 = 2007; Max.u64 = 2010; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 23783134; SumSQ.u64 = 47749257124; Count.u64 = 11846; Min.u64 = 2005; Max.u64 = 2010; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 6105592; SumSQ.u64 = 8473902354; Count.u64 = 9515; Min.u64 = 3; Max.u64 = 2007; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 1313342; SumSQ.u64 = 2637412270; Count.u64 = 654; Min.u64 = 2007; Max.u64 = 2009; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/cassini/tests/refFiles/test_cassini_prefetch_sp.out
+++ b/src/sst/elements/cassini/tests/refFiles/test_cassini_prefetch_sp.out
@@ -91,8 +91,8 @@ Completed @ 11074943 ns
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 75718461; SumSQ.u64 = 97972842609; Count.u64 = 83713; Min.u64 = 3; Max.u64 = 2008; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 12318021; SumSQ.u64 = 24736497897; Count.u64 = 6134; Min.u64 = 2007; Max.u64 = 2010; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 85803309; SumSQ.u64 = 114055276563; Count.u64 = 90314; Min.u64 = 3; Max.u64 = 2008; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 23710914; SumSQ.u64 = 47592290000; Count.u64 = 11813; Min.u64 = 2005; Max.u64 = 2010; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 8557763; SumSQ.u64 = 11064193585; Count.u64 = 9466; Min.u64 = 3; Max.u64 = 2007; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 1379585; SumSQ.u64 = 2770386079; Count.u64 = 687; Min.u64 = 2007; Max.u64 = 2009; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/cacheController.cc
+++ b/src/sst/elements/memHierarchy/cacheController.cc
@@ -62,13 +62,6 @@ void Cache::handleEvent(SST::Event * ev) {
  *  a prefetch target
  */
 void Cache::handlePrefetchEvent(SST::Event * ev) {
-    MemEventBase *event = static_cast<MemEventBase*>(ev);
-
-    // Record the time at which requests arrive for latency statistics
-    if (CommandClassArr[(int)event->getCmd()] == CommandClass::Request &&
-        !CommandWriteback[(int)event->getCmd()])
-        coherenceMgr_->recordIncomingRequest(event);
-
     prefetchSelfLink_->send(prefetchDelay_, ev);
 }
 
@@ -82,6 +75,11 @@ void Cache::processPrefetchEvent(SST::Event * ev) {
     if (!clockIsOn_) {
         turnClockOn();
     }
+
+    // Record the time at which requests arrive for latency statistics
+    if (CommandClassArr[(int)event->getCmd()] == CommandClass::Request &&
+        !CommandWriteback[(int)event->getCmd()])
+        coherenceMgr_->recordIncomingRequest(static_cast<MemEventBase*>(event));
 
     // Record received prefetch
     statPrefetchRequest->addData(1);

--- a/src/sst/elements/memHierarchy/cacheController.cc
+++ b/src/sst/elements/memHierarchy/cacheController.cc
@@ -62,6 +62,13 @@ void Cache::handleEvent(SST::Event * ev) {
  *  a prefetch target
  */
 void Cache::handlePrefetchEvent(SST::Event * ev) {
+    MemEventBase *event = static_cast<MemEventBase*>(ev);
+
+    // Record the time at which requests arrive for latency statistics
+    if (CommandClassArr[(int)event->getCmd()] == CommandClass::Request &&
+        !CommandWriteback[(int)event->getCmd()])
+        coherenceMgr_->recordIncomingRequest(event);
+
     prefetchSelfLink_->send(prefetchDelay_, ev);
 }
 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_1.out
@@ -7,13 +7,13 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu7 Finished after 5000 issued reads, 5000 returned (15989437 clocks)
-TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
-TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
-TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
-TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
-TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
-TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
 TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15837221 clocks)
+TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
+TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
+TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
+TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
+TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
+TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
  l3cache:memlink.packet_latency : Accumulator : Sum.u64 = 7032280; SumSQ.u64 = 668066600; Count.u64 = 74024; Min.u64 = 95; Max.u64 = 95; 
  l3cache:memlink.send_bit_count : Accumulator : Sum.u64 = 6681088; SumSQ.u64 = 1547075584; Count.u64 = 74024; Min.u64 = 64; Max.u64 = 576; 
  l3cache:memlink.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_2.out
@@ -7,13 +7,13 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu7 Finished after 5000 issued reads, 5000 returned (15989437 clocks)
-TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
-TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
-TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
-TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
-TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
-TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
 TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15837221 clocks)
+TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
+TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
+TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
+TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
+TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
+TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
  l3cache:memlink.packet_latency : Accumulator : Sum.u64 = 7476424; SumSQ.u64 = 755118824; Count.u64 = 74024; Min.u64 = 101; Max.u64 = 101; 
  l3cache:memlink.send_bit_count : Accumulator : Sum.u64 = 6681088; SumSQ.u64 = 1547075584; Count.u64 = 74024; Min.u64 = 64; Max.u64 = 576; 
  l3cache:memlink.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_3.out
@@ -7,13 +7,13 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu7 Finished after 5000 issued reads, 5000 returned (15989437 clocks)
-TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
-TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
-TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
-TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
-TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
-TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
 TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15837221 clocks)
+TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
+TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
+TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
+TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
+TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
+TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
  l3cache:memlink.packet_latency : Accumulator : Sum.u64 = 7032280; SumSQ.u64 = 668066600; Count.u64 = 74024; Min.u64 = 95; Max.u64 = 95; 
  l3cache:memlink.send_bit_count : Accumulator : Sum.u64 = 6681088; SumSQ.u64 = 1547075584; Count.u64 = 74024; Min.u64 = 64; Max.u64 = 576; 
  l3cache:memlink.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_4.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendTimingDRAM_4.out
@@ -7,13 +7,13 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu7 Finished after 5000 issued reads, 5000 returned (15989437 clocks)
-TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
-TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
-TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
-TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
-TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
-TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
 TrivialCPU cpu6 Finished after 5000 issued reads, 5000 returned (15837221 clocks)
+TrivialCPU cpu5 Finished after 5000 issued reads, 5000 returned (15968248 clocks)
+TrivialCPU cpu4 Finished after 5000 issued reads, 5000 returned (15857113 clocks)
+TrivialCPU cpu0 Finished after 5000 issued reads, 5000 returned (16006302 clocks)
+TrivialCPU cpu1 Finished after 5000 issued reads, 5000 returned (15858410 clocks)
+TrivialCPU cpu2 Finished after 5000 issued reads, 5000 returned (15969113 clocks)
+TrivialCPU cpu3 Finished after 5000 issued reads, 5000 returned (15904248 clocks)
  l3cache:memlink.packet_latency : Accumulator : Sum.u64 = 7032280; SumSQ.u64 = 668066600; Count.u64 = 74024; Min.u64 = 95; Max.u64 = 95; 
  l3cache:memlink.send_bit_count : Accumulator : Sum.u64 = 6681088; SumSQ.u64 = 1547075584; Count.u64 = 74024; Min.u64 = 64; Max.u64 = 576; 
  l3cache:memlink.output_port_stalls : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_BackendVaultSim.out
@@ -6,10 +6,10 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (471954 clocks)
-TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (470658 clocks)
-TrivialCPU cpu1 Finished after 1000 issued reads, 1000 returned (472242 clocks)
 TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (471522 clocks)
+TrivialCPU cpu1 Finished after 1000 issued reads, 1000 returned (472242 clocks)
+TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (470658 clocks)
+TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (471954 clocks)
  cpu0.pendCycle : Accumulator : Sum.u64 = 4584129; SumSQ.u64 = 44799551; Count.u64 = 471522; Min.u64 = 0; Max.u64 = 10; 
  c0.l1cache.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  c0.l1cache.stateEvent_GetS_I : Accumulator : Sum.u64 = 896; SumSQ.u64 = 896; Count.u64 = 896; Min.u64 = 1; Max.u64 = 1; 
@@ -1238,7 +1238,7 @@ TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (471522 clocks)
  dirctrl.eventSent_FlushLineResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  dirctrl.eventSent_read_directory_entry : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  dirctrl.eventSent_write_directory_entry : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- dirctrl.MSHR_occupancy : Accumulator : Sum.u64 = 260544; SumSQ.u64 = 260544; Count.u64 = 471962; Min.u64 = 0; Max.u64 = 1; 
+ dirctrl.MSHR_occupancy : Accumulator : Sum.u64 = 260544; SumSQ.u64 = 260544; Count.u64 = 471961; Min.u64 = 0; Max.u64 = 1; 
  memory.requests_received_GetS : Accumulator : Sum.u64 = 3399; SumSQ.u64 = 3399; Count.u64 = 3399; Min.u64 = 1; Max.u64 = 1; 
  memory.requests_received_GetSX : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  memory.requests_received_GetX : Accumulator : Sum.u64 = 377; SumSQ.u64 = 377; Count.u64 = 377; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 95894; SumSQ.u64 = 656170; Count.u64 = 19222; Min.u64 = 3; Max.u64 = 13; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 9142; SumSQ.u64 = 107892; Count.u64 = 778; Min.u64 = 11; Max.u64 = 13; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 96821; SumSQ.u64 = 664585; Count.u64 = 19355; Min.u64 = 1; Max.u64 = 13; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 25998; SumSQ.u64 = 273252; Count.u64 = 2502; Min.u64 = 9; Max.u64 = 13; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_1_MC.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 95894; SumSQ.u64 = 656170; Count.u64 = 19222; Min.u64 = 3; Max.u64 = 13; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 9142; SumSQ.u64 = 107892; Count.u64 = 778; Min.u64 = 11; Max.u64 = 13; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 96821; SumSQ.u64 = 664585; Count.u64 = 19355; Min.u64 = 1; Max.u64 = 13; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 25998; SumSQ.u64 = 273252; Count.u64 = 2502; Min.u64 = 9; Max.u64 = 13; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3.out
@@ -243,8 +243,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_0.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 88074; SumSQ.u64 = 24543946; Count.u64 = 368; Min.u64 = 5; Max.u64 = 438; 
- l1cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 73029; SumSQ.u64 = 21605029; Count.u64 = 256; Min.u64 = 17; Max.u64 = 445; 
+ l1cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 98744; SumSQ.u64 = 27057812; Count.u64 = 448; Min.u64 = 1; Max.u64 = 438; 
+ l1cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 89190; SumSQ.u64 = 26283246; Count.u64 = 313; Min.u64 = 13; Max.u64 = 445; 
  l1cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -455,7 +455,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_0.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 76; SumSQ.u64 = 370; Count.u64 = 34; Min.u64 = 1; Max.u64 = 7; 
  l2cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 86238; SumSQ.u64 = 24655472; Count.u64 = 306; Min.u64 = 65; Max.u64 = 435; 
  l2cache_0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -670,8 +670,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_1.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 125801; SumSQ.u64 = 31605783; Count.u64 = 706; Min.u64 = 5; Max.u64 = 439; 
- l1cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 58737; SumSQ.u64 = 16369195; Count.u64 = 230; Min.u64 = 17; Max.u64 = 450; 
+ l1cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 140384; SumSQ.u64 = 35147526; Count.u64 = 807; Min.u64 = 1; Max.u64 = 439; 
+ l1cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 78816; SumSQ.u64 = 21693132; Count.u64 = 315; Min.u64 = 13; Max.u64 = 450; 
  l1cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -882,7 +882,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_1.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_1.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 67; SumSQ.u64 = 361; Count.u64 = 25; Min.u64 = 1; Max.u64 = 7; 
  l2cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 75954; SumSQ.u64 = 20301490; Count.u64 = 308; Min.u64 = 77; Max.u64 = 440; 
  l2cache_1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1097,8 +1097,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_2.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 83553; SumSQ.u64 = 22051371; Count.u64 = 386; Min.u64 = 5; Max.u64 = 447; 
- l1cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 69946; SumSQ.u64 = 21013796; Count.u64 = 238; Min.u64 = 17; Max.u64 = 517; 
+ l1cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 92211; SumSQ.u64 = 24010925; Count.u64 = 441; Min.u64 = 1; Max.u64 = 447; 
+ l1cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 92018; SumSQ.u64 = 27621826; Count.u64 = 316; Min.u64 = 13; Max.u64 = 517; 
  l1cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1309,7 +1309,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_2.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 166; SumSQ.u64 = 10316; Count.u64 = 5; Min.u64 = 7; Max.u64 = 89; 
+ l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 191; SumSQ.u64 = 10341; Count.u64 = 30; Min.u64 = 1; Max.u64 = 89; 
  l2cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 88983; SumSQ.u64 = 25970155; Count.u64 = 311; Min.u64 = 87; Max.u64 = 508; 
  l2cache_2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1524,8 +1524,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_3.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 125758; SumSQ.u64 = 32186034; Count.u64 = 708; Min.u64 = 5; Max.u64 = 413; 
- l1cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 57845; SumSQ.u64 = 16082553; Count.u64 = 228; Min.u64 = 17; Max.u64 = 460; 
+ l1cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 139780; SumSQ.u64 = 35563810; Count.u64 = 804; Min.u64 = 1; Max.u64 = 413; 
+ l1cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 79853; SumSQ.u64 = 22068287; Count.u64 = 317; Min.u64 = 13; Max.u64 = 460; 
  l1cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1736,7 +1736,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_3.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_3.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 61; SumSQ.u64 = 355; Count.u64 = 19; Min.u64 = 1; Max.u64 = 7; 
  l2cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 76989; SumSQ.u64 = 20672397; Count.u64 = 310; Min.u64 = 91; Max.u64 = 450; 
  l2cache_3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1951,8 +1951,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_4.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 87229; SumSQ.u64 = 24445019; Count.u64 = 369; Min.u64 = 5; Max.u64 = 417; 
- l1cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 73235; SumSQ.u64 = 21725869; Count.u64 = 255; Min.u64 = 17; Max.u64 = 453; 
+ l1cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 98023; SumSQ.u64 = 27039287; Count.u64 = 447; Min.u64 = 1; Max.u64 = 417; 
+ l1cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 90376; SumSQ.u64 = 26753252; Count.u64 = 315; Min.u64 = 13; Max.u64 = 495; 
  l1cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2163,7 +2163,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_4.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 66; SumSQ.u64 = 318; Count.u64 = 30; Min.u64 = 1; Max.u64 = 7; 
  l2cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 87422; SumSQ.u64 = 25109118; Count.u64 = 309; Min.u64 = 71; Max.u64 = 489; 
  l2cache_4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2378,8 +2378,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_5.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 126789; SumSQ.u64 = 31889845; Count.u64 = 716; Min.u64 = 5; Max.u64 = 417; 
- l1cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 57130; SumSQ.u64 = 15995428; Count.u64 = 220; Min.u64 = 17; Max.u64 = 454; 
+ l1cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 141401; SumSQ.u64 = 35424525; Count.u64 = 809; Min.u64 = 1; Max.u64 = 417; 
+ l1cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 81703; SumSQ.u64 = 22738309; Count.u64 = 317; Min.u64 = 13; Max.u64 = 454; 
  l1cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2590,7 +2590,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_5.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_5.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 57; SumSQ.u64 = 309; Count.u64 = 21; Min.u64 = 1; Max.u64 = 7; 
  l2cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 78876; SumSQ.u64 = 21324706; Count.u64 = 311; Min.u64 = 75; Max.u64 = 444; 
  l2cache_5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2805,8 +2805,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_6.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 84175; SumSQ.u64 = 21818649; Count.u64 = 381; Min.u64 = 5; Max.u64 = 488; 
- l1cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 70733; SumSQ.u64 = 21144417; Count.u64 = 243; Min.u64 = 17; Max.u64 = 511; 
+ l1cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 91113; SumSQ.u64 = 23117579; Count.u64 = 434; Min.u64 = 1; Max.u64 = 488; 
+ l1cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 92350; SumSQ.u64 = 27933156; Count.u64 = 316; Min.u64 = 11; Max.u64 = 661; 
  l1cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3017,7 +3017,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_6.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_6.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 82; SumSQ.u64 = 3308; Count.u64 = 5; Min.u64 = 5; Max.u64 = 56; 
+ l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 107; SumSQ.u64 = 3333; Count.u64 = 30; Min.u64 = 1; Max.u64 = 56; 
  l2cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 89262; SumSQ.u64 = 26168886; Count.u64 = 311; Min.u64 = 85; Max.u64 = 655; 
  l2cache_6.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3232,8 +3232,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_7.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 126634; SumSQ.u64 = 33067910; Count.u64 = 712; Min.u64 = 5; Max.u64 = 451; 
- l1cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 57568; SumSQ.u64 = 16143378; Count.u64 = 224; Min.u64 = 17; Max.u64 = 458; 
+ l1cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 141181; SumSQ.u64 = 36697911; Count.u64 = 810; Min.u64 = 1; Max.u64 = 451; 
+ l1cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 79917; SumSQ.u64 = 22233551; Count.u64 = 315; Min.u64 = 13; Max.u64 = 458; 
  l1cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3444,7 +3444,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_7.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_7.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_7.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 68; SumSQ.u64 = 362; Count.u64 = 26; Min.u64 = 1; Max.u64 = 7; 
  l2cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 77072; SumSQ.u64 = 20834844; Count.u64 = 308; Min.u64 = 89; Max.u64 = 448; 
  l2cache_7.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3659,8 +3659,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_8.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 87758; SumSQ.u64 = 24033698; Count.u64 = 368; Min.u64 = 5; Max.u64 = 442; 
- l1cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 73303; SumSQ.u64 = 21681979; Count.u64 = 256; Min.u64 = 17; Max.u64 = 447; 
+ l1cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 100582; SumSQ.u64 = 26888700; Count.u64 = 451; Min.u64 = 1; Max.u64 = 442; 
+ l1cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 89779; SumSQ.u64 = 26495959; Count.u64 = 314; Min.u64 = 13; Max.u64 = 447; 
  l1cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3871,7 +3871,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_8.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_8.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 128; SumSQ.u64 = 7690; Count.u64 = 7; Min.u64 = 7; Max.u64 = 86; 
+ l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 152; SumSQ.u64 = 7714; Count.u64 = 31; Min.u64 = 1; Max.u64 = 86; 
  l2cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 86743; SumSQ.u64 = 24852185; Count.u64 = 307; Min.u64 = 69; Max.u64 = 437; 
  l2cache_8.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4086,8 +4086,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_9.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 128091; SumSQ.u64 = 32437145; Count.u64 = 721; Min.u64 = 5; Max.u64 = 416; 
- l1cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 55987; SumSQ.u64 = 15705223; Count.u64 = 215; Min.u64 = 17; Max.u64 = 448; 
+ l1cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 141044; SumSQ.u64 = 35589786; Count.u64 = 809; Min.u64 = 1; Max.u64 = 416; 
+ l1cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 81182; SumSQ.u64 = 22581964; Count.u64 = 316; Min.u64 = 13; Max.u64 = 448; 
  l1cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4298,7 +4298,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_9.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_9.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_9.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 64; SumSQ.u64 = 316; Count.u64 = 28; Min.u64 = 1; Max.u64 = 7; 
  l2cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 78380; SumSQ.u64 = 21182940; Count.u64 = 310; Min.u64 = 73; Max.u64 = 438; 
  l2cache_9.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4513,8 +4513,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_10.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 86078; SumSQ.u64 = 23231080; Count.u64 = 387; Min.u64 = 5; Max.u64 = 425; 
- l1cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 69102; SumSQ.u64 = 20690392; Count.u64 = 237; Min.u64 = 17; Max.u64 = 502; 
+ l1cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 94000; SumSQ.u64 = 25111986; Count.u64 = 436; Min.u64 = 1; Max.u64 = 425; 
+ l1cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 92315; SumSQ.u64 = 27798329; Count.u64 = 316; Min.u64 = 11; Max.u64 = 533; 
  l1cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4725,7 +4725,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_10.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_10.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 82; SumSQ.u64 = 3308; Count.u64 = 5; Min.u64 = 5; Max.u64 = 56; 
+ l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 100; SumSQ.u64 = 3326; Count.u64 = 23; Min.u64 = 1; Max.u64 = 56; 
  l2cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 89292; SumSQ.u64 = 26086128; Count.u64 = 311; Min.u64 = 83; Max.u64 = 527; 
  l2cache_10.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4940,8 +4940,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_11.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 130473; SumSQ.u64 = 33294585; Count.u64 = 709; Min.u64 = 5; Max.u64 = 462; 
- l1cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 56100; SumSQ.u64 = 15459976; Count.u64 = 227; Min.u64 = 17; Max.u64 = 465; 
+ l1cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 146335; SumSQ.u64 = 37287809; Count.u64 = 812; Min.u64 = 1; Max.u64 = 462; 
+ l1cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 78220; SumSQ.u64 = 21516156; Count.u64 = 316; Min.u64 = 17; Max.u64 = 465; 
  l1cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5152,7 +5152,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_11.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_11.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_11.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 28; SumSQ.u64 = 196; Count.u64 = 4; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 50; SumSQ.u64 = 218; Count.u64 = 26; Min.u64 = 1; Max.u64 = 7; 
  l2cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 75384; SumSQ.u64 = 20152166; Count.u64 = 312; Min.u64 = 57; Max.u64 = 455; 
  l2cache_11.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5367,8 +5367,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_12.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 87104; SumSQ.u64 = 24419210; Count.u64 = 370; Min.u64 = 5; Max.u64 = 440; 
- l1cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 72867; SumSQ.u64 = 21665667; Count.u64 = 254; Min.u64 = 17; Max.u64 = 455; 
+ l1cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 98105; SumSQ.u64 = 27021151; Count.u64 = 452; Min.u64 = 1; Max.u64 = 440; 
+ l1cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 89507; SumSQ.u64 = 26419005; Count.u64 = 313; Min.u64 = 17; Max.u64 = 455; 
  l1cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5579,7 +5579,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_12.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_12.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 105; SumSQ.u64 = 4263; Count.u64 = 7; Min.u64 = 7; Max.u64 = 63; 
+ l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 120; SumSQ.u64 = 4278; Count.u64 = 22; Min.u64 = 1; Max.u64 = 63; 
  l2cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 86506; SumSQ.u64 = 24785216; Count.u64 = 306; Min.u64 = 67; Max.u64 = 445; 
  l2cache_12.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5794,8 +5794,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_13.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 127686; SumSQ.u64 = 32108078; Count.u64 = 709; Min.u64 = 5; Max.u64 = 430; 
- l1cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 58257; SumSQ.u64 = 16231107; Count.u64 = 227; Min.u64 = 17; Max.u64 = 470; 
+ l1cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 143117; SumSQ.u64 = 35772527; Count.u64 = 812; Min.u64 = 1; Max.u64 = 430; 
+ l1cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 79926; SumSQ.u64 = 22328724; Count.u64 = 317; Min.u64 = 13; Max.u64 = 703; 
  l1cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6006,7 +6006,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_13.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_13.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_13.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 35; SumSQ.u64 = 245; Count.u64 = 5; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 59; SumSQ.u64 = 269; Count.u64 = 29; Min.u64 = 1; Max.u64 = 7; 
  l2cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 77077; SumSQ.u64 = 20928229; Count.u64 = 312; Min.u64 = 79; Max.u64 = 697; 
  l2cache_13.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6221,8 +6221,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_14.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 86809; SumSQ.u64 = 23894827; Count.u64 = 381; Min.u64 = 5; Max.u64 = 424; 
- l1cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 70728; SumSQ.u64 = 21131260; Count.u64 = 243; Min.u64 = 17; Max.u64 = 506; 
+ l1cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 94193; SumSQ.u64 = 25612575; Count.u64 = 439; Min.u64 = 1; Max.u64 = 424; 
+ l1cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 91943; SumSQ.u64 = 27498963; Count.u64 = 316; Min.u64 = 17; Max.u64 = 522; 
  l1cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6433,7 +6433,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_14.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_14.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 108; SumSQ.u64 = 4244; Count.u64 = 5; Min.u64 = 7; Max.u64 = 56; 
+ l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 130; SumSQ.u64 = 4266; Count.u64 = 27; Min.u64 = 1; Max.u64 = 56; 
  l2cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 88870; SumSQ.u64 = 25777058; Count.u64 = 311; Min.u64 = 81; Max.u64 = 496; 
  l2cache_14.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6648,8 +6648,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_15.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 128887; SumSQ.u64 = 33229877; Count.u64 = 717; Min.u64 = 5; Max.u64 = 452; 
- l1cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 55518; SumSQ.u64 = 15486170; Count.u64 = 219; Min.u64 = 17; Max.u64 = 462; 
+ l1cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 144789; SumSQ.u64 = 37378001; Count.u64 = 813; Min.u64 = 1; Max.u64 = 452; 
+ l1cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 78306; SumSQ.u64 = 21560064; Count.u64 = 317; Min.u64 = 13; Max.u64 = 463; 
  l1cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6860,7 +6860,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_15.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_15.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_15.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 74; SumSQ.u64 = 368; Count.u64 = 32; Min.u64 = 1; Max.u64 = 7; 
  l2cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 75473; SumSQ.u64 = 20199071; Count.u64 = 310; Min.u64 = 62; Max.u64 = 457; 
  l2cache_15.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_CustomCmdGoblin_3_MC.out
@@ -243,8 +243,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_0.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 88074; SumSQ.u64 = 24543946; Count.u64 = 368; Min.u64 = 5; Max.u64 = 438; 
- l1cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 73029; SumSQ.u64 = 21605029; Count.u64 = 256; Min.u64 = 17; Max.u64 = 445; 
+ l1cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 98744; SumSQ.u64 = 27057812; Count.u64 = 448; Min.u64 = 1; Max.u64 = 438; 
+ l1cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 89190; SumSQ.u64 = 26283246; Count.u64 = 313; Min.u64 = 13; Max.u64 = 445; 
  l1cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_0.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -455,7 +455,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_0.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_0.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 76; SumSQ.u64 = 370; Count.u64 = 34; Min.u64 = 1; Max.u64 = 7; 
  l2cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 86238; SumSQ.u64 = 24655472; Count.u64 = 306; Min.u64 = 65; Max.u64 = 435; 
  l2cache_0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -670,8 +670,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_1.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 125801; SumSQ.u64 = 31605783; Count.u64 = 706; Min.u64 = 5; Max.u64 = 439; 
- l1cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 58737; SumSQ.u64 = 16369195; Count.u64 = 230; Min.u64 = 17; Max.u64 = 450; 
+ l1cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 140384; SumSQ.u64 = 35147526; Count.u64 = 807; Min.u64 = 1; Max.u64 = 439; 
+ l1cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 78816; SumSQ.u64 = 21693132; Count.u64 = 315; Min.u64 = 13; Max.u64 = 450; 
  l1cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_1.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -882,7 +882,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_1.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_1.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 67; SumSQ.u64 = 361; Count.u64 = 25; Min.u64 = 1; Max.u64 = 7; 
  l2cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 75954; SumSQ.u64 = 20301490; Count.u64 = 308; Min.u64 = 77; Max.u64 = 440; 
  l2cache_1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1097,8 +1097,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_2.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 83553; SumSQ.u64 = 22051371; Count.u64 = 386; Min.u64 = 5; Max.u64 = 447; 
- l1cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 69946; SumSQ.u64 = 21013796; Count.u64 = 238; Min.u64 = 17; Max.u64 = 517; 
+ l1cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 92211; SumSQ.u64 = 24010925; Count.u64 = 441; Min.u64 = 1; Max.u64 = 447; 
+ l1cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 92018; SumSQ.u64 = 27621826; Count.u64 = 316; Min.u64 = 13; Max.u64 = 517; 
  l1cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_2.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1309,7 +1309,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_2.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_2.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 166; SumSQ.u64 = 10316; Count.u64 = 5; Min.u64 = 7; Max.u64 = 89; 
+ l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 191; SumSQ.u64 = 10341; Count.u64 = 30; Min.u64 = 1; Max.u64 = 89; 
  l2cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 88983; SumSQ.u64 = 25970155; Count.u64 = 311; Min.u64 = 87; Max.u64 = 508; 
  l2cache_2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1524,8 +1524,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_3.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 125758; SumSQ.u64 = 32186034; Count.u64 = 708; Min.u64 = 5; Max.u64 = 413; 
- l1cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 57845; SumSQ.u64 = 16082553; Count.u64 = 228; Min.u64 = 17; Max.u64 = 460; 
+ l1cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 139780; SumSQ.u64 = 35563810; Count.u64 = 804; Min.u64 = 1; Max.u64 = 413; 
+ l1cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 79853; SumSQ.u64 = 22068287; Count.u64 = 317; Min.u64 = 13; Max.u64 = 460; 
  l1cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_3.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1736,7 +1736,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_3.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_3.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 61; SumSQ.u64 = 355; Count.u64 = 19; Min.u64 = 1; Max.u64 = 7; 
  l2cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 76989; SumSQ.u64 = 20672397; Count.u64 = 310; Min.u64 = 91; Max.u64 = 450; 
  l2cache_3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1951,8 +1951,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_4.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 87229; SumSQ.u64 = 24445019; Count.u64 = 369; Min.u64 = 5; Max.u64 = 417; 
- l1cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 73235; SumSQ.u64 = 21725869; Count.u64 = 255; Min.u64 = 17; Max.u64 = 453; 
+ l1cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 98023; SumSQ.u64 = 27039287; Count.u64 = 447; Min.u64 = 1; Max.u64 = 417; 
+ l1cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 90376; SumSQ.u64 = 26753252; Count.u64 = 315; Min.u64 = 13; Max.u64 = 495; 
  l1cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_4.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2163,7 +2163,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_4.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_4.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 66; SumSQ.u64 = 318; Count.u64 = 30; Min.u64 = 1; Max.u64 = 7; 
  l2cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 87422; SumSQ.u64 = 25109118; Count.u64 = 309; Min.u64 = 71; Max.u64 = 489; 
  l2cache_4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2378,8 +2378,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_5.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 126789; SumSQ.u64 = 31889845; Count.u64 = 716; Min.u64 = 5; Max.u64 = 417; 
- l1cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 57130; SumSQ.u64 = 15995428; Count.u64 = 220; Min.u64 = 17; Max.u64 = 454; 
+ l1cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 141401; SumSQ.u64 = 35424525; Count.u64 = 809; Min.u64 = 1; Max.u64 = 417; 
+ l1cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 81703; SumSQ.u64 = 22738309; Count.u64 = 317; Min.u64 = 13; Max.u64 = 454; 
  l1cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_5.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2590,7 +2590,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_5.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_5.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 57; SumSQ.u64 = 309; Count.u64 = 21; Min.u64 = 1; Max.u64 = 7; 
  l2cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 78876; SumSQ.u64 = 21324706; Count.u64 = 311; Min.u64 = 75; Max.u64 = 444; 
  l2cache_5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2805,8 +2805,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_6.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 84175; SumSQ.u64 = 21818649; Count.u64 = 381; Min.u64 = 5; Max.u64 = 488; 
- l1cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 70733; SumSQ.u64 = 21144417; Count.u64 = 243; Min.u64 = 17; Max.u64 = 511; 
+ l1cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 91113; SumSQ.u64 = 23117579; Count.u64 = 434; Min.u64 = 1; Max.u64 = 488; 
+ l1cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 92350; SumSQ.u64 = 27933156; Count.u64 = 316; Min.u64 = 11; Max.u64 = 661; 
  l1cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_6.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3017,7 +3017,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_6.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_6.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_6.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 82; SumSQ.u64 = 3308; Count.u64 = 5; Min.u64 = 5; Max.u64 = 56; 
+ l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 107; SumSQ.u64 = 3333; Count.u64 = 30; Min.u64 = 1; Max.u64 = 56; 
  l2cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 89262; SumSQ.u64 = 26168886; Count.u64 = 311; Min.u64 = 85; Max.u64 = 655; 
  l2cache_6.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3232,8 +3232,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_7.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 126634; SumSQ.u64 = 33067910; Count.u64 = 712; Min.u64 = 5; Max.u64 = 451; 
- l1cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 57568; SumSQ.u64 = 16143378; Count.u64 = 224; Min.u64 = 17; Max.u64 = 458; 
+ l1cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 141181; SumSQ.u64 = 36697911; Count.u64 = 810; Min.u64 = 1; Max.u64 = 451; 
+ l1cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 79917; SumSQ.u64 = 22233551; Count.u64 = 315; Min.u64 = 13; Max.u64 = 458; 
  l1cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_7.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3444,7 +3444,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_7.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_7.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_7.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 68; SumSQ.u64 = 362; Count.u64 = 26; Min.u64 = 1; Max.u64 = 7; 
  l2cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 77072; SumSQ.u64 = 20834844; Count.u64 = 308; Min.u64 = 89; Max.u64 = 448; 
  l2cache_7.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3659,8 +3659,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_8.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 87758; SumSQ.u64 = 24033698; Count.u64 = 368; Min.u64 = 5; Max.u64 = 442; 
- l1cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 73303; SumSQ.u64 = 21681979; Count.u64 = 256; Min.u64 = 17; Max.u64 = 447; 
+ l1cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 100582; SumSQ.u64 = 26888700; Count.u64 = 451; Min.u64 = 1; Max.u64 = 442; 
+ l1cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 89779; SumSQ.u64 = 26495959; Count.u64 = 314; Min.u64 = 13; Max.u64 = 447; 
  l1cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_8.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -3871,7 +3871,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_8.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_8.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_8.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 128; SumSQ.u64 = 7690; Count.u64 = 7; Min.u64 = 7; Max.u64 = 86; 
+ l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 152; SumSQ.u64 = 7714; Count.u64 = 31; Min.u64 = 1; Max.u64 = 86; 
  l2cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 86743; SumSQ.u64 = 24852185; Count.u64 = 307; Min.u64 = 69; Max.u64 = 437; 
  l2cache_8.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4086,8 +4086,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_9.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 128091; SumSQ.u64 = 32437145; Count.u64 = 721; Min.u64 = 5; Max.u64 = 416; 
- l1cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 55987; SumSQ.u64 = 15705223; Count.u64 = 215; Min.u64 = 17; Max.u64 = 448; 
+ l1cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 141044; SumSQ.u64 = 35589786; Count.u64 = 809; Min.u64 = 1; Max.u64 = 416; 
+ l1cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 81182; SumSQ.u64 = 22581964; Count.u64 = 316; Min.u64 = 13; Max.u64 = 448; 
  l1cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_9.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4298,7 +4298,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_9.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_9.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_9.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 42; SumSQ.u64 = 294; Count.u64 = 6; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 64; SumSQ.u64 = 316; Count.u64 = 28; Min.u64 = 1; Max.u64 = 7; 
  l2cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 78380; SumSQ.u64 = 21182940; Count.u64 = 310; Min.u64 = 73; Max.u64 = 438; 
  l2cache_9.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4513,8 +4513,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_10.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 86078; SumSQ.u64 = 23231080; Count.u64 = 387; Min.u64 = 5; Max.u64 = 425; 
- l1cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 69102; SumSQ.u64 = 20690392; Count.u64 = 237; Min.u64 = 17; Max.u64 = 502; 
+ l1cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 94000; SumSQ.u64 = 25111986; Count.u64 = 436; Min.u64 = 1; Max.u64 = 425; 
+ l1cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 92315; SumSQ.u64 = 27798329; Count.u64 = 316; Min.u64 = 11; Max.u64 = 533; 
  l1cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_10.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4725,7 +4725,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_10.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_10.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_10.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 82; SumSQ.u64 = 3308; Count.u64 = 5; Min.u64 = 5; Max.u64 = 56; 
+ l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 100; SumSQ.u64 = 3326; Count.u64 = 23; Min.u64 = 1; Max.u64 = 56; 
  l2cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 89292; SumSQ.u64 = 26086128; Count.u64 = 311; Min.u64 = 83; Max.u64 = 527; 
  l2cache_10.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -4940,8 +4940,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_11.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 130473; SumSQ.u64 = 33294585; Count.u64 = 709; Min.u64 = 5; Max.u64 = 462; 
- l1cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 56100; SumSQ.u64 = 15459976; Count.u64 = 227; Min.u64 = 17; Max.u64 = 465; 
+ l1cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 146335; SumSQ.u64 = 37287809; Count.u64 = 812; Min.u64 = 1; Max.u64 = 462; 
+ l1cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 78220; SumSQ.u64 = 21516156; Count.u64 = 316; Min.u64 = 17; Max.u64 = 465; 
  l1cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_11.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5152,7 +5152,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_11.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_11.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_11.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 28; SumSQ.u64 = 196; Count.u64 = 4; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 50; SumSQ.u64 = 218; Count.u64 = 26; Min.u64 = 1; Max.u64 = 7; 
  l2cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 75384; SumSQ.u64 = 20152166; Count.u64 = 312; Min.u64 = 57; Max.u64 = 455; 
  l2cache_11.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5367,8 +5367,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_12.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 87104; SumSQ.u64 = 24419210; Count.u64 = 370; Min.u64 = 5; Max.u64 = 440; 
- l1cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 72867; SumSQ.u64 = 21665667; Count.u64 = 254; Min.u64 = 17; Max.u64 = 455; 
+ l1cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 98105; SumSQ.u64 = 27021151; Count.u64 = 452; Min.u64 = 1; Max.u64 = 440; 
+ l1cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 89507; SumSQ.u64 = 26419005; Count.u64 = 313; Min.u64 = 17; Max.u64 = 455; 
  l1cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_12.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5579,7 +5579,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_12.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_12.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_12.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 105; SumSQ.u64 = 4263; Count.u64 = 7; Min.u64 = 7; Max.u64 = 63; 
+ l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 120; SumSQ.u64 = 4278; Count.u64 = 22; Min.u64 = 1; Max.u64 = 63; 
  l2cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 86506; SumSQ.u64 = 24785216; Count.u64 = 306; Min.u64 = 67; Max.u64 = 445; 
  l2cache_12.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -5794,8 +5794,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_13.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 127686; SumSQ.u64 = 32108078; Count.u64 = 709; Min.u64 = 5; Max.u64 = 430; 
- l1cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 58257; SumSQ.u64 = 16231107; Count.u64 = 227; Min.u64 = 17; Max.u64 = 470; 
+ l1cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 143117; SumSQ.u64 = 35772527; Count.u64 = 812; Min.u64 = 1; Max.u64 = 430; 
+ l1cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 79926; SumSQ.u64 = 22328724; Count.u64 = 317; Min.u64 = 13; Max.u64 = 703; 
  l1cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_13.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6006,7 +6006,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_13.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_13.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_13.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 35; SumSQ.u64 = 245; Count.u64 = 5; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 59; SumSQ.u64 = 269; Count.u64 = 29; Min.u64 = 1; Max.u64 = 7; 
  l2cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 77077; SumSQ.u64 = 20928229; Count.u64 = 312; Min.u64 = 79; Max.u64 = 697; 
  l2cache_13.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6221,8 +6221,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_14.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 86809; SumSQ.u64 = 23894827; Count.u64 = 381; Min.u64 = 5; Max.u64 = 424; 
- l1cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 70728; SumSQ.u64 = 21131260; Count.u64 = 243; Min.u64 = 17; Max.u64 = 506; 
+ l1cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 94193; SumSQ.u64 = 25612575; Count.u64 = 439; Min.u64 = 1; Max.u64 = 424; 
+ l1cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 91943; SumSQ.u64 = 27498963; Count.u64 = 316; Min.u64 = 17; Max.u64 = 522; 
  l1cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_14.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6433,7 +6433,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_14.eventSent_CustomReq : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_14.eventSent_CustomResp : Accumulator : Sum.u64 = 312; SumSQ.u64 = 312; Count.u64 = 312; Min.u64 = 1; Max.u64 = 1; 
  l2cache_14.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 108; SumSQ.u64 = 4244; Count.u64 = 5; Min.u64 = 7; Max.u64 = 56; 
+ l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 130; SumSQ.u64 = 4266; Count.u64 = 27; Min.u64 = 1; Max.u64 = 56; 
  l2cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 88870; SumSQ.u64 = 25777058; Count.u64 = 311; Min.u64 = 81; Max.u64 = 496; 
  l2cache_14.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6648,8 +6648,8 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l1cache_15.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 128887; SumSQ.u64 = 33229877; Count.u64 = 717; Min.u64 = 5; Max.u64 = 452; 
- l1cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 55518; SumSQ.u64 = 15486170; Count.u64 = 219; Min.u64 = 17; Max.u64 = 462; 
+ l1cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 144789; SumSQ.u64 = 37378001; Count.u64 = 813; Min.u64 = 1; Max.u64 = 452; 
+ l1cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 78306; SumSQ.u64 = 21560064; Count.u64 = 317; Min.u64 = 13; Max.u64 = 463; 
  l1cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache_15.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -6860,7 +6860,7 @@ l2cache_15: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated
  l2cache_15.eventSent_CustomReq : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_15.eventSent_CustomResp : Accumulator : Sum.u64 = 468; SumSQ.u64 = 468; Count.u64 = 468; Min.u64 = 1; Max.u64 = 1; 
  l2cache_15.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 49; SumSQ.u64 = 343; Count.u64 = 7; Min.u64 = 7; Max.u64 = 7; 
+ l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 74; SumSQ.u64 = 368; Count.u64 = 32; Min.u64 = 1; Max.u64 = 7; 
  l2cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 75473; SumSQ.u64 = 20199071; Count.u64 = 310; Min.u64 = 62; Max.u64 = 457; 
  l2cache_15.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_DistributedCaches.out
@@ -12,12 +12,12 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU cpu7 Finished after 1200 issued reads, 1200 returned (91780 clocks)
 TrivialCPU cpu6 Finished after 1200 issued reads, 1200 returned (92446 clocks)
-TrivialCPU cpu5 Finished after 1200 issued reads, 1200 returned (92666 clocks)
-TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92278 clocks)
-TrivialCPU cpu3 Finished after 1200 issued reads, 1200 returned (91842 clocks)
-TrivialCPU cpu2 Finished after 1200 issued reads, 1200 returned (90135 clocks)
-TrivialCPU cpu1 Finished after 1200 issued reads, 1200 returned (92722 clocks)
 TrivialCPU cpu0 Finished after 1200 issued reads, 1200 returned (92512 clocks)
+TrivialCPU cpu1 Finished after 1200 issued reads, 1200 returned (92722 clocks)
+TrivialCPU cpu2 Finished after 1200 issued reads, 1200 returned (90135 clocks)
+TrivialCPU cpu3 Finished after 1200 issued reads, 1200 returned (91842 clocks)
+TrivialCPU cpu4 Finished after 1200 issued reads, 1200 returned (92278 clocks)
+TrivialCPU cpu5 Finished after 1200 issued reads, 1200 returned (92666 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 691200; SumSQ.u64 = 398131200; Count.u64 = 1200; Min.u64 = 576; Max.u64 = 576; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 1200; SumSQ.u64 = 1200; Count.u64 = 1200; Min.u64 = 1; Max.u64 = 1; 
  network.output_port_stalls.port0 : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes.out
@@ -4,12 +4,12 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (16962 clocks)
-TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (16093 clocks)
-TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (14926 clocks)
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (15414 clocks)
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (15140 clocks)
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (15699 clocks)
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (15140 clocks)
+TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (14926 clocks)
+TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (16093 clocks)
+TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (16962 clocks)
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (15414 clocks)
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 486656; SumSQ.u64 = 246431744; Count.u64 = 1764; Min.u64 = 64; Max.u64 = 576; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 1764; SumSQ.u64 = 1764; Count.u64 = 1764; Min.u64 = 1; Max.u64 = 1; 
  network.output_port_stalls.port0 : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Flushes_2.out
@@ -4,24 +4,24 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (19545 clocks)
+TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (18668 clocks)
+	74 Noncacheable Reads
+	11 Noncacheable Writes
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (20025 clocks)
 	78 Noncacheable Reads
-	10 Noncacheable Writes
-TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (18322 clocks)
-	83 Noncacheable Reads
 	8 Noncacheable Writes
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (18632 clocks)
 	64 Noncacheable Reads
 	12 Noncacheable Writes
+TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (18322 clocks)
+	83 Noncacheable Reads
+	8 Noncacheable Writes
+TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (19545 clocks)
+	78 Noncacheable Reads
+	10 Noncacheable Writes
 TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (20186 clocks)
 	60 Noncacheable Reads
 	6 Noncacheable Writes
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (20025 clocks)
-	78 Noncacheable Reads
-	8 Noncacheable Writes
-TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (18668 clocks)
-	74 Noncacheable Reads
-	11 Noncacheable Writes
  network.send_bit_count.port0 : Accumulator : Sum.u64 = 480576; SumSQ.u64 = 234184704; Count.u64 = 1959; Min.u64 = 64; Max.u64 = 576; 
  network.send_packet_count.port0 : Accumulator : Sum.u64 = 1959; SumSQ.u64 = 1959; Count.u64 = 1959; Min.u64 = 1; Max.u64 = 1; 
  network.output_port_stalls.port0 : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Kingsley.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Kingsley.out
@@ -791,7 +791,7 @@
  l2cache_0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 181; SumSQ.u64 = 1639; Count.u64 = 20; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 232; SumSQ.u64 = 1690; Count.u64 = 71; Min.u64 = 1; Max.u64 = 10; 
  l2cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 67320; SumSQ.u64 = 5071042; Count.u64 = 980; Min.u64 = 49; Max.u64 = 312; 
  l2cache_0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 27; SumSQ.u64 = 243; Count.u64 = 3; Min.u64 = 9; Max.u64 = 9; 
@@ -1443,7 +1443,7 @@
  l2cache_1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 181; SumSQ.u64 = 1639; Count.u64 = 20; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 234; SumSQ.u64 = 1692; Count.u64 = 73; Min.u64 = 1; Max.u64 = 10; 
  l2cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 67414; SumSQ.u64 = 5010608; Count.u64 = 980; Min.u64 = 47; Max.u64 = 221; 
  l2cache_1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 27; SumSQ.u64 = 243; Count.u64 = 3; Min.u64 = 9; Max.u64 = 9; 
@@ -2134,7 +2134,7 @@
  l2cache_2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 181; SumSQ.u64 = 1639; Count.u64 = 20; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 232; SumSQ.u64 = 1690; Count.u64 = 71; Min.u64 = 1; Max.u64 = 10; 
  l2cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 68274; SumSQ.u64 = 5211680; Count.u64 = 980; Min.u64 = 49; Max.u64 = 363; 
  l2cache_2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 27; SumSQ.u64 = 243; Count.u64 = 3; Min.u64 = 9; Max.u64 = 9; 
@@ -2848,7 +2848,7 @@
  l2cache_3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 163; SumSQ.u64 = 1477; Count.u64 = 18; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 290; SumSQ.u64 = 6716; Count.u64 = 74; Min.u64 = 1; Max.u64 = 72; 
  l2cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 69008; SumSQ.u64 = 5286682; Count.u64 = 982; Min.u64 = 47; Max.u64 = 370; 
  l2cache_3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 36; SumSQ.u64 = 324; Count.u64 = 4; Min.u64 = 9; Max.u64 = 9; 
@@ -3539,7 +3539,7 @@
  l2cache_4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 153; SumSQ.u64 = 1377; Count.u64 = 17; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 203; SumSQ.u64 = 1427; Count.u64 = 67; Min.u64 = 1; Max.u64 = 9; 
  l2cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 67508; SumSQ.u64 = 5010296; Count.u64 = 983; Min.u64 = 49; Max.u64 = 234; 
  l2cache_4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 54; SumSQ.u64 = 486; Count.u64 = 6; Min.u64 = 9; Max.u64 = 9; 
@@ -4253,7 +4253,7 @@
  l2cache_5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 157; SumSQ.u64 = 1455; Count.u64 = 17; Min.u64 = 9; Max.u64 = 11; 
+ l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 213; SumSQ.u64 = 1511; Count.u64 = 73; Min.u64 = 1; Max.u64 = 11; 
  l2cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 70039; SumSQ.u64 = 5699625; Count.u64 = 983; Min.u64 = 50; Max.u64 = 427; 
  l2cache_5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 54; SumSQ.u64 = 486; Count.u64 = 6; Min.u64 = 9; Max.u64 = 9; 
@@ -4944,7 +4944,7 @@
  l2cache_6.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 163; SumSQ.u64 = 1477; Count.u64 = 18; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 211; SumSQ.u64 = 1525; Count.u64 = 66; Min.u64 = 1; Max.u64 = 10; 
  l2cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 70239; SumSQ.u64 = 5669871; Count.u64 = 982; Min.u64 = 49; Max.u64 = 412; 
  l2cache_6.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 45; SumSQ.u64 = 405; Count.u64 = 5; Min.u64 = 9; Max.u64 = 9; 
@@ -5658,7 +5658,7 @@
  l2cache_7.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 154; SumSQ.u64 = 1396; Count.u64 = 17; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 208; SumSQ.u64 = 1450; Count.u64 = 71; Min.u64 = 1; Max.u64 = 10; 
  l2cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 71310; SumSQ.u64 = 5852488; Count.u64 = 983; Min.u64 = 50; Max.u64 = 457; 
  l2cache_7.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 54; SumSQ.u64 = 486; Count.u64 = 6; Min.u64 = 9; Max.u64 = 9; 
@@ -6349,7 +6349,7 @@
  l2cache_8.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 165; SumSQ.u64 = 1515; Count.u64 = 18; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 217; SumSQ.u64 = 1567; Count.u64 = 70; Min.u64 = 1; Max.u64 = 10; 
  l2cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 70574; SumSQ.u64 = 5817428; Count.u64 = 982; Min.u64 = 49; Max.u64 = 434; 
  l2cache_8.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 45; SumSQ.u64 = 405; Count.u64 = 5; Min.u64 = 9; Max.u64 = 9; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_MemoryCache.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_MemoryCache.out
@@ -2764,7 +2764,7 @@ Model complete
  l2cache_0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 225; SumSQ.u64 = 2025; Count.u64 = 25; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 290; SumSQ.u64 = 2090; Count.u64 = 90; Min.u64 = 1; Max.u64 = 9; 
  l2cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 77181; SumSQ.u64 = 12953955; Count.u64 = 475; Min.u64 = 54; Max.u64 = 351; 
  l2cache_0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 54; SumSQ.u64 = 486; Count.u64 = 6; Min.u64 = 9; Max.u64 = 9; 
@@ -3448,7 +3448,7 @@ Model complete
  l2cache_1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 2430; Count.u64 = 30; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 341; SumSQ.u64 = 2501; Count.u64 = 101; Min.u64 = 1; Max.u64 = 9; 
  l2cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 78509; SumSQ.u64 = 13816959; Count.u64 = 470; Min.u64 = 114; Max.u64 = 533; 
  l2cache_1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 9; SumSQ.u64 = 81; Count.u64 = 1; Min.u64 = 9; Max.u64 = 9; 
@@ -4105,7 +4105,7 @@ Model complete
  l2cache_2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 288; SumSQ.u64 = 1944; Count.u64 = 104; Min.u64 = 1; Max.u64 = 9; 
  l2cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 78362; SumSQ.u64 = 13331574; Count.u64 = 477; Min.u64 = 45; Max.u64 = 394; 
  l2cache_2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -4762,7 +4762,7 @@ Model complete
  l2cache_3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 279; SumSQ.u64 = 1863; Count.u64 = 103; Min.u64 = 1; Max.u64 = 9; 
  l2cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 78875; SumSQ.u64 = 13518021; Count.u64 = 478; Min.u64 = 119; Max.u64 = 358; 
  l2cache_3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -5446,7 +5446,7 @@ Model complete
  l2cache_4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 171; SumSQ.u64 = 1539; Count.u64 = 19; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 249; SumSQ.u64 = 1617; Count.u64 = 97; Min.u64 = 1; Max.u64 = 9; 
  l2cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 79809; SumSQ.u64 = 13893787; Count.u64 = 481; Min.u64 = 114; Max.u64 = 423; 
  l2cache_4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 108; SumSQ.u64 = 972; Count.u64 = 12; Min.u64 = 9; Max.u64 = 9; 
@@ -6130,7 +6130,7 @@ Model complete
  l2cache_5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 180; SumSQ.u64 = 1620; Count.u64 = 20; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 262; SumSQ.u64 = 1702; Count.u64 = 102; Min.u64 = 1; Max.u64 = 9; 
  l2cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 80444; SumSQ.u64 = 14032926; Count.u64 = 480; Min.u64 = 114; Max.u64 = 404; 
  l2cache_5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 99; SumSQ.u64 = 891; Count.u64 = 11; Min.u64 = 9; Max.u64 = 9; 
@@ -6810,7 +6810,7 @@ Model complete
  l2cache_6.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 281; SumSQ.u64 = 1937; Count.u64 = 97; Min.u64 = 1; Max.u64 = 9; 
  l2cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 80445; SumSQ.u64 = 14084571; Count.u64 = 477; Min.u64 = 102; Max.u64 = 351; 
  l2cache_6.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -7467,7 +7467,7 @@ Model complete
  l2cache_7.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 180; SumSQ.u64 = 1620; Count.u64 = 20; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 1710; Count.u64 = 110; Min.u64 = 1; Max.u64 = 9; 
  l2cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 78765; SumSQ.u64 = 13372113; Count.u64 = 480; Min.u64 = 54; Max.u64 = 395; 
  l2cache_7.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 99; SumSQ.u64 = 891; Count.u64 = 11; Min.u64 = 9; Max.u64 = 9; 
@@ -8124,7 +8124,7 @@ Model complete
  l2cache_8.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 258; SumSQ.u64 = 1554; Count.u64 = 114; Min.u64 = 1; Max.u64 = 9; 
  l2cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 78412; SumSQ.u64 = 13172992; Count.u64 = 482; Min.u64 = 115; Max.u64 = 433; 
  l2cache_8.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 117; SumSQ.u64 = 1053; Count.u64 = 13; Min.u64 = 9; Max.u64 = 9; 
@@ -8781,7 +8781,7 @@ Model complete
  l2cache_9.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 311; SumSQ.u64 = 1967; Count.u64 = 127; Min.u64 = 1; Max.u64 = 9; 
  l2cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 78137; SumSQ.u64 = 13340941; Count.u64 = 477; Min.u64 = 116; Max.u64 = 453; 
  l2cache_9.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -9438,7 +9438,7 @@ Model complete
  l2cache_10.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 309; SumSQ.u64 = 1965; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 78844; SumSQ.u64 = 13487110; Count.u64 = 477; Min.u64 = 118; Max.u64 = 357; 
  l2cache_10.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -10118,7 +10118,7 @@ Model complete
  l2cache_11.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 243; SumSQ.u64 = 2187; Count.u64 = 27; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 335; SumSQ.u64 = 2279; Count.u64 = 119; Min.u64 = 1; Max.u64 = 9; 
  l2cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 78246; SumSQ.u64 = 13399530; Count.u64 = 473; Min.u64 = 111; Max.u64 = 448; 
  l2cache_11.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 36; SumSQ.u64 = 324; Count.u64 = 4; Min.u64 = 9; Max.u64 = 9; 
@@ -10798,7 +10798,7 @@ Model complete
  l2cache_12.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 252; SumSQ.u64 = 2268; Count.u64 = 28; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 349; SumSQ.u64 = 2365; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 78493; SumSQ.u64 = 13527921; Count.u64 = 472; Min.u64 = 110; Max.u64 = 363; 
  l2cache_12.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 27; SumSQ.u64 = 243; Count.u64 = 3; Min.u64 = 9; Max.u64 = 9; 
@@ -11455,7 +11455,7 @@ Model complete
  l2cache_13.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 300; SumSQ.u64 = 1956; Count.u64 = 116; Min.u64 = 1; Max.u64 = 9; 
  l2cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 87702; SumSQ.u64 = 18447932; Count.u64 = 477; Min.u64 = 120; Max.u64 = 942; 
  l2cache_13.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -12112,7 +12112,7 @@ Model complete
  l2cache_14.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 189; SumSQ.u64 = 1701; Count.u64 = 21; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 292; SumSQ.u64 = 1804; Count.u64 = 124; Min.u64 = 1; Max.u64 = 9; 
  l2cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 87750; SumSQ.u64 = 19368206; Count.u64 = 479; Min.u64 = 115; Max.u64 = 961; 
  l2cache_14.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 90; SumSQ.u64 = 810; Count.u64 = 10; Min.u64 = 9; Max.u64 = 9; 
@@ -12769,7 +12769,7 @@ Model complete
  l2cache_15.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 258; SumSQ.u64 = 1554; Count.u64 = 114; Min.u64 = 1; Max.u64 = 9; 
  l2cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 87568; SumSQ.u64 = 18715330; Count.u64 = 482; Min.u64 = 117; Max.u64 = 959; 
  l2cache_15.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 117; SumSQ.u64 = 1053; Count.u64 = 13; Min.u64 = 9; Max.u64 = 9; 
@@ -13426,7 +13426,7 @@ Model complete
  l2cache_16.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_16.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_16.latency_GetS_hit : Accumulator : Sum.u64 = 294; SumSQ.u64 = 1878; Count.u64 = 118; Min.u64 = 1; Max.u64 = 9; 
  l2cache_16.latency_GetS_miss : Accumulator : Sum.u64 = 86832; SumSQ.u64 = 18343164; Count.u64 = 478; Min.u64 = 117; Max.u64 = 947; 
  l2cache_16.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -14106,7 +14106,7 @@ Model complete
  l2cache_17.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_17.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_17.latency_GetS_hit : Accumulator : Sum.u64 = 307; SumSQ.u64 = 1963; Count.u64 = 123; Min.u64 = 1; Max.u64 = 9; 
  l2cache_17.latency_GetS_miss : Accumulator : Sum.u64 = 86586; SumSQ.u64 = 19096012; Count.u64 = 477; Min.u64 = 115; Max.u64 = 982; 
  l2cache_17.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.latency_GetX_hit : Accumulator : Sum.u64 = 72; SumSQ.u64 = 648; Count.u64 = 8; Min.u64 = 9; Max.u64 = 9; 
@@ -14786,7 +14786,7 @@ Model complete
  l2cache_18.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_18.latency_GetS_hit : Accumulator : Sum.u64 = 171; SumSQ.u64 = 1539; Count.u64 = 19; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_18.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 1638; Count.u64 = 118; Min.u64 = 1; Max.u64 = 9; 
  l2cache_18.latency_GetS_miss : Accumulator : Sum.u64 = 86351; SumSQ.u64 = 19595413; Count.u64 = 481; Min.u64 = 48; Max.u64 = 1124; 
  l2cache_18.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -15443,7 +15443,7 @@ Model complete
  l2cache_19.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_19.latency_GetS_hit : Accumulator : Sum.u64 = 189; SumSQ.u64 = 1701; Count.u64 = 21; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_19.latency_GetS_hit : Accumulator : Sum.u64 = 293; SumSQ.u64 = 1805; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_19.latency_GetS_miss : Accumulator : Sum.u64 = 86072; SumSQ.u64 = 19084608; Count.u64 = 479; Min.u64 = 48; Max.u64 = 892; 
  l2cache_19.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -16100,7 +16100,7 @@ Model complete
  l2cache_20.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_20.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_20.latency_GetS_hit : Accumulator : Sum.u64 = 324; SumSQ.u64 = 2052; Count.u64 = 132; Min.u64 = 1; Max.u64 = 9; 
  l2cache_20.latency_GetS_miss : Accumulator : Sum.u64 = 85800; SumSQ.u64 = 18596540; Count.u64 = 476; Min.u64 = 48; Max.u64 = 881; 
  l2cache_20.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -16757,7 +16757,7 @@ Model complete
  l2cache_21.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_21.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_21.latency_GetS_hit : Accumulator : Sum.u64 = 321; SumSQ.u64 = 2049; Count.u64 = 129; Min.u64 = 1; Max.u64 = 9; 
  l2cache_21.latency_GetS_miss : Accumulator : Sum.u64 = 86024; SumSQ.u64 = 20282812; Count.u64 = 476; Min.u64 = 48; Max.u64 = 1169; 
  l2cache_21.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -17414,7 +17414,7 @@ Model complete
  l2cache_22.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_22.latency_GetS_hit : Accumulator : Sum.u64 = 261; SumSQ.u64 = 2349; Count.u64 = 29; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_22.latency_GetS_hit : Accumulator : Sum.u64 = 364; SumSQ.u64 = 2452; Count.u64 = 132; Min.u64 = 1; Max.u64 = 9; 
  l2cache_22.latency_GetS_miss : Accumulator : Sum.u64 = 84736; SumSQ.u64 = 18475714; Count.u64 = 471; Min.u64 = 48; Max.u64 = 929; 
  l2cache_22.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -18094,7 +18094,7 @@ Model complete
  l2cache_23.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_23.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_23.latency_GetS_hit : Accumulator : Sum.u64 = 323; SumSQ.u64 = 2051; Count.u64 = 131; Min.u64 = 1; Max.u64 = 9; 
  l2cache_23.latency_GetS_miss : Accumulator : Sum.u64 = 88278; SumSQ.u64 = 20342500; Count.u64 = 476; Min.u64 = 54; Max.u64 = 968; 
  l2cache_23.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -18751,7 +18751,7 @@ Model complete
  l2cache_24.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_24.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_24.latency_GetS_hit : Accumulator : Sum.u64 = 312; SumSQ.u64 = 2040; Count.u64 = 120; Min.u64 = 1; Max.u64 = 9; 
  l2cache_24.latency_GetS_miss : Accumulator : Sum.u64 = 84072; SumSQ.u64 = 18760220; Count.u64 = 476; Min.u64 = 51; Max.u64 = 1015; 
  l2cache_24.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -19408,7 +19408,7 @@ Model complete
  l2cache_25.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_25.latency_GetS_hit : Accumulator : Sum.u64 = 190; SumSQ.u64 = 1720; Count.u64 = 21; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_25.latency_GetS_hit : Accumulator : Sum.u64 = 280; SumSQ.u64 = 1810; Count.u64 = 111; Min.u64 = 1; Max.u64 = 10; 
  l2cache_25.latency_GetS_miss : Accumulator : Sum.u64 = 93173; SumSQ.u64 = 33710281; Count.u64 = 479; Min.u64 = 48; Max.u64 = 1862; 
  l2cache_25.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -20065,7 +20065,7 @@ Model complete
  l2cache_26.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_26.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_26.latency_GetS_hit : Accumulator : Sum.u64 = 265; SumSQ.u64 = 1561; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_26.latency_GetS_miss : Accumulator : Sum.u64 = 97680; SumSQ.u64 = 44478288; Count.u64 = 482; Min.u64 = 47; Max.u64 = 1794; 
  l2cache_26.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -20722,7 +20722,7 @@ Model complete
  l2cache_27.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_27.latency_GetS_hit : Accumulator : Sum.u64 = 224; SumSQ.u64 = 2458; Count.u64 = 23; Min.u64 = 9; Max.u64 = 26; 
+ l2cache_27.latency_GetS_hit : Accumulator : Sum.u64 = 328; SumSQ.u64 = 2562; Count.u64 = 127; Min.u64 = 1; Max.u64 = 26; 
  l2cache_27.latency_GetS_miss : Accumulator : Sum.u64 = 97717; SumSQ.u64 = 47091541; Count.u64 = 477; Min.u64 = 47; Max.u64 = 2077; 
  l2cache_27.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -21379,7 +21379,7 @@ Model complete
  l2cache_28.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_28.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_28.latency_GetS_hit : Accumulator : Sum.u64 = 297; SumSQ.u64 = 1881; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_28.latency_GetS_miss : Accumulator : Sum.u64 = 99102; SumSQ.u64 = 46348464; Count.u64 = 478; Min.u64 = 47; Max.u64 = 1971; 
  l2cache_28.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -22036,7 +22036,7 @@ Model complete
  l2cache_29.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_29.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_29.latency_GetS_hit : Accumulator : Sum.u64 = 263; SumSQ.u64 = 1559; Count.u64 = 119; Min.u64 = 1; Max.u64 = 9; 
  l2cache_29.latency_GetS_miss : Accumulator : Sum.u64 = 101566; SumSQ.u64 = 46672440; Count.u64 = 482; Min.u64 = 47; Max.u64 = 1914; 
  l2cache_29.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -22720,7 +22720,7 @@ Model complete
  l2cache_30.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_30.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_30.latency_GetS_hit : Accumulator : Sum.u64 = 305; SumSQ.u64 = 1889; Count.u64 = 129; Min.u64 = 1; Max.u64 = 9; 
  l2cache_30.latency_GetS_miss : Accumulator : Sum.u64 = 99947; SumSQ.u64 = 47778863; Count.u64 = 478; Min.u64 = 48; Max.u64 = 2260; 
  l2cache_30.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -23404,7 +23404,7 @@ Model complete
  l2cache_31.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_31.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_31.latency_GetS_hit : Accumulator : Sum.u64 = 314; SumSQ.u64 = 2042; Count.u64 = 122; Min.u64 = 1; Max.u64 = 9; 
  l2cache_31.latency_GetS_miss : Accumulator : Sum.u64 = 97821; SumSQ.u64 = 47914309; Count.u64 = 476; Min.u64 = 47; Max.u64 = 1954; 
  l2cache_31.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -24061,7 +24061,7 @@ Model complete
  l2cache_32.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_32.latency_GetS_hit : Accumulator : Sum.u64 = 629; SumSQ.u64 = 172513; Count.u64 = 25; Min.u64 = 9; Max.u64 = 413; 
+ l2cache_32.latency_GetS_hit : Accumulator : Sum.u64 = 725; SumSQ.u64 = 172609; Count.u64 = 121; Min.u64 = 1; Max.u64 = 413; 
  l2cache_32.latency_GetS_miss : Accumulator : Sum.u64 = 95285; SumSQ.u64 = 45434903; Count.u64 = 475; Min.u64 = 47; Max.u64 = 2481; 
  l2cache_32.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -24718,7 +24718,7 @@ Model complete
  l2cache_33.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_33.latency_GetS_hit : Accumulator : Sum.u64 = 261; SumSQ.u64 = 2349; Count.u64 = 29; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_33.latency_GetS_hit : Accumulator : Sum.u64 = 353; SumSQ.u64 = 2441; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_33.latency_GetS_miss : Accumulator : Sum.u64 = 94263; SumSQ.u64 = 45994117; Count.u64 = 471; Min.u64 = 47; Max.u64 = 2363; 
  l2cache_33.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -25402,7 +25402,7 @@ Model complete
  l2cache_34.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_34.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_34.latency_GetS_hit : Accumulator : Sum.u64 = 323; SumSQ.u64 = 2051; Count.u64 = 131; Min.u64 = 1; Max.u64 = 9; 
  l2cache_34.latency_GetS_miss : Accumulator : Sum.u64 = 95963; SumSQ.u64 = 45299209; Count.u64 = 476; Min.u64 = 47; Max.u64 = 2168; 
  l2cache_34.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -26086,7 +26086,7 @@ Model complete
  l2cache_35.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_35.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_35.latency_GetS_hit : Accumulator : Sum.u64 = 299; SumSQ.u64 = 1955; Count.u64 = 115; Min.u64 = 1; Max.u64 = 9; 
  l2cache_35.latency_GetS_miss : Accumulator : Sum.u64 = 97092; SumSQ.u64 = 46849630; Count.u64 = 477; Min.u64 = 48; Max.u64 = 2412; 
  l2cache_35.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_MemoryCache_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_MemoryCache_MC.out
@@ -2764,7 +2764,7 @@ Model complete
  l2cache_0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 225; SumSQ.u64 = 2025; Count.u64 = 25; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_0.latency_GetS_hit : Accumulator : Sum.u64 = 290; SumSQ.u64 = 2090; Count.u64 = 90; Min.u64 = 1; Max.u64 = 9; 
  l2cache_0.latency_GetS_miss : Accumulator : Sum.u64 = 77181; SumSQ.u64 = 12953955; Count.u64 = 475; Min.u64 = 54; Max.u64 = 351; 
  l2cache_0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_0.latency_GetX_hit : Accumulator : Sum.u64 = 54; SumSQ.u64 = 486; Count.u64 = 6; Min.u64 = 9; Max.u64 = 9; 
@@ -3448,7 +3448,7 @@ Model complete
  l2cache_1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 2430; Count.u64 = 30; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_1.latency_GetS_hit : Accumulator : Sum.u64 = 341; SumSQ.u64 = 2501; Count.u64 = 101; Min.u64 = 1; Max.u64 = 9; 
  l2cache_1.latency_GetS_miss : Accumulator : Sum.u64 = 78509; SumSQ.u64 = 13816959; Count.u64 = 470; Min.u64 = 114; Max.u64 = 533; 
  l2cache_1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_1.latency_GetX_hit : Accumulator : Sum.u64 = 9; SumSQ.u64 = 81; Count.u64 = 1; Min.u64 = 9; Max.u64 = 9; 
@@ -4105,7 +4105,7 @@ Model complete
  l2cache_2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_2.latency_GetS_hit : Accumulator : Sum.u64 = 288; SumSQ.u64 = 1944; Count.u64 = 104; Min.u64 = 1; Max.u64 = 9; 
  l2cache_2.latency_GetS_miss : Accumulator : Sum.u64 = 78362; SumSQ.u64 = 13331574; Count.u64 = 477; Min.u64 = 45; Max.u64 = 394; 
  l2cache_2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_2.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -4762,7 +4762,7 @@ Model complete
  l2cache_3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_3.latency_GetS_hit : Accumulator : Sum.u64 = 279; SumSQ.u64 = 1863; Count.u64 = 103; Min.u64 = 1; Max.u64 = 9; 
  l2cache_3.latency_GetS_miss : Accumulator : Sum.u64 = 78875; SumSQ.u64 = 13518021; Count.u64 = 478; Min.u64 = 119; Max.u64 = 358; 
  l2cache_3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_3.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -5446,7 +5446,7 @@ Model complete
  l2cache_4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 171; SumSQ.u64 = 1539; Count.u64 = 19; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_4.latency_GetS_hit : Accumulator : Sum.u64 = 249; SumSQ.u64 = 1617; Count.u64 = 97; Min.u64 = 1; Max.u64 = 9; 
  l2cache_4.latency_GetS_miss : Accumulator : Sum.u64 = 79809; SumSQ.u64 = 13893787; Count.u64 = 481; Min.u64 = 114; Max.u64 = 423; 
  l2cache_4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_4.latency_GetX_hit : Accumulator : Sum.u64 = 108; SumSQ.u64 = 972; Count.u64 = 12; Min.u64 = 9; Max.u64 = 9; 
@@ -6130,7 +6130,7 @@ Model complete
  l2cache_5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 180; SumSQ.u64 = 1620; Count.u64 = 20; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_5.latency_GetS_hit : Accumulator : Sum.u64 = 262; SumSQ.u64 = 1702; Count.u64 = 102; Min.u64 = 1; Max.u64 = 9; 
  l2cache_5.latency_GetS_miss : Accumulator : Sum.u64 = 80444; SumSQ.u64 = 14032926; Count.u64 = 480; Min.u64 = 114; Max.u64 = 404; 
  l2cache_5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_5.latency_GetX_hit : Accumulator : Sum.u64 = 99; SumSQ.u64 = 891; Count.u64 = 11; Min.u64 = 9; Max.u64 = 9; 
@@ -6810,7 +6810,7 @@ Model complete
  l2cache_6.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_6.latency_GetS_hit : Accumulator : Sum.u64 = 281; SumSQ.u64 = 1937; Count.u64 = 97; Min.u64 = 1; Max.u64 = 9; 
  l2cache_6.latency_GetS_miss : Accumulator : Sum.u64 = 80445; SumSQ.u64 = 14084571; Count.u64 = 477; Min.u64 = 102; Max.u64 = 351; 
  l2cache_6.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_6.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -7467,7 +7467,7 @@ Model complete
  l2cache_7.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 180; SumSQ.u64 = 1620; Count.u64 = 20; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_7.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 1710; Count.u64 = 110; Min.u64 = 1; Max.u64 = 9; 
  l2cache_7.latency_GetS_miss : Accumulator : Sum.u64 = 78765; SumSQ.u64 = 13372113; Count.u64 = 480; Min.u64 = 54; Max.u64 = 395; 
  l2cache_7.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_7.latency_GetX_hit : Accumulator : Sum.u64 = 99; SumSQ.u64 = 891; Count.u64 = 11; Min.u64 = 9; Max.u64 = 9; 
@@ -8124,7 +8124,7 @@ Model complete
  l2cache_8.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_8.latency_GetS_hit : Accumulator : Sum.u64 = 258; SumSQ.u64 = 1554; Count.u64 = 114; Min.u64 = 1; Max.u64 = 9; 
  l2cache_8.latency_GetS_miss : Accumulator : Sum.u64 = 78412; SumSQ.u64 = 13172992; Count.u64 = 482; Min.u64 = 115; Max.u64 = 433; 
  l2cache_8.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_8.latency_GetX_hit : Accumulator : Sum.u64 = 117; SumSQ.u64 = 1053; Count.u64 = 13; Min.u64 = 9; Max.u64 = 9; 
@@ -8781,7 +8781,7 @@ Model complete
  l2cache_9.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_9.latency_GetS_hit : Accumulator : Sum.u64 = 311; SumSQ.u64 = 1967; Count.u64 = 127; Min.u64 = 1; Max.u64 = 9; 
  l2cache_9.latency_GetS_miss : Accumulator : Sum.u64 = 78137; SumSQ.u64 = 13340941; Count.u64 = 477; Min.u64 = 116; Max.u64 = 453; 
  l2cache_9.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_9.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -9438,7 +9438,7 @@ Model complete
  l2cache_10.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_10.latency_GetS_hit : Accumulator : Sum.u64 = 309; SumSQ.u64 = 1965; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_10.latency_GetS_miss : Accumulator : Sum.u64 = 78844; SumSQ.u64 = 13487110; Count.u64 = 477; Min.u64 = 118; Max.u64 = 357; 
  l2cache_10.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_10.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -10118,7 +10118,7 @@ Model complete
  l2cache_11.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 243; SumSQ.u64 = 2187; Count.u64 = 27; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_11.latency_GetS_hit : Accumulator : Sum.u64 = 335; SumSQ.u64 = 2279; Count.u64 = 119; Min.u64 = 1; Max.u64 = 9; 
  l2cache_11.latency_GetS_miss : Accumulator : Sum.u64 = 78246; SumSQ.u64 = 13399530; Count.u64 = 473; Min.u64 = 111; Max.u64 = 448; 
  l2cache_11.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_11.latency_GetX_hit : Accumulator : Sum.u64 = 36; SumSQ.u64 = 324; Count.u64 = 4; Min.u64 = 9; Max.u64 = 9; 
@@ -10798,7 +10798,7 @@ Model complete
  l2cache_12.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 252; SumSQ.u64 = 2268; Count.u64 = 28; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_12.latency_GetS_hit : Accumulator : Sum.u64 = 349; SumSQ.u64 = 2365; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_12.latency_GetS_miss : Accumulator : Sum.u64 = 78493; SumSQ.u64 = 13527921; Count.u64 = 472; Min.u64 = 110; Max.u64 = 363; 
  l2cache_12.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_12.latency_GetX_hit : Accumulator : Sum.u64 = 27; SumSQ.u64 = 243; Count.u64 = 3; Min.u64 = 9; Max.u64 = 9; 
@@ -11455,7 +11455,7 @@ Model complete
  l2cache_13.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_13.latency_GetS_hit : Accumulator : Sum.u64 = 300; SumSQ.u64 = 1956; Count.u64 = 116; Min.u64 = 1; Max.u64 = 9; 
  l2cache_13.latency_GetS_miss : Accumulator : Sum.u64 = 87702; SumSQ.u64 = 18447932; Count.u64 = 477; Min.u64 = 120; Max.u64 = 942; 
  l2cache_13.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_13.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -12112,7 +12112,7 @@ Model complete
  l2cache_14.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 189; SumSQ.u64 = 1701; Count.u64 = 21; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_14.latency_GetS_hit : Accumulator : Sum.u64 = 292; SumSQ.u64 = 1804; Count.u64 = 124; Min.u64 = 1; Max.u64 = 9; 
  l2cache_14.latency_GetS_miss : Accumulator : Sum.u64 = 87750; SumSQ.u64 = 19368206; Count.u64 = 479; Min.u64 = 115; Max.u64 = 961; 
  l2cache_14.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_14.latency_GetX_hit : Accumulator : Sum.u64 = 90; SumSQ.u64 = 810; Count.u64 = 10; Min.u64 = 9; Max.u64 = 9; 
@@ -12769,7 +12769,7 @@ Model complete
  l2cache_15.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_15.latency_GetS_hit : Accumulator : Sum.u64 = 258; SumSQ.u64 = 1554; Count.u64 = 114; Min.u64 = 1; Max.u64 = 9; 
  l2cache_15.latency_GetS_miss : Accumulator : Sum.u64 = 87568; SumSQ.u64 = 18715330; Count.u64 = 482; Min.u64 = 117; Max.u64 = 959; 
  l2cache_15.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_15.latency_GetX_hit : Accumulator : Sum.u64 = 117; SumSQ.u64 = 1053; Count.u64 = 13; Min.u64 = 9; Max.u64 = 9; 
@@ -13426,7 +13426,7 @@ Model complete
  l2cache_16.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_16.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_16.latency_GetS_hit : Accumulator : Sum.u64 = 294; SumSQ.u64 = 1878; Count.u64 = 118; Min.u64 = 1; Max.u64 = 9; 
  l2cache_16.latency_GetS_miss : Accumulator : Sum.u64 = 86832; SumSQ.u64 = 18343164; Count.u64 = 478; Min.u64 = 117; Max.u64 = 947; 
  l2cache_16.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_16.latency_GetX_hit : Accumulator : Sum.u64 = 81; SumSQ.u64 = 729; Count.u64 = 9; Min.u64 = 9; Max.u64 = 9; 
@@ -14106,7 +14106,7 @@ Model complete
  l2cache_17.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_17.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_17.latency_GetS_hit : Accumulator : Sum.u64 = 307; SumSQ.u64 = 1963; Count.u64 = 123; Min.u64 = 1; Max.u64 = 9; 
  l2cache_17.latency_GetS_miss : Accumulator : Sum.u64 = 86586; SumSQ.u64 = 19096012; Count.u64 = 477; Min.u64 = 115; Max.u64 = 982; 
  l2cache_17.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_17.latency_GetX_hit : Accumulator : Sum.u64 = 72; SumSQ.u64 = 648; Count.u64 = 8; Min.u64 = 9; Max.u64 = 9; 
@@ -14786,7 +14786,7 @@ Model complete
  l2cache_18.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_18.latency_GetS_hit : Accumulator : Sum.u64 = 171; SumSQ.u64 = 1539; Count.u64 = 19; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_18.latency_GetS_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 1638; Count.u64 = 118; Min.u64 = 1; Max.u64 = 9; 
  l2cache_18.latency_GetS_miss : Accumulator : Sum.u64 = 86351; SumSQ.u64 = 19595413; Count.u64 = 481; Min.u64 = 48; Max.u64 = 1124; 
  l2cache_18.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_18.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -15443,7 +15443,7 @@ Model complete
  l2cache_19.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_19.latency_GetS_hit : Accumulator : Sum.u64 = 189; SumSQ.u64 = 1701; Count.u64 = 21; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_19.latency_GetS_hit : Accumulator : Sum.u64 = 293; SumSQ.u64 = 1805; Count.u64 = 125; Min.u64 = 1; Max.u64 = 9; 
  l2cache_19.latency_GetS_miss : Accumulator : Sum.u64 = 86072; SumSQ.u64 = 19084608; Count.u64 = 479; Min.u64 = 48; Max.u64 = 892; 
  l2cache_19.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_19.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -16100,7 +16100,7 @@ Model complete
  l2cache_20.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_20.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_20.latency_GetS_hit : Accumulator : Sum.u64 = 324; SumSQ.u64 = 2052; Count.u64 = 132; Min.u64 = 1; Max.u64 = 9; 
  l2cache_20.latency_GetS_miss : Accumulator : Sum.u64 = 85800; SumSQ.u64 = 18596540; Count.u64 = 476; Min.u64 = 48; Max.u64 = 881; 
  l2cache_20.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_20.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -16757,7 +16757,7 @@ Model complete
  l2cache_21.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_21.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_21.latency_GetS_hit : Accumulator : Sum.u64 = 321; SumSQ.u64 = 2049; Count.u64 = 129; Min.u64 = 1; Max.u64 = 9; 
  l2cache_21.latency_GetS_miss : Accumulator : Sum.u64 = 86024; SumSQ.u64 = 20282812; Count.u64 = 476; Min.u64 = 48; Max.u64 = 1169; 
  l2cache_21.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_21.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -17414,7 +17414,7 @@ Model complete
  l2cache_22.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_22.latency_GetS_hit : Accumulator : Sum.u64 = 261; SumSQ.u64 = 2349; Count.u64 = 29; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_22.latency_GetS_hit : Accumulator : Sum.u64 = 364; SumSQ.u64 = 2452; Count.u64 = 132; Min.u64 = 1; Max.u64 = 9; 
  l2cache_22.latency_GetS_miss : Accumulator : Sum.u64 = 84736; SumSQ.u64 = 18475714; Count.u64 = 471; Min.u64 = 48; Max.u64 = 929; 
  l2cache_22.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_22.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -18094,7 +18094,7 @@ Model complete
  l2cache_23.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_23.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_23.latency_GetS_hit : Accumulator : Sum.u64 = 323; SumSQ.u64 = 2051; Count.u64 = 131; Min.u64 = 1; Max.u64 = 9; 
  l2cache_23.latency_GetS_miss : Accumulator : Sum.u64 = 88278; SumSQ.u64 = 20342500; Count.u64 = 476; Min.u64 = 54; Max.u64 = 968; 
  l2cache_23.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_23.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -18751,7 +18751,7 @@ Model complete
  l2cache_24.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_24.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_24.latency_GetS_hit : Accumulator : Sum.u64 = 312; SumSQ.u64 = 2040; Count.u64 = 120; Min.u64 = 1; Max.u64 = 9; 
  l2cache_24.latency_GetS_miss : Accumulator : Sum.u64 = 84072; SumSQ.u64 = 18760220; Count.u64 = 476; Min.u64 = 51; Max.u64 = 1015; 
  l2cache_24.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_24.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -19408,7 +19408,7 @@ Model complete
  l2cache_25.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_25.latency_GetS_hit : Accumulator : Sum.u64 = 190; SumSQ.u64 = 1720; Count.u64 = 21; Min.u64 = 9; Max.u64 = 10; 
+ l2cache_25.latency_GetS_hit : Accumulator : Sum.u64 = 280; SumSQ.u64 = 1810; Count.u64 = 111; Min.u64 = 1; Max.u64 = 10; 
  l2cache_25.latency_GetS_miss : Accumulator : Sum.u64 = 93173; SumSQ.u64 = 33710281; Count.u64 = 479; Min.u64 = 48; Max.u64 = 1862; 
  l2cache_25.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_25.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -20065,7 +20065,7 @@ Model complete
  l2cache_26.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_26.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_26.latency_GetS_hit : Accumulator : Sum.u64 = 265; SumSQ.u64 = 1561; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_26.latency_GetS_miss : Accumulator : Sum.u64 = 97680; SumSQ.u64 = 44478288; Count.u64 = 482; Min.u64 = 47; Max.u64 = 1794; 
  l2cache_26.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_26.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -20722,7 +20722,7 @@ Model complete
  l2cache_27.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_27.latency_GetS_hit : Accumulator : Sum.u64 = 224; SumSQ.u64 = 2458; Count.u64 = 23; Min.u64 = 9; Max.u64 = 26; 
+ l2cache_27.latency_GetS_hit : Accumulator : Sum.u64 = 328; SumSQ.u64 = 2562; Count.u64 = 127; Min.u64 = 1; Max.u64 = 26; 
  l2cache_27.latency_GetS_miss : Accumulator : Sum.u64 = 97717; SumSQ.u64 = 47091541; Count.u64 = 477; Min.u64 = 47; Max.u64 = 2077; 
  l2cache_27.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_27.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -21379,7 +21379,7 @@ Model complete
  l2cache_28.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_28.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_28.latency_GetS_hit : Accumulator : Sum.u64 = 297; SumSQ.u64 = 1881; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_28.latency_GetS_miss : Accumulator : Sum.u64 = 99102; SumSQ.u64 = 46348464; Count.u64 = 478; Min.u64 = 47; Max.u64 = 1971; 
  l2cache_28.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_28.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -22036,7 +22036,7 @@ Model complete
  l2cache_29.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_29.latency_GetS_hit : Accumulator : Sum.u64 = 162; SumSQ.u64 = 1458; Count.u64 = 18; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_29.latency_GetS_hit : Accumulator : Sum.u64 = 263; SumSQ.u64 = 1559; Count.u64 = 119; Min.u64 = 1; Max.u64 = 9; 
  l2cache_29.latency_GetS_miss : Accumulator : Sum.u64 = 101566; SumSQ.u64 = 46672440; Count.u64 = 482; Min.u64 = 47; Max.u64 = 1914; 
  l2cache_29.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_29.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -22720,7 +22720,7 @@ Model complete
  l2cache_30.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_30.latency_GetS_hit : Accumulator : Sum.u64 = 198; SumSQ.u64 = 1782; Count.u64 = 22; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_30.latency_GetS_hit : Accumulator : Sum.u64 = 305; SumSQ.u64 = 1889; Count.u64 = 129; Min.u64 = 1; Max.u64 = 9; 
  l2cache_30.latency_GetS_miss : Accumulator : Sum.u64 = 99947; SumSQ.u64 = 47778863; Count.u64 = 478; Min.u64 = 48; Max.u64 = 2260; 
  l2cache_30.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_30.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -23404,7 +23404,7 @@ Model complete
  l2cache_31.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_31.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_31.latency_GetS_hit : Accumulator : Sum.u64 = 314; SumSQ.u64 = 2042; Count.u64 = 122; Min.u64 = 1; Max.u64 = 9; 
  l2cache_31.latency_GetS_miss : Accumulator : Sum.u64 = 97821; SumSQ.u64 = 47914309; Count.u64 = 476; Min.u64 = 47; Max.u64 = 1954; 
  l2cache_31.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_31.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -24061,7 +24061,7 @@ Model complete
  l2cache_32.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_32.latency_GetS_hit : Accumulator : Sum.u64 = 629; SumSQ.u64 = 172513; Count.u64 = 25; Min.u64 = 9; Max.u64 = 413; 
+ l2cache_32.latency_GetS_hit : Accumulator : Sum.u64 = 725; SumSQ.u64 = 172609; Count.u64 = 121; Min.u64 = 1; Max.u64 = 413; 
  l2cache_32.latency_GetS_miss : Accumulator : Sum.u64 = 95285; SumSQ.u64 = 45434903; Count.u64 = 475; Min.u64 = 47; Max.u64 = 2481; 
  l2cache_32.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_32.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -24718,7 +24718,7 @@ Model complete
  l2cache_33.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_33.latency_GetS_hit : Accumulator : Sum.u64 = 261; SumSQ.u64 = 2349; Count.u64 = 29; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_33.latency_GetS_hit : Accumulator : Sum.u64 = 353; SumSQ.u64 = 2441; Count.u64 = 121; Min.u64 = 1; Max.u64 = 9; 
  l2cache_33.latency_GetS_miss : Accumulator : Sum.u64 = 94263; SumSQ.u64 = 45994117; Count.u64 = 471; Min.u64 = 47; Max.u64 = 2363; 
  l2cache_33.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_33.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -25402,7 +25402,7 @@ Model complete
  l2cache_34.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_34.latency_GetS_hit : Accumulator : Sum.u64 = 216; SumSQ.u64 = 1944; Count.u64 = 24; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_34.latency_GetS_hit : Accumulator : Sum.u64 = 323; SumSQ.u64 = 2051; Count.u64 = 131; Min.u64 = 1; Max.u64 = 9; 
  l2cache_34.latency_GetS_miss : Accumulator : Sum.u64 = 95963; SumSQ.u64 = 45299209; Count.u64 = 476; Min.u64 = 47; Max.u64 = 2168; 
  l2cache_34.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_34.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -26086,7 +26086,7 @@ Model complete
  l2cache_35.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache_35.latency_GetS_hit : Accumulator : Sum.u64 = 207; SumSQ.u64 = 1863; Count.u64 = 23; Min.u64 = 9; Max.u64 = 9; 
+ l2cache_35.latency_GetS_hit : Accumulator : Sum.u64 = 299; SumSQ.u64 = 1955; Count.u64 = 115; Min.u64 = 1; Max.u64 = 9; 
  l2cache_35.latency_GetS_miss : Accumulator : Sum.u64 = 97092; SumSQ.u64 = 46849630; Count.u64 = 477; Min.u64 = 48; Max.u64 = 2412; 
  l2cache_35.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache_35.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_1.out
@@ -10,14 +10,14 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (116962 clocks)
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (115581 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (116860 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (114868 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (114261 clocks)
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (115581 clocks)
 TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (116612 clocks)
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (115576 clocks)
 TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (116296 clocks)
+TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (116962 clocks)
  cpu0.pendCycle : Accumulator : Sum.u64 = 1132404; SumSQ.u64 = 11254902; Count.u64 = 114261; Min.u64 = 0; Max.u64 = 10; 
  l1cache0.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.stateEvent_GetS_I : Accumulator : Sum.u64 = 1345; SumSQ.u64 = 1345; Count.u64 = 1345; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_Noninclusive_2.out
@@ -10,14 +10,14 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (130406 clocks)
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (131399 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (125943 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (130827 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (129240 clocks)
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (131399 clocks)
 TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (128015 clocks)
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (129227 clocks)
 TrivialCPU cpu6 Finished after 1500 issued reads, 1500 returned (134065 clocks)
+TrivialCPU cpu7 Finished after 1500 issued reads, 1500 returned (130406 clocks)
  cpu0.pendCycle : Accumulator : Sum.u64 = 1281355; SumSQ.u64 = 12742561; Count.u64 = 129240; Min.u64 = 0; Max.u64 = 10; 
  l1cache0.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.stateEvent_GetS_I : Accumulator : Sum.u64 = 1352; SumSQ.u64 = 1352; Count.u64 = 1352; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams.out
@@ -98,8 +98,8 @@ Completed @ 5416 ns
  l1cache0.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69409; SumSQ.u64 = 5358541; Count.u64 = 1194; Min.u64 = 4; Max.u64 = 251; 
- l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 12222; SumSQ.u64 = 963804; Count.u64 = 166; Min.u64 = 16; Max.u64 = 110; 
+ l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69411; SumSQ.u64 = 5358543; Count.u64 = 1196; Min.u64 = 1; Max.u64 = 251; 
+ l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 12422; SumSQ.u64 = 983804; Count.u64 = 168; Min.u64 = 16; Max.u64 = 110; 
  l1cache0.latency_GetX_hit : Accumulator : Sum.u64 = 4347; SumSQ.u64 = 399691; Count.u64 = 54; Min.u64 = 4; Max.u64 = 138; 
  l1cache0.latency_GetX_miss : Accumulator : Sum.u64 = 1719; SumSQ.u64 = 162727; Count.u64 = 19; Min.u64 = 73; Max.u64 = 154; 
  l1cache0.latency_GetX_upgrade : Accumulator : Sum.u64 = 7594; SumSQ.u64 = 930150; Count.u64 = 67; Min.u64 = 65; Max.u64 = 250; 
@@ -306,7 +306,7 @@ Completed @ 5416 ns
  l2cache0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 66; SumSQ.u64 = 3236; Count.u64 = 2; Min.u64 = 10; Max.u64 = 56; 
+ l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69; SumSQ.u64 = 3239; Count.u64 = 5; Min.u64 = 1; Max.u64 = 56; 
  l2cache0.latency_GetS_miss : Accumulator : Sum.u64 = 11352; SumSQ.u64 = 838478; Count.u64 = 166; Min.u64 = 38; Max.u64 = 104; 
  l2cache0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -500,8 +500,8 @@ Completed @ 5416 ns
  l1cache1.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache1.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 74099; SumSQ.u64 = 6868869; Count.u64 = 1185; Min.u64 = 4; Max.u64 = 253; 
- l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 12773; SumSQ.u64 = 1067503; Count.u64 = 170; Min.u64 = 37; Max.u64 = 147; 
+ l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 74102; SumSQ.u64 = 6868872; Count.u64 = 1188; Min.u64 = 1; Max.u64 = 253; 
+ l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 12989; SumSQ.u64 = 1091031; Count.u64 = 172; Min.u64 = 37; Max.u64 = 147; 
  l1cache1.latency_GetX_hit : Accumulator : Sum.u64 = 4494; SumSQ.u64 = 561712; Count.u64 = 48; Min.u64 = 2; Max.u64 = 249; 
  l1cache1.latency_GetX_miss : Accumulator : Sum.u64 = 1498; SumSQ.u64 = 127570; Count.u64 = 18; Min.u64 = 71; Max.u64 = 129; 
  l1cache1.latency_GetX_upgrade : Accumulator : Sum.u64 = 9952; SumSQ.u64 = 1354950; Count.u64 = 79; Min.u64 = 72; Max.u64 = 253; 
@@ -708,7 +708,7 @@ Completed @ 5416 ns
  l2cache1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 31; SumSQ.u64 = 961; Count.u64 = 1; Min.u64 = 31; Max.u64 = 31; 
+ l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 43; SumSQ.u64 = 993; Count.u64 = 9; Min.u64 = 1; Max.u64 = 31; 
  l2cache1.latency_GetS_miss : Accumulator : Sum.u64 = 11922; SumSQ.u64 = 940274; Count.u64 = 171; Min.u64 = 38; Max.u64 = 140; 
  l2cache1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -902,8 +902,8 @@ Completed @ 5416 ns
  l1cache2.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache2.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 71133; SumSQ.u64 = 6728565; Count.u64 = 1204; Min.u64 = 4; Max.u64 = 396; 
- l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 11741; SumSQ.u64 = 962839; Count.u64 = 168; Min.u64 = 16; Max.u64 = 286; 
+ l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 71143; SumSQ.u64 = 6728575; Count.u64 = 1214; Min.u64 = 1; Max.u64 = 396; 
+ l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 11980; SumSQ.u64 = 992084; Count.u64 = 170; Min.u64 = 16; Max.u64 = 286; 
  l1cache2.latency_GetX_hit : Accumulator : Sum.u64 = 3321; SumSQ.u64 = 373217; Count.u64 = 35; Min.u64 = 2; Max.u64 = 159; 
  l1cache2.latency_GetX_miss : Accumulator : Sum.u64 = 1301; SumSQ.u64 = 118935; Count.u64 = 15; Min.u64 = 72; Max.u64 = 141; 
  l1cache2.latency_GetX_upgrade : Accumulator : Sum.u64 = 9876; SumSQ.u64 = 1471204; Count.u64 = 78; Min.u64 = 71; Max.u64 = 395; 
@@ -1110,7 +1110,7 @@ Completed @ 5416 ns
  l2cache2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 10; SumSQ.u64 = 100; Count.u64 = 1; Min.u64 = 10; Max.u64 = 10; 
+ l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 201; SumSQ.u64 = 31443; Count.u64 = 16; Min.u64 = 1; Max.u64 = 177; 
  l2cache2.latency_GetS_miss : Accumulator : Sum.u64 = 10952; SumSQ.u64 = 855260; Count.u64 = 169; Min.u64 = 37; Max.u64 = 280; 
  l2cache2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1304,8 +1304,8 @@ Completed @ 5416 ns
  l1cache3.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache3.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 75426; SumSQ.u64 = 7437294; Count.u64 = 1159; Min.u64 = 4; Max.u64 = 375; 
- l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 12110; SumSQ.u64 = 1010270; Count.u64 = 168; Min.u64 = 16; Max.u64 = 230; 
+ l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 75430; SumSQ.u64 = 7437298; Count.u64 = 1163; Min.u64 = 1; Max.u64 = 375; 
+ l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 12370; SumSQ.u64 = 1045752; Count.u64 = 170; Min.u64 = 16; Max.u64 = 230; 
  l1cache3.latency_GetX_hit : Accumulator : Sum.u64 = 4006; SumSQ.u64 = 435048; Count.u64 = 52; Min.u64 = 2; Max.u64 = 192; 
  l1cache3.latency_GetX_miss : Accumulator : Sum.u64 = 1932; SumSQ.u64 = 197212; Count.u64 = 21; Min.u64 = 75; Max.u64 = 183; 
  l1cache3.latency_GetX_upgrade : Accumulator : Sum.u64 = 11985; SumSQ.u64 = 1662247; Count.u64 = 100; Min.u64 = 71; Max.u64 = 375; 
@@ -1512,7 +1512,7 @@ Completed @ 5416 ns
  l2cache3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 52; SumSQ.u64 = 544; Count.u64 = 5; Min.u64 = 10; Max.u64 = 12; 
+ l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 284; SumSQ.u64 = 51176; Count.u64 = 13; Min.u64 = 1; Max.u64 = 225; 
  l2cache3.latency_GetS_miss : Accumulator : Sum.u64 = 11296; SumSQ.u64 = 903394; Count.u64 = 165; Min.u64 = 38; Max.u64 = 224; 
  l2cache3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1706,8 +1706,8 @@ Completed @ 5416 ns
  l1cache4.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache4.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 75027; SumSQ.u64 = 7394697; Count.u64 = 1190; Min.u64 = 4; Max.u64 = 441; 
- l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 12575; SumSQ.u64 = 1106755; Count.u64 = 171; Min.u64 = 15; Max.u64 = 249; 
+ l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 75044; SumSQ.u64 = 7394714; Count.u64 = 1207; Min.u64 = 1; Max.u64 = 441; 
+ l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 12819; SumSQ.u64 = 1142573; Count.u64 = 173; Min.u64 = 15; Max.u64 = 249; 
  l1cache4.latency_GetX_hit : Accumulator : Sum.u64 = 3766; SumSQ.u64 = 496752; Count.u64 = 39; Min.u64 = 2; Max.u64 = 305; 
  l1cache4.latency_GetX_miss : Accumulator : Sum.u64 = 2064; SumSQ.u64 = 240684; Count.u64 = 20; Min.u64 = 71; Max.u64 = 235; 
  l1cache4.latency_GetX_upgrade : Accumulator : Sum.u64 = 10255; SumSQ.u64 = 1556997; Count.u64 = 80; Min.u64 = 72; Max.u64 = 444; 
@@ -1914,7 +1914,7 @@ Completed @ 5416 ns
  l2cache4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 19; SumSQ.u64 = 181; Count.u64 = 2; Min.u64 = 9; Max.u64 = 10; 
+ l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 37; SumSQ.u64 = 199; Count.u64 = 20; Min.u64 = 1; Max.u64 = 10; 
  l2cache4.latency_GetS_miss : Accumulator : Sum.u64 = 11764; SumSQ.u64 = 995800; Count.u64 = 171; Min.u64 = 37; Max.u64 = 243; 
  l2cache4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2108,8 +2108,8 @@ Completed @ 5416 ns
  l1cache5.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache5.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 73012; SumSQ.u64 = 7558900; Count.u64 = 1185; Min.u64 = 4; Max.u64 = 515; 
- l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 12385; SumSQ.u64 = 1083259; Count.u64 = 172; Min.u64 = 17; Max.u64 = 267; 
+ l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 73026; SumSQ.u64 = 7558914; Count.u64 = 1199; Min.u64 = 1; Max.u64 = 515; 
+ l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 12770; SumSQ.u64 = 1157412; Count.u64 = 174; Min.u64 = 17; Max.u64 = 267; 
  l1cache5.latency_GetX_hit : Accumulator : Sum.u64 = 4584; SumSQ.u64 = 777332; Count.u64 = 41; Min.u64 = 2; Max.u64 = 514; 
  l1cache5.latency_GetX_miss : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 129287; Count.u64 = 14; Min.u64 = 75; Max.u64 = 138; 
  l1cache5.latency_GetX_upgrade : Accumulator : Sum.u64 = 11124; SumSQ.u64 = 1703066; Count.u64 = 88; Min.u64 = 70; Max.u64 = 520; 
@@ -2316,7 +2316,7 @@ Completed @ 5416 ns
  l2cache5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 84; SumSQ.u64 = 2798; Count.u64 = 3; Min.u64 = 11; Max.u64 = 39; 
+ l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 104; SumSQ.u64 = 2818; Count.u64 = 23; Min.u64 = 1; Max.u64 = 39; 
  l2cache5.latency_GetS_miss : Accumulator : Sum.u64 = 11643; SumSQ.u64 = 1009375; Count.u64 = 171; Min.u64 = 38; Max.u64 = 261; 
  l2cache5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_PrefetchParams_MC.out
@@ -98,8 +98,8 @@ Completed @ 5416 ns
  l1cache0.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69409; SumSQ.u64 = 5358541; Count.u64 = 1194; Min.u64 = 4; Max.u64 = 251; 
- l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 12222; SumSQ.u64 = 963804; Count.u64 = 166; Min.u64 = 16; Max.u64 = 110; 
+ l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69411; SumSQ.u64 = 5358543; Count.u64 = 1196; Min.u64 = 1; Max.u64 = 251; 
+ l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 12422; SumSQ.u64 = 983804; Count.u64 = 168; Min.u64 = 16; Max.u64 = 110; 
  l1cache0.latency_GetX_hit : Accumulator : Sum.u64 = 4347; SumSQ.u64 = 399691; Count.u64 = 54; Min.u64 = 4; Max.u64 = 138; 
  l1cache0.latency_GetX_miss : Accumulator : Sum.u64 = 1719; SumSQ.u64 = 162727; Count.u64 = 19; Min.u64 = 73; Max.u64 = 154; 
  l1cache0.latency_GetX_upgrade : Accumulator : Sum.u64 = 7594; SumSQ.u64 = 930150; Count.u64 = 67; Min.u64 = 65; Max.u64 = 250; 
@@ -306,7 +306,7 @@ Completed @ 5416 ns
  l2cache0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 66; SumSQ.u64 = 3236; Count.u64 = 2; Min.u64 = 10; Max.u64 = 56; 
+ l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 69; SumSQ.u64 = 3239; Count.u64 = 5; Min.u64 = 1; Max.u64 = 56; 
  l2cache0.latency_GetS_miss : Accumulator : Sum.u64 = 11352; SumSQ.u64 = 838478; Count.u64 = 166; Min.u64 = 38; Max.u64 = 104; 
  l2cache0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -500,8 +500,8 @@ Completed @ 5416 ns
  l1cache1.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache1.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 74099; SumSQ.u64 = 6868869; Count.u64 = 1185; Min.u64 = 4; Max.u64 = 253; 
- l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 12773; SumSQ.u64 = 1067503; Count.u64 = 170; Min.u64 = 37; Max.u64 = 147; 
+ l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 74102; SumSQ.u64 = 6868872; Count.u64 = 1188; Min.u64 = 1; Max.u64 = 253; 
+ l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 12989; SumSQ.u64 = 1091031; Count.u64 = 172; Min.u64 = 37; Max.u64 = 147; 
  l1cache1.latency_GetX_hit : Accumulator : Sum.u64 = 4494; SumSQ.u64 = 561712; Count.u64 = 48; Min.u64 = 2; Max.u64 = 249; 
  l1cache1.latency_GetX_miss : Accumulator : Sum.u64 = 1498; SumSQ.u64 = 127570; Count.u64 = 18; Min.u64 = 71; Max.u64 = 129; 
  l1cache1.latency_GetX_upgrade : Accumulator : Sum.u64 = 9952; SumSQ.u64 = 1354950; Count.u64 = 79; Min.u64 = 72; Max.u64 = 253; 
@@ -708,7 +708,7 @@ Completed @ 5416 ns
  l2cache1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 31; SumSQ.u64 = 961; Count.u64 = 1; Min.u64 = 31; Max.u64 = 31; 
+ l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 43; SumSQ.u64 = 993; Count.u64 = 9; Min.u64 = 1; Max.u64 = 31; 
  l2cache1.latency_GetS_miss : Accumulator : Sum.u64 = 11922; SumSQ.u64 = 940274; Count.u64 = 171; Min.u64 = 38; Max.u64 = 140; 
  l2cache1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -902,8 +902,8 @@ Completed @ 5416 ns
  l1cache2.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache2.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 71133; SumSQ.u64 = 6728565; Count.u64 = 1204; Min.u64 = 4; Max.u64 = 396; 
- l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 11741; SumSQ.u64 = 962839; Count.u64 = 168; Min.u64 = 16; Max.u64 = 286; 
+ l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 71143; SumSQ.u64 = 6728575; Count.u64 = 1214; Min.u64 = 1; Max.u64 = 396; 
+ l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 11980; SumSQ.u64 = 992084; Count.u64 = 170; Min.u64 = 16; Max.u64 = 286; 
  l1cache2.latency_GetX_hit : Accumulator : Sum.u64 = 3321; SumSQ.u64 = 373217; Count.u64 = 35; Min.u64 = 2; Max.u64 = 159; 
  l1cache2.latency_GetX_miss : Accumulator : Sum.u64 = 1301; SumSQ.u64 = 118935; Count.u64 = 15; Min.u64 = 72; Max.u64 = 141; 
  l1cache2.latency_GetX_upgrade : Accumulator : Sum.u64 = 9876; SumSQ.u64 = 1471204; Count.u64 = 78; Min.u64 = 71; Max.u64 = 395; 
@@ -1110,7 +1110,7 @@ Completed @ 5416 ns
  l2cache2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 10; SumSQ.u64 = 100; Count.u64 = 1; Min.u64 = 10; Max.u64 = 10; 
+ l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 201; SumSQ.u64 = 31443; Count.u64 = 16; Min.u64 = 1; Max.u64 = 177; 
  l2cache2.latency_GetS_miss : Accumulator : Sum.u64 = 10952; SumSQ.u64 = 855260; Count.u64 = 169; Min.u64 = 37; Max.u64 = 280; 
  l2cache2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1304,8 +1304,8 @@ Completed @ 5416 ns
  l1cache3.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache3.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 75426; SumSQ.u64 = 7437294; Count.u64 = 1159; Min.u64 = 4; Max.u64 = 375; 
- l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 12110; SumSQ.u64 = 1010270; Count.u64 = 168; Min.u64 = 16; Max.u64 = 230; 
+ l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 75430; SumSQ.u64 = 7437298; Count.u64 = 1163; Min.u64 = 1; Max.u64 = 375; 
+ l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 12370; SumSQ.u64 = 1045752; Count.u64 = 170; Min.u64 = 16; Max.u64 = 230; 
  l1cache3.latency_GetX_hit : Accumulator : Sum.u64 = 4006; SumSQ.u64 = 435048; Count.u64 = 52; Min.u64 = 2; Max.u64 = 192; 
  l1cache3.latency_GetX_miss : Accumulator : Sum.u64 = 1932; SumSQ.u64 = 197212; Count.u64 = 21; Min.u64 = 75; Max.u64 = 183; 
  l1cache3.latency_GetX_upgrade : Accumulator : Sum.u64 = 11985; SumSQ.u64 = 1662247; Count.u64 = 100; Min.u64 = 71; Max.u64 = 375; 
@@ -1512,7 +1512,7 @@ Completed @ 5416 ns
  l2cache3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 52; SumSQ.u64 = 544; Count.u64 = 5; Min.u64 = 10; Max.u64 = 12; 
+ l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 284; SumSQ.u64 = 51176; Count.u64 = 13; Min.u64 = 1; Max.u64 = 225; 
  l2cache3.latency_GetS_miss : Accumulator : Sum.u64 = 11296; SumSQ.u64 = 903394; Count.u64 = 165; Min.u64 = 38; Max.u64 = 224; 
  l2cache3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1706,8 +1706,8 @@ Completed @ 5416 ns
  l1cache4.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache4.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 75027; SumSQ.u64 = 7394697; Count.u64 = 1190; Min.u64 = 4; Max.u64 = 441; 
- l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 12575; SumSQ.u64 = 1106755; Count.u64 = 171; Min.u64 = 15; Max.u64 = 249; 
+ l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 75044; SumSQ.u64 = 7394714; Count.u64 = 1207; Min.u64 = 1; Max.u64 = 441; 
+ l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 12819; SumSQ.u64 = 1142573; Count.u64 = 173; Min.u64 = 15; Max.u64 = 249; 
  l1cache4.latency_GetX_hit : Accumulator : Sum.u64 = 3766; SumSQ.u64 = 496752; Count.u64 = 39; Min.u64 = 2; Max.u64 = 305; 
  l1cache4.latency_GetX_miss : Accumulator : Sum.u64 = 2064; SumSQ.u64 = 240684; Count.u64 = 20; Min.u64 = 71; Max.u64 = 235; 
  l1cache4.latency_GetX_upgrade : Accumulator : Sum.u64 = 10255; SumSQ.u64 = 1556997; Count.u64 = 80; Min.u64 = 72; Max.u64 = 444; 
@@ -1914,7 +1914,7 @@ Completed @ 5416 ns
  l2cache4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 19; SumSQ.u64 = 181; Count.u64 = 2; Min.u64 = 9; Max.u64 = 10; 
+ l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 37; SumSQ.u64 = 199; Count.u64 = 20; Min.u64 = 1; Max.u64 = 10; 
  l2cache4.latency_GetS_miss : Accumulator : Sum.u64 = 11764; SumSQ.u64 = 995800; Count.u64 = 171; Min.u64 = 37; Max.u64 = 243; 
  l2cache4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2108,8 +2108,8 @@ Completed @ 5416 ns
  l1cache5.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache5.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 73012; SumSQ.u64 = 7558900; Count.u64 = 1185; Min.u64 = 4; Max.u64 = 515; 
- l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 12385; SumSQ.u64 = 1083259; Count.u64 = 172; Min.u64 = 17; Max.u64 = 267; 
+ l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 73026; SumSQ.u64 = 7558914; Count.u64 = 1199; Min.u64 = 1; Max.u64 = 515; 
+ l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 12770; SumSQ.u64 = 1157412; Count.u64 = 174; Min.u64 = 17; Max.u64 = 267; 
  l1cache5.latency_GetX_hit : Accumulator : Sum.u64 = 4584; SumSQ.u64 = 777332; Count.u64 = 41; Min.u64 = 2; Max.u64 = 514; 
  l1cache5.latency_GetX_miss : Accumulator : Sum.u64 = 1315; SumSQ.u64 = 129287; Count.u64 = 14; Min.u64 = 75; Max.u64 = 138; 
  l1cache5.latency_GetX_upgrade : Accumulator : Sum.u64 = 11124; SumSQ.u64 = 1703066; Count.u64 = 88; Min.u64 = 70; Max.u64 = 520; 
@@ -2316,7 +2316,7 @@ Completed @ 5416 ns
  l2cache5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 84; SumSQ.u64 = 2798; Count.u64 = 3; Min.u64 = 11; Max.u64 = 39; 
+ l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 104; SumSQ.u64 = 2818; Count.u64 = 23; Min.u64 = 1; Max.u64 = 39; 
  l2cache5.latency_GetS_miss : Accumulator : Sum.u64 = 11643; SumSQ.u64 = 1009375; Count.u64 = 171; Min.u64 = 38; Max.u64 = 261; 
  l2cache5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ScratchCache_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ScratchCache_2.out
@@ -1,7 +1,7 @@
 l2_0: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 cycles.
 l2_1: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 cycles.
-ScratchCPU cpu0 Finished after 1000 issued memory events, 1000 returned, 3974 cycles
 ScratchCPU cpu1 Finished after 1000 issued memory events, 1000 returned, 4009 cycles
+ScratchCPU cpu0 Finished after 1000 issued memory events, 1000 returned, 3974 cycles
  l1_0.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1_0.stateEvent_GetS_I : Accumulator : Sum.u64 = 172; SumSQ.u64 = 172; Count.u64 = 172; Min.u64 = 1; Max.u64 = 1; 
  l1_0.stateEvent_GetS_S : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ScratchCache_3.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ScratchCache_3.out
@@ -2,8 +2,8 @@ l2_0: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 
 l3_0: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 cycles.
 l2_1: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 cycles.
 l3_1: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 2 cycles.
-ScratchCPU cpu0 Finished after 1000 issued memory events, 1000 returned, 65358 cycles
 ScratchCPU cpu1 Finished after 1000 issued memory events, 1000 returned, 67763 cycles
+ScratchCPU cpu0 Finished after 1000 issued memory events, 1000 returned, 65358 cycles
  l1_0.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1_0.stateEvent_GetS_I : Accumulator : Sum.u64 = 162; SumSQ.u64 = 162; Count.u64 = 162; Min.u64 = 1; Max.u64 = 1; 
  l1_0.stateEvent_GetS_S : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling.out
@@ -4,12 +4,12 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (9168 clocks)
-TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (8793 clocks)
-TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (8726 clocks)
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (9085 clocks)
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (9113 clocks)
 TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (9113 clocks)
+TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (8726 clocks)
+TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (8793 clocks)
+TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (9168 clocks)
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (9085 clocks)
  cpu0.pendCycle : Accumulator : Sum.u64 = 78911; SumSQ.u64 = 729059; Count.u64 = 8726; Min.u64 = 0; Max.u64 = 10; 
  l1cache0.Prefetch_requests : Accumulator : Sum.u64 = 883; SumSQ.u64 = 883; Count.u64 = 883; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.Prefetch_drops : Accumulator : Sum.u64 = 623; SumSQ.u64 = 623; Count.u64 = 623; Min.u64 = 1; Max.u64 = 1; 
@@ -99,8 +99,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache0.evict_IM : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.evict_SM : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 12083; SumSQ.u64 = 1613465; Count.u64 = 606; Min.u64 = 4; Max.u64 = 603; 
- l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 47970; SumSQ.u64 = 6335964; Count.u64 = 753; Min.u64 = 16; Max.u64 = 823; 
+ l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 12341; SumSQ.u64 = 1613723; Count.u64 = 864; Min.u64 = 1; Max.u64 = 603; 
+ l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 48585; SumSQ.u64 = 6551757; Count.u64 = 755; Min.u64 = 16; Max.u64 = 823; 
  l1cache0.latency_GetX_hit : Accumulator : Sum.u64 = 737; SumSQ.u64 = 91037; Count.u64 = 11; Min.u64 = 2; Max.u64 = 197; 
  l1cache0.latency_GetX_miss : Accumulator : Sum.u64 = 9796; SumSQ.u64 = 1260116; Count.u64 = 83; Min.u64 = 78; Max.u64 = 225; 
  l1cache0.latency_GetX_upgrade : Accumulator : Sum.u64 = 5325; SumSQ.u64 = 670465; Count.u64 = 47; Min.u64 = 76; Max.u64 = 257; 
@@ -307,7 +307,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 3756; SumSQ.u64 = 43026; Count.u64 = 331; Min.u64 = 10; Max.u64 = 17; 
+ l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 3913; SumSQ.u64 = 43183; Count.u64 = 488; Min.u64 = 1; Max.u64 = 17; 
  l2cache0.latency_GetS_miss : Accumulator : Sum.u64 = 35579; SumSQ.u64 = 4820639; Count.u64 = 424; Min.u64 = 37; Max.u64 = 814; 
  l2cache0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -502,8 +502,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache1.evict_IM : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; Min.u64 = 1; Max.u64 = 1; 
  l1cache1.evict_SM : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; Min.u64 = 1; Max.u64 = 1; 
  l1cache1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 9942; SumSQ.u64 = 890490; Count.u64 = 608; Min.u64 = 4; Max.u64 = 296; 
- l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 47302; SumSQ.u64 = 5688294; Count.u64 = 731; Min.u64 = 16; Max.u64 = 665; 
+ l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 10186; SumSQ.u64 = 890734; Count.u64 = 852; Min.u64 = 1; Max.u64 = 296; 
+ l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 47772; SumSQ.u64 = 5806432; Count.u64 = 733; Min.u64 = 16; Max.u64 = 665; 
  l1cache1.latency_GetX_hit : Accumulator : Sum.u64 = 254; SumSQ.u64 = 37114; Count.u64 = 7; Min.u64 = 2; Max.u64 = 183; 
  l1cache1.latency_GetX_miss : Accumulator : Sum.u64 = 10260; SumSQ.u64 = 1380020; Count.u64 = 85; Min.u64 = 17; Max.u64 = 214; 
  l1cache1.latency_GetX_upgrade : Accumulator : Sum.u64 = 8018; SumSQ.u64 = 1039360; Count.u64 = 69; Min.u64 = 77; Max.u64 = 279; 
@@ -710,7 +710,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 3651; SumSQ.u64 = 42147; Count.u64 = 320; Min.u64 = 10; Max.u64 = 18; 
+ l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 3796; SumSQ.u64 = 42292; Count.u64 = 465; Min.u64 = 1; Max.u64 = 18; 
  l2cache1.latency_GetS_miss : Accumulator : Sum.u64 = 33678; SumSQ.u64 = 3762104; Count.u64 = 413; Min.u64 = 38; Max.u64 = 489; 
  l2cache1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.latency_GetX_hit : Accumulator : Sum.u64 = 11; SumSQ.u64 = 121; Count.u64 = 1; Min.u64 = 11; Max.u64 = 11; 
@@ -905,8 +905,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache2.evict_IM : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; Min.u64 = 1; Max.u64 = 1; 
  l1cache2.evict_SM : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; Min.u64 = 1; Max.u64 = 1; 
  l1cache2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 8899; SumSQ.u64 = 671527; Count.u64 = 564; Min.u64 = 4; Max.u64 = 317; 
- l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 53351; SumSQ.u64 = 6064477; Count.u64 = 789; Min.u64 = 16; Max.u64 = 529; 
+ l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 9171; SumSQ.u64 = 671799; Count.u64 = 836; Min.u64 = 1; Max.u64 = 317; 
+ l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 53573; SumSQ.u64 = 6089151; Count.u64 = 791; Min.u64 = 16; Max.u64 = 529; 
  l1cache2.latency_GetX_hit : Accumulator : Sum.u64 = 452; SumSQ.u64 = 84438; Count.u64 = 4; Min.u64 = 8; Max.u64 = 259; 
  l1cache2.latency_GetX_miss : Accumulator : Sum.u64 = 9062; SumSQ.u64 = 1292148; Count.u64 = 76; Min.u64 = 76; Max.u64 = 327; 
  l1cache2.latency_GetX_upgrade : Accumulator : Sum.u64 = 8332; SumSQ.u64 = 1324226; Count.u64 = 67; Min.u64 = 71; Max.u64 = 376; 
@@ -1113,7 +1113,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 3462; SumSQ.u64 = 40122; Count.u64 = 302; Min.u64 = 10; Max.u64 = 16; 
+ l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 3648; SumSQ.u64 = 40308; Count.u64 = 488; Min.u64 = 1; Max.u64 = 16; 
  l2cache2.latency_GetS_miss : Accumulator : Sum.u64 = 38353; SumSQ.u64 = 4052147; Count.u64 = 489; Min.u64 = 37; Max.u64 = 522; 
  l2cache2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1308,8 +1308,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache3.evict_IM : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; Min.u64 = 1; Max.u64 = 1; 
  l1cache3.evict_SM : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; Min.u64 = 1; Max.u64 = 1; 
  l1cache3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 10005; SumSQ.u64 = 790389; Count.u64 = 602; Min.u64 = 4; Max.u64 = 357; 
- l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 49063; SumSQ.u64 = 6302815; Count.u64 = 735; Min.u64 = 16; Max.u64 = 616; 
+ l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 10281; SumSQ.u64 = 790665; Count.u64 = 878; Min.u64 = 1; Max.u64 = 357; 
+ l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 49702; SumSQ.u64 = 6532288; Count.u64 = 737; Min.u64 = 16; Max.u64 = 616; 
  l1cache3.latency_GetX_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 35514; Count.u64 = 4; Min.u64 = 2; Max.u64 = 141; 
  l1cache3.latency_GetX_miss : Accumulator : Sum.u64 = 12164; SumSQ.u64 = 2017428; Count.u64 = 98; Min.u64 = 76; Max.u64 = 684; 
  l1cache3.latency_GetX_upgrade : Accumulator : Sum.u64 = 7565; SumSQ.u64 = 1112397; Count.u64 = 61; Min.u64 = 71; Max.u64 = 298; 
@@ -1516,7 +1516,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 3534; SumSQ.u64 = 43896; Count.u64 = 309; Min.u64 = 10; Max.u64 = 64; 
+ l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 3688; SumSQ.u64 = 44050; Count.u64 = 463; Min.u64 = 1; Max.u64 = 64; 
  l2cache3.latency_GetS_miss : Accumulator : Sum.u64 = 35048; SumSQ.u64 = 4143740; Count.u64 = 428; Min.u64 = 36; Max.u64 = 567; 
  l2cache3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1711,8 +1711,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache4.evict_IM : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
  l1cache4.evict_SM : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; Min.u64 = 1; Max.u64 = 1; 
  l1cache4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 10141; SumSQ.u64 = 1015471; Count.u64 = 579; Min.u64 = 4; Max.u64 = 580; 
- l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 52330; SumSQ.u64 = 6700760; Count.u64 = 777; Min.u64 = 16; Max.u64 = 681; 
+ l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 10389; SumSQ.u64 = 1015719; Count.u64 = 827; Min.u64 = 1; Max.u64 = 580; 
+ l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 52744; SumSQ.u64 = 6789346; Count.u64 = 779; Min.u64 = 16; Max.u64 = 681; 
  l1cache4.latency_GetX_hit : Accumulator : Sum.u64 = 607; SumSQ.u64 = 87369; Count.u64 = 7; Min.u64 = 2; Max.u64 = 216; 
  l1cache4.latency_GetX_miss : Accumulator : Sum.u64 = 9275; SumSQ.u64 = 1216663; Count.u64 = 79; Min.u64 = 75; Max.u64 = 284; 
  l1cache4.latency_GetX_upgrade : Accumulator : Sum.u64 = 6840; SumSQ.u64 = 899782; Count.u64 = 58; Min.u64 = 74; Max.u64 = 231; 
@@ -1919,7 +1919,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 3562; SumSQ.u64 = 40438; Count.u64 = 316; Min.u64 = 10; Max.u64 = 15; 
+ l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 3730; SumSQ.u64 = 40606; Count.u64 = 484; Min.u64 = 1; Max.u64 = 15; 
  l2cache4.latency_GetS_miss : Accumulator : Sum.u64 = 37402; SumSQ.u64 = 4170526; Count.u64 = 463; Min.u64 = 37; Max.u64 = 500; 
  l2cache4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2114,8 +2114,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache5.evict_IM : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; Min.u64 = 1; Max.u64 = 1; 
  l1cache5.evict_SM : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; Min.u64 = 1; Max.u64 = 1; 
  l1cache5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 11149; SumSQ.u64 = 1097871; Count.u64 = 587; Min.u64 = 4; Max.u64 = 428; 
- l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 51576; SumSQ.u64 = 9381230; Count.u64 = 768; Min.u64 = 16; Max.u64 = 1191; 
+ l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 11421; SumSQ.u64 = 1098143; Count.u64 = 859; Min.u64 = 1; Max.u64 = 428; 
+ l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 52507; SumSQ.u64 = 10060311; Count.u64 = 770; Min.u64 = 16; Max.u64 = 1191; 
  l1cache5.latency_GetX_hit : Accumulator : Sum.u64 = 190; SumSQ.u64 = 13556; Count.u64 = 5; Min.u64 = 2; Max.u64 = 98; 
  l1cache5.latency_GetX_miss : Accumulator : Sum.u64 = 8761; SumSQ.u64 = 1256307; Count.u64 = 74; Min.u64 = 76; Max.u64 = 474; 
  l1cache5.latency_GetX_upgrade : Accumulator : Sum.u64 = 7612; SumSQ.u64 = 1014898; Count.u64 = 66; Min.u64 = 78; Max.u64 = 302; 
@@ -2322,7 +2322,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 3678; SumSQ.u64 = 42132; Count.u64 = 324; Min.u64 = 10; Max.u64 = 16; 
+ l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 3856; SumSQ.u64 = 42310; Count.u64 = 502; Min.u64 = 1; Max.u64 = 16; 
  l2cache5.latency_GetS_miss : Accumulator : Sum.u64 = 36954; SumSQ.u64 = 5370482; Count.u64 = 446; Min.u64 = 38; Max.u64 = 849; 
  l2cache5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling_MC.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHA_ThroughputThrottling_MC.out
@@ -4,12 +4,12 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (9085 clocks)
+TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
+TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (9113 clocks)
 TrivialCPU cpu0 Finished after 1500 issued reads, 1500 returned (8726 clocks)
 TrivialCPU cpu1 Finished after 1500 issued reads, 1500 returned (8793 clocks)
 TrivialCPU cpu2 Finished after 1500 issued reads, 1500 returned (9168 clocks)
-TrivialCPU cpu4 Finished after 1500 issued reads, 1500 returned (9113 clocks)
-TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
+TrivialCPU cpu3 Finished after 1500 issued reads, 1500 returned (9085 clocks)
  cpu0.pendCycle : Accumulator : Sum.u64 = 78911; SumSQ.u64 = 729059; Count.u64 = 8726; Min.u64 = 0; Max.u64 = 10; 
  l1cache0.Prefetch_requests : Accumulator : Sum.u64 = 883; SumSQ.u64 = 883; Count.u64 = 883; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.Prefetch_drops : Accumulator : Sum.u64 = 623; SumSQ.u64 = 623; Count.u64 = 623; Min.u64 = 1; Max.u64 = 1; 
@@ -99,8 +99,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache0.evict_IM : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.evict_SM : Accumulator : Sum.u64 = 4; SumSQ.u64 = 4; Count.u64 = 4; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 12083; SumSQ.u64 = 1613465; Count.u64 = 606; Min.u64 = 4; Max.u64 = 603; 
- l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 47970; SumSQ.u64 = 6335964; Count.u64 = 753; Min.u64 = 16; Max.u64 = 823; 
+ l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 12341; SumSQ.u64 = 1613723; Count.u64 = 864; Min.u64 = 1; Max.u64 = 603; 
+ l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 48585; SumSQ.u64 = 6551757; Count.u64 = 755; Min.u64 = 16; Max.u64 = 823; 
  l1cache0.latency_GetX_hit : Accumulator : Sum.u64 = 737; SumSQ.u64 = 91037; Count.u64 = 11; Min.u64 = 2; Max.u64 = 197; 
  l1cache0.latency_GetX_miss : Accumulator : Sum.u64 = 9796; SumSQ.u64 = 1260116; Count.u64 = 83; Min.u64 = 78; Max.u64 = 225; 
  l1cache0.latency_GetX_upgrade : Accumulator : Sum.u64 = 5325; SumSQ.u64 = 670465; Count.u64 = 47; Min.u64 = 76; Max.u64 = 257; 
@@ -307,7 +307,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache0.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 3756; SumSQ.u64 = 43026; Count.u64 = 331; Min.u64 = 10; Max.u64 = 17; 
+ l2cache0.latency_GetS_hit : Accumulator : Sum.u64 = 3913; SumSQ.u64 = 43183; Count.u64 = 488; Min.u64 = 1; Max.u64 = 17; 
  l2cache0.latency_GetS_miss : Accumulator : Sum.u64 = 35579; SumSQ.u64 = 4820639; Count.u64 = 424; Min.u64 = 37; Max.u64 = 814; 
  l2cache0.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache0.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -502,8 +502,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache1.evict_IM : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; Min.u64 = 1; Max.u64 = 1; 
  l1cache1.evict_SM : Accumulator : Sum.u64 = 9; SumSQ.u64 = 9; Count.u64 = 9; Min.u64 = 1; Max.u64 = 1; 
  l1cache1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 9942; SumSQ.u64 = 890490; Count.u64 = 608; Min.u64 = 4; Max.u64 = 296; 
- l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 47302; SumSQ.u64 = 5688294; Count.u64 = 731; Min.u64 = 16; Max.u64 = 665; 
+ l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 10186; SumSQ.u64 = 890734; Count.u64 = 852; Min.u64 = 1; Max.u64 = 296; 
+ l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 47772; SumSQ.u64 = 5806432; Count.u64 = 733; Min.u64 = 16; Max.u64 = 665; 
  l1cache1.latency_GetX_hit : Accumulator : Sum.u64 = 254; SumSQ.u64 = 37114; Count.u64 = 7; Min.u64 = 2; Max.u64 = 183; 
  l1cache1.latency_GetX_miss : Accumulator : Sum.u64 = 10260; SumSQ.u64 = 1380020; Count.u64 = 85; Min.u64 = 17; Max.u64 = 214; 
  l1cache1.latency_GetX_upgrade : Accumulator : Sum.u64 = 8018; SumSQ.u64 = 1039360; Count.u64 = 69; Min.u64 = 77; Max.u64 = 279; 
@@ -710,7 +710,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache1.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 3651; SumSQ.u64 = 42147; Count.u64 = 320; Min.u64 = 10; Max.u64 = 18; 
+ l2cache1.latency_GetS_hit : Accumulator : Sum.u64 = 3796; SumSQ.u64 = 42292; Count.u64 = 465; Min.u64 = 1; Max.u64 = 18; 
  l2cache1.latency_GetS_miss : Accumulator : Sum.u64 = 33678; SumSQ.u64 = 3762104; Count.u64 = 413; Min.u64 = 38; Max.u64 = 489; 
  l2cache1.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache1.latency_GetX_hit : Accumulator : Sum.u64 = 11; SumSQ.u64 = 121; Count.u64 = 1; Min.u64 = 11; Max.u64 = 11; 
@@ -905,8 +905,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache2.evict_IM : Accumulator : Sum.u64 = 14; SumSQ.u64 = 14; Count.u64 = 14; Min.u64 = 1; Max.u64 = 1; 
  l1cache2.evict_SM : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; Min.u64 = 1; Max.u64 = 1; 
  l1cache2.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 8899; SumSQ.u64 = 671527; Count.u64 = 564; Min.u64 = 4; Max.u64 = 317; 
- l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 53351; SumSQ.u64 = 6064477; Count.u64 = 789; Min.u64 = 16; Max.u64 = 529; 
+ l1cache2.latency_GetS_hit : Accumulator : Sum.u64 = 9171; SumSQ.u64 = 671799; Count.u64 = 836; Min.u64 = 1; Max.u64 = 317; 
+ l1cache2.latency_GetS_miss : Accumulator : Sum.u64 = 53573; SumSQ.u64 = 6089151; Count.u64 = 791; Min.u64 = 16; Max.u64 = 529; 
  l1cache2.latency_GetX_hit : Accumulator : Sum.u64 = 452; SumSQ.u64 = 84438; Count.u64 = 4; Min.u64 = 8; Max.u64 = 259; 
  l1cache2.latency_GetX_miss : Accumulator : Sum.u64 = 9062; SumSQ.u64 = 1292148; Count.u64 = 76; Min.u64 = 76; Max.u64 = 327; 
  l1cache2.latency_GetX_upgrade : Accumulator : Sum.u64 = 8332; SumSQ.u64 = 1324226; Count.u64 = 67; Min.u64 = 71; Max.u64 = 376; 
@@ -1113,7 +1113,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache2.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 3462; SumSQ.u64 = 40122; Count.u64 = 302; Min.u64 = 10; Max.u64 = 16; 
+ l2cache2.latency_GetS_hit : Accumulator : Sum.u64 = 3648; SumSQ.u64 = 40308; Count.u64 = 488; Min.u64 = 1; Max.u64 = 16; 
  l2cache2.latency_GetS_miss : Accumulator : Sum.u64 = 38353; SumSQ.u64 = 4052147; Count.u64 = 489; Min.u64 = 37; Max.u64 = 522; 
  l2cache2.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache2.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1308,8 +1308,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache3.evict_IM : Accumulator : Sum.u64 = 18; SumSQ.u64 = 18; Count.u64 = 18; Min.u64 = 1; Max.u64 = 1; 
  l1cache3.evict_SM : Accumulator : Sum.u64 = 7; SumSQ.u64 = 7; Count.u64 = 7; Min.u64 = 1; Max.u64 = 1; 
  l1cache3.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 10005; SumSQ.u64 = 790389; Count.u64 = 602; Min.u64 = 4; Max.u64 = 357; 
- l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 49063; SumSQ.u64 = 6302815; Count.u64 = 735; Min.u64 = 16; Max.u64 = 616; 
+ l1cache3.latency_GetS_hit : Accumulator : Sum.u64 = 10281; SumSQ.u64 = 790665; Count.u64 = 878; Min.u64 = 1; Max.u64 = 357; 
+ l1cache3.latency_GetS_miss : Accumulator : Sum.u64 = 49702; SumSQ.u64 = 6532288; Count.u64 = 737; Min.u64 = 16; Max.u64 = 616; 
  l1cache3.latency_GetX_hit : Accumulator : Sum.u64 = 270; SumSQ.u64 = 35514; Count.u64 = 4; Min.u64 = 2; Max.u64 = 141; 
  l1cache3.latency_GetX_miss : Accumulator : Sum.u64 = 12164; SumSQ.u64 = 2017428; Count.u64 = 98; Min.u64 = 76; Max.u64 = 684; 
  l1cache3.latency_GetX_upgrade : Accumulator : Sum.u64 = 7565; SumSQ.u64 = 1112397; Count.u64 = 61; Min.u64 = 71; Max.u64 = 298; 
@@ -1516,7 +1516,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache3.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 3534; SumSQ.u64 = 43896; Count.u64 = 309; Min.u64 = 10; Max.u64 = 64; 
+ l2cache3.latency_GetS_hit : Accumulator : Sum.u64 = 3688; SumSQ.u64 = 44050; Count.u64 = 463; Min.u64 = 1; Max.u64 = 64; 
  l2cache3.latency_GetS_miss : Accumulator : Sum.u64 = 35048; SumSQ.u64 = 4143740; Count.u64 = 428; Min.u64 = 36; Max.u64 = 567; 
  l2cache3.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache3.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -1711,8 +1711,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache4.evict_IM : Accumulator : Sum.u64 = 15; SumSQ.u64 = 15; Count.u64 = 15; Min.u64 = 1; Max.u64 = 1; 
  l1cache4.evict_SM : Accumulator : Sum.u64 = 10; SumSQ.u64 = 10; Count.u64 = 10; Min.u64 = 1; Max.u64 = 1; 
  l1cache4.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 10141; SumSQ.u64 = 1015471; Count.u64 = 579; Min.u64 = 4; Max.u64 = 580; 
- l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 52330; SumSQ.u64 = 6700760; Count.u64 = 777; Min.u64 = 16; Max.u64 = 681; 
+ l1cache4.latency_GetS_hit : Accumulator : Sum.u64 = 10389; SumSQ.u64 = 1015719; Count.u64 = 827; Min.u64 = 1; Max.u64 = 580; 
+ l1cache4.latency_GetS_miss : Accumulator : Sum.u64 = 52744; SumSQ.u64 = 6789346; Count.u64 = 779; Min.u64 = 16; Max.u64 = 681; 
  l1cache4.latency_GetX_hit : Accumulator : Sum.u64 = 607; SumSQ.u64 = 87369; Count.u64 = 7; Min.u64 = 2; Max.u64 = 216; 
  l1cache4.latency_GetX_miss : Accumulator : Sum.u64 = 9275; SumSQ.u64 = 1216663; Count.u64 = 79; Min.u64 = 75; Max.u64 = 284; 
  l1cache4.latency_GetX_upgrade : Accumulator : Sum.u64 = 6840; SumSQ.u64 = 899782; Count.u64 = 58; Min.u64 = 74; Max.u64 = 231; 
@@ -1919,7 +1919,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache4.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 3562; SumSQ.u64 = 40438; Count.u64 = 316; Min.u64 = 10; Max.u64 = 15; 
+ l2cache4.latency_GetS_hit : Accumulator : Sum.u64 = 3730; SumSQ.u64 = 40606; Count.u64 = 484; Min.u64 = 1; Max.u64 = 15; 
  l2cache4.latency_GetS_miss : Accumulator : Sum.u64 = 37402; SumSQ.u64 = 4170526; Count.u64 = 463; Min.u64 = 37; Max.u64 = 500; 
  l2cache4.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache4.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -2114,8 +2114,8 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l1cache5.evict_IM : Accumulator : Sum.u64 = 13; SumSQ.u64 = 13; Count.u64 = 13; Min.u64 = 1; Max.u64 = 1; 
  l1cache5.evict_SM : Accumulator : Sum.u64 = 8; SumSQ.u64 = 8; Count.u64 = 8; Min.u64 = 1; Max.u64 = 1; 
  l1cache5.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 11149; SumSQ.u64 = 1097871; Count.u64 = 587; Min.u64 = 4; Max.u64 = 428; 
- l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 51576; SumSQ.u64 = 9381230; Count.u64 = 768; Min.u64 = 16; Max.u64 = 1191; 
+ l1cache5.latency_GetS_hit : Accumulator : Sum.u64 = 11421; SumSQ.u64 = 1098143; Count.u64 = 859; Min.u64 = 1; Max.u64 = 428; 
+ l1cache5.latency_GetS_miss : Accumulator : Sum.u64 = 52507; SumSQ.u64 = 10060311; Count.u64 = 770; Min.u64 = 16; Max.u64 = 1191; 
  l1cache5.latency_GetX_hit : Accumulator : Sum.u64 = 190; SumSQ.u64 = 13556; Count.u64 = 5; Min.u64 = 2; Max.u64 = 98; 
  l1cache5.latency_GetX_miss : Accumulator : Sum.u64 = 8761; SumSQ.u64 = 1256307; Count.u64 = 74; Min.u64 = 76; Max.u64 = 474; 
  l1cache5.latency_GetX_upgrade : Accumulator : Sum.u64 = 7612; SumSQ.u64 = 1014898; Count.u64 = 66; Min.u64 = 78; Max.u64 = 302; 
@@ -2322,7 +2322,7 @@ TrivialCPU cpu5 Finished after 1500 issued reads, 1500 returned (9044 clocks)
  l2cache5.eventSent_CustomReq : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomResp : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.eventSent_CustomAck : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 3678; SumSQ.u64 = 42132; Count.u64 = 324; Min.u64 = 10; Max.u64 = 16; 
+ l2cache5.latency_GetS_hit : Accumulator : Sum.u64 = 3856; SumSQ.u64 = 42310; Count.u64 = 502; Min.u64 = 1; Max.u64 = 16; 
  l2cache5.latency_GetS_miss : Accumulator : Sum.u64 = 36954; SumSQ.u64 = 5370482; Count.u64 = 446; Min.u64 = 38; Max.u64 = 849; 
  l2cache5.latency_GetS_inv : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l2cache5.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_2.out
+++ b/src/sst/elements/memHierarchy/tests/refFiles/test_memHierarchy_sdl9_2.out
@@ -6,16 +6,22 @@ TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
 TrivialCPU: Test Completed Successfuly
-TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104384 clocks)
+TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104578 clocks)
+	49 Noncacheable Reads
+	5 Noncacheable Writes
+TrivialCPU cpu6 Finished after 1000 issued reads, 1000 returned (104275 clocks)
 	50 Noncacheable Reads
 	5 Noncacheable Writes
-TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (104382 clocks)
+TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104378 clocks)
 	50 Noncacheable Reads
 	5 Noncacheable Writes
 TrivialCPU cpu1 Finished after 1000 issued reads, 1000 returned (104380 clocks)
 	50 Noncacheable Reads
 	5 Noncacheable Writes
-TrivialCPU cpu0 Finished after 1000 issued reads, 1000 returned (104378 clocks)
+TrivialCPU cpu2 Finished after 1000 issued reads, 1000 returned (104382 clocks)
+	50 Noncacheable Reads
+	5 Noncacheable Writes
+TrivialCPU cpu3 Finished after 1000 issued reads, 1000 returned (104384 clocks)
 	50 Noncacheable Reads
 	5 Noncacheable Writes
 TrivialCPU cpu4 Finished after 1000 issued reads, 1000 returned (104270 clocks)
@@ -23,12 +29,6 @@ TrivialCPU cpu4 Finished after 1000 issued reads, 1000 returned (104270 clocks)
 	5 Noncacheable Writes
 TrivialCPU cpu5 Finished after 1000 issued reads, 1000 returned (104272 clocks)
 	50 Noncacheable Reads
-	5 Noncacheable Writes
-TrivialCPU cpu6 Finished after 1000 issued reads, 1000 returned (104275 clocks)
-	50 Noncacheable Reads
-	5 Noncacheable Writes
-TrivialCPU cpu7 Finished after 1000 issued reads, 1000 returned (104578 clocks)
-	49 Noncacheable Reads
 	5 Noncacheable Writes
  cpu0.pendCycle : Accumulator : Sum.u64 = 143447; SumSQ.u64 = 440813; Count.u64 = 104378; Min.u64 = 0; Max.u64 = 10; 
  c0.l1cache.default_stat : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_copybench.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_copybench.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 88048979; SumSQ.u64 = 176613277163; Count.u64 = 59199; Min.u64 = 3; Max.u64 = 2013; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 12731616; SumSQ.u64 = 25578995514; Count.u64 = 6337; Min.u64 = 2007; Max.u64 = 2012; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 88778936; SumSQ.u64 = 177978410426; Count.u64 = 63270; Min.u64 = 1; Max.u64 = 2013; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 22421025; SumSQ.u64 = 45041010659; Count.u64 = 11161; Min.u64 = 2005; Max.u64 = 2014; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 90926505; SumSQ.u64 = 182346593623; Count.u64 = 60313; Min.u64 = 3; Max.u64 = 2012; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 10494843; SumSQ.u64 = 21087831663; Count.u64 = 5223; Min.u64 = 2007; Max.u64 = 2012; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_gupsgen.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_gupsgen.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 68; SumSQ.u64 = 68; Count.u64 = 68; Min.u64 = 1; Max.u64 = 1; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 20208239; SumSQ.u64 = 41035682315; Count.u64 = 10000; Min.u64 = 2008; Max.u64 = 3998; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 6017; SumSQ.u64 = 12068099; Count.u64 = 3; Min.u64 = 2005; Max.u64 = 2007; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 30197097; SumSQ.u64 = 61239929389; Count.u64 = 14954; Min.u64 = 2005; Max.u64 = 3998; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 29214; SumSQ.u64 = 87642; Count.u64 = 9738; Min.u64 = 3; Max.u64 = 3; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 609764; SumSQ.u64 = 1541109918; Count.u64 = 262; Min.u64 = 2007; Max.u64 = 4011; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_inorderstream.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_inorderstream.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 34437593; SumSQ.u64 = 68966909117; Count.u64 = 18955; Min.u64 = 3; Max.u64 = 2012; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 2099213; SumSQ.u64 = 4216933773; Count.u64 = 1045; Min.u64 = 2007; Max.u64 = 2011; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 35237074; SumSQ.u64 = 70565972978; Count.u64 = 19479; Min.u64 = 3; Max.u64 = 2012; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 7115861; SumSQ.u64 = 14283641529; Count.u64 = 3545; Min.u64 = 2005; Max.u64 = 2013; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 17547059; SumSQ.u64 = 35019580857; Count.u64 = 9793; Min.u64 = 3; Max.u64 = 2010; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 415809; SumSQ.u64 = 835252473; Count.u64 = 207; Min.u64 = 2007; Max.u64 = 2011; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_randomgen.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_randomgen.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 11595; SumSQ.u64 = 34785; Count.u64 = 3865; Min.u64 = 3; Max.u64 = 3; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 494554615; SumSQ.u64 = 993457732847; Count.u64 = 246195; Min.u64 = 2007; Max.u64 = 2010; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 69536; SumSQ.u64 = 112685528; Count.u64 = 5672; Min.u64 = 1; Max.u64 = 2007; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 741401184; SumSQ.u64 = 1489023317670; Count.u64 = 369152; Min.u64 = 2005; Max.u64 = 2010; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 11808; SumSQ.u64 = 35424; Count.u64 = 3936; Min.u64 = 3; Max.u64 = 3; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 494170926; SumSQ.u64 = 992686961436; Count.u64 = 246004; Min.u64 = 2007; Max.u64 = 2010; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_revsinglestream.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_revsinglestream.out
@@ -110,7 +110,7 @@ ReverseSingleStreamGenerator[build]: Stride:                8
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 53292; SumSQ.u64 = 1387400; Count.u64 = 2048; Min.u64 = 26; Max.u64 = 46; 
  l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 254088; SumSQ.u64 = 7882872; Count.u64 = 8192; Min.u64 = 28; Max.u64 = 51; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_singlestream.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_singlestream.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 909621835; SumSQ.u64 = 1823639250201; Count.u64 = 515615; Min.u64 = 5; Max.u64 = 2012; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 94130294; SumSQ.u64 = 188983970474; Count.u64 = 46885; Min.u64 = 2007; Max.u64 = 2009; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 923870555; SumSQ.u64 = 1851630269311; Count.u64 = 546015; Min.u64 = 5; Max.u64 = 2012; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 125474045; SumSQ.u64 = 251859536991; Count.u64 = 62510; Min.u64 = 2005; Max.u64 = 2009; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_stencil3dbench.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_stencil3dbench.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 1272936; SumSQ.u64 = 122433644; Count.u64 = 108815; Min.u64 = 3; Max.u64 = 219; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 10330; SumSQ.u64 = 2178204; Count.u64 = 49; Min.u64 = 207; Max.u64 = 218; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 1287159; SumSQ.u64 = 124371341; Count.u64 = 112981; Min.u64 = 1; Max.u64 = 219; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 240348; SumSQ.u64 = 49631502; Count.u64 = 1164; Min.u64 = 205; Max.u64 = 218; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 129113; SumSQ.u64 = 17859663; Count.u64 = 3893; Min.u64 = 3; Max.u64 = 208; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 28846; SumSQ.u64 = 5986314; Count.u64 = 139; Min.u64 = 207; Max.u64 = 210; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/miranda/tests/refFiles/test_miranda_streambench.out
+++ b/src/sst/elements/miranda/tests/refFiles/test_miranda_streambench.out
@@ -106,8 +106,8 @@
  l1cache.evict_IM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 3155364; SumSQ.u64 = 741785506; Count.u64 = 16134; Min.u64 = 3; Max.u64 = 256; 
- l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 964354; SumSQ.u64 = 240564596; Count.u64 = 3866; Min.u64 = 246; Max.u64 = 257; 
+ l1cache.latency_GetS_hit : Accumulator : Sum.u64 = 3561461; SumSQ.u64 = 824137923; Count.u64 = 19762; Min.u64 = 1; Max.u64 = 256; 
+ l1cache.latency_GetS_miss : Accumulator : Sum.u64 = 1363259; SumSQ.u64 = 340224703; Count.u64 = 5463; Min.u64 = 244; Max.u64 = 257; 
  l1cache.latency_GetX_hit : Accumulator : Sum.u64 = 1845257; SumSQ.u64 = 448245745; Count.u64 = 7963; Min.u64 = 6; Max.u64 = 255; 
  l1cache.latency_GetX_miss : Accumulator : Sum.u64 = 507984; SumSQ.u64 = 126694416; Count.u64 = 2037; Min.u64 = 246; Max.u64 = 256; 
  l1cache.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 

--- a/src/sst/elements/shogun/tests/refFiles/test_shogun_basic_miranda.out
+++ b/src/sst/elements/shogun/tests/refFiles/test_shogun_basic_miranda.out
@@ -123,8 +123,8 @@
  l1cache0.evict_IM : Accumulator : Sum.u64 = 2309; SumSQ.u64 = 2309; Count.u64 = 2309; Min.u64 = 1; Max.u64 = 1; 
  l1cache0.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache0.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 11871239; SumSQ.u64 = 2099244551; Count.u64 = 100000; Min.u64 = 24; Max.u64 = 474; 
+ l1cache0.latency_GetS_hit : Accumulator : Sum.u64 = 2704; SumSQ.u64 = 440404; Count.u64 = 319; Min.u64 = 1; Max.u64 = 219; 
+ l1cache0.latency_GetS_miss : Accumulator : Sum.u64 = 17393447; SumSQ.u64 = 3090051109; Count.u64 = 144910; Min.u64 = 21; Max.u64 = 520; 
  l1cache0.latency_GetX_hit : Accumulator : Sum.u64 = 284781; SumSQ.u64 = 854343; Count.u64 = 94927; Min.u64 = 3; Max.u64 = 3; 
  l1cache0.latency_GetX_miss : Accumulator : Sum.u64 = 1978881; SumSQ.u64 = 787686161; Count.u64 = 5073; Min.u64 = 49; Max.u64 = 737; 
  l1cache0.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
@@ -285,8 +285,8 @@
  l1cache1.evict_IM : Accumulator : Sum.u64 = 1333; SumSQ.u64 = 1333; Count.u64 = 1333; Min.u64 = 1; Max.u64 = 1; 
  l1cache1.evict_SM : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
  l1cache1.evict_SB : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 
- l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 9; SumSQ.u64 = 27; Count.u64 = 3; Min.u64 = 3; Max.u64 = 3; 
- l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 14110840; SumSQ.u64 = 2666168214; Count.u64 = 99997; Min.u64 = 22; Max.u64 = 618; 
+ l1cache1.latency_GetS_hit : Accumulator : Sum.u64 = 1351; SumSQ.u64 = 209911; Count.u64 = 301; Min.u64 = 1; Max.u64 = 262; 
+ l1cache1.latency_GetS_miss : Accumulator : Sum.u64 = 20634671; SumSQ.u64 = 3913918929; Count.u64 = 145041; Min.u64 = 21; Max.u64 = 618; 
  l1cache1.latency_GetX_hit : Accumulator : Sum.u64 = 288243; SumSQ.u64 = 864729; Count.u64 = 96081; Min.u64 = 3; Max.u64 = 3; 
  l1cache1.latency_GetX_miss : Accumulator : Sum.u64 = 1644613; SumSQ.u64 = 734024519; Count.u64 = 3919; Min.u64 = 73; Max.u64 = 825; 
  l1cache1.latency_GetX_upgrade : Accumulator : Sum.u64 = 0; SumSQ.u64 = 0; Count.u64 = 0; Min.u64 = 0; Max.u64 = 0; 


### PR DESCRIPTION
recordPrefetchLatency() doesn't work since there is no startTimes_ map entries for prefetch requests. Unlike handleEvent() in
cacheController, which calls recordIncomingRequest() for an incoming request, handlePrefetchEvent() does not call recordIncomingRequest(), and thus corresponding latency is not collected.
