### PR TITLE
memH: fix; memNIC sources/destinations params

### DIFF
--- a/src/sst/elements/memHierarchy/memNICBase.h
+++ b/src/sst/elements/memHierarchy/memNICBase.h
@@ -209,7 +209,8 @@ class MemNICBase : public MemLinkBase {
             if (sourceIDs.find(imre->info.id) != sourceIDs.end()) {
                 addSource(imre->info);
                 dbg.debug(_L10_, "\tAdding to sourceEndpointInfo. %zu sources found\n", sourceEndpointInfo.size());
-            } else if (destIDs.find(imre->info.id) != destIDs.end()) {
+            }
+            if (destIDs.find(imre->info.id) != destIDs.end()) {
                 addDest(imre->info);
                 dbg.debug(_L10_, "\tAdding to destEndpointInfo. %zu destinations found\n", destEndpointInfo.size());
             }
@@ -409,7 +410,8 @@ class MemNICBase : public MemLinkBase {
                     }
                     if (sourceIDs.find(imre->info.id) != sourceIDs.end()) {
                         addSource(imre->info);
-                    } else if (destIDs.find(imre->info.id) != destIDs.end()) {
+                    } 
+                    if (destIDs.find(imre->info.id) != destIDs.end()) {
                         addDest(imre->info);
                     }
                     delete imre;

--- a/src/sst/elements/memHierarchy/memNICFour.cc
+++ b/src/sst/elements/memHierarchy/memNICFour.cc
@@ -275,7 +275,8 @@ MemNICFour::OrderedMemRtrEvent* MemNICFour::processRecv(SimpleNetwork::Request *
             }
             if (sourceIDs.find(imre->info.id) != sourceIDs.end()) {
                 sourceEndpointInfo.insert(imre->info);
-            } else if (destIDs.find(imre->info.id) != destIDs.end()) {
+            } 
+            if (destIDs.find(imre->info.id) != destIDs.end()) {
                 destEndpointInfo.insert(imre->info);
             }
             delete imre;


### PR DESCRIPTION
For some otherwise reasonable specification on sources/destination lists -- which
are interpreted as watchlists to process incoming 'imre' -- if an imre happens to match
in the source-list, the destinationEndpoint info in the nic is never updated even if
this imre were also a match in the destionation-list, leading to an incomplete discovery process.
