### PR TITLE
Improve Debugging Prints for Micro-ops in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -150,14 +150,14 @@ public:
             const VanadisELFProgramHeaderEntry* nxt_entry = elf_info->getProgramHeader(i);
 
             vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getHeaderTypeNumber());
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getImageOffset());
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getVirtualMemoryStart());
-            // Physical address - just ignore this for now
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getPhysicalMemoryStart());
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getHeaderImageLength());
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getHeaderMemoryLength());
             vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getSegmentFlags());
-            vanadis_vec_copy_in<int>(phdr_data_block, (int)nxt_entry->getAlignment());
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getImageOffset());
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getVirtualMemoryStart());
+            // Physical address - just ignore this for now
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getPhysicalMemoryStart());
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getHeaderImageLength());
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getHeaderMemoryLength());
+            vanadis_vec_copy_in<uint64_t>(phdr_data_block, (uint64_t)nxt_entry->getAlignment());
         }
 
         if ( elf_info->getEndian() != VANADIS_LITTLE_ENDIAN ) {
@@ -180,85 +180,83 @@ public:
         std::vector<uint8_t> aux_data_block;
 
         // AT_EXECFD (file descriptor of the executable)
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_EXECFD);
-        vanadis_vec_copy_in<int>(aux_data_block, 4);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_EXECFD);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 4);
 
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_PHDR);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)phdr_address);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_PHDR);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)phdr_address);
 
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_PHENT);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)elf_info->getProgramHeaderEntrySize());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_PHENT);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)elf_info->getProgramHeaderEntrySize());
 
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_PHNUM);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)elf_info->getProgramHeaderEntryCount());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_PHNUM);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)elf_info->getProgramHeaderEntryCount());
 
         // System page size
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_PAGESZ);
-        vanadis_vec_copy_in<int>(aux_data_block, 4096);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_PAGESZ);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 4096);
 
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_ENTRY);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)elf_info->getEntryPoint());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_ENTRY);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)elf_info->getEntryPoint());
 
         // AT_BASE (base address loaded into)
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_BASE);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_BASE);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
         // AT_FLAGS
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_FLAGS);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_FLAGS);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
         // AT_HWCAP
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_HWCAP);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_HWCAP);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
         // AT_CLKTCK (Clock Tick Resolution)
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_CLKTCK);
-        vanadis_vec_copy_in<int>(aux_data_block, 100);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_CLKTCK);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 100);
 
         // Not ELF
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_NOTELF);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_NOTELF);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
         // Real UID
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_UID);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)getuid());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_UID);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)getuid());
 
         // Effective UID
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_EUID);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)geteuid());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_EUID);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)geteuid());
 
         // Real GID
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_GID);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)getgid());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_GID);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)getgid());
 
         // Effective GID
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_EGID);
-        vanadis_vec_copy_in<int>(aux_data_block, (int)getegid());
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_EGID);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, (int)getegid());
 
         // D-Cache Line Size
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_DCACHEBSIZE);
-        vanadis_vec_copy_in<int>(aux_data_block, 64);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_DCACHEBSIZE);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 64);
 
         // I-Cache Line Size
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_ICACHEBSIZE);
-        vanadis_vec_copy_in<int>(aux_data_block, 64);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_ICACHEBSIZE);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 64);
 
         // AT_SECURE?
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_SECURE);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_SECURE);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
         // AT_RANDOM - 8 bytes of random stuff
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_RANDOM);
-        vanadis_vec_copy_in<int>(aux_data_block, rand_values_address);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_RANDOM);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, rand_values_address);
 
         // End the Auxillary vector
-        vanadis_vec_copy_in<int>(aux_data_block, VANADIS_AT_NULL);
-        vanadis_vec_copy_in<int>(aux_data_block, 0);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, VANADIS_AT_NULL);
+        vanadis_vec_copy_in<int64_t>(aux_data_block, 0);
 
-        // Find out how many AUX entries we added, these should be an int
-        // (identifier) and then an int (value) so div by 8 but we need to count
-        // ints, so really div by 4
-        const int aux_entry_count = aux_data_block.size() / 4;
+		  // How many entries do we have, divide by 8 because we are running on a 64b system
+        const int aux_entry_count = aux_data_block.size() / 8;
 
         // Per RISCV Assembly Programemr's handbook, register x2 is for stack
         // pointer
@@ -287,7 +285,7 @@ public:
 
         uint64_t arg_env_space_needed = 1 + arg_count + 1 + env_count + 1 + aux_entry_count;
         uint64_t arg_env_space_and_data_needed =
-            (arg_env_space_needed * 4) + arg_data_block.size() + env_data_block.size() + aux_data_block.size();
+            (arg_env_space_needed * 8) + arg_data_block.size() + env_data_block.size() + aux_data_block.size();
 
         uint64_t       aligned_start_stack_address = (start_stack_address - arg_env_space_and_data_needed);
         const uint64_t padding_needed              = (aligned_start_stack_address % 64);
@@ -315,10 +313,10 @@ public:
             output->verbose(
                 CALL_INFO, 16, 0, "--> Setting arg%" PRIu32 " to point to address %" PRIu64 " / 0x%llx\n", (uint32_t)i,
                 arg_env_data_start + arg_start_offsets[i], arg_env_data_start + arg_start_offsets[i]);
-            vanadis_vec_copy_in<uint32_t>(stack_data, (uint32_t)(arg_env_data_start + arg_start_offsets[i]));
+            vanadis_vec_copy_in<uint64_t>(stack_data, (uint64_t)(arg_env_data_start + arg_start_offsets[i]));
         }
 
-        vanadis_vec_copy_in<uint32_t>(stack_data, 0);
+        vanadis_vec_copy_in<uint64_t>(stack_data, 0);
 
         for ( size_t i = 0; i < env_start_offsets.size(); ++i ) {
             output->verbose(
@@ -326,11 +324,11 @@ public:
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i],
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i]);
 
-            vanadis_vec_copy_in<uint32_t>(
-                stack_data, (uint32_t)(arg_env_data_start + arg_data_block.size() + env_start_offsets[i]));
+            vanadis_vec_copy_in<uint64_t>(
+                stack_data, (uint64_t)(arg_env_data_start + arg_data_block.size() + env_start_offsets[i]));
         }
 
-        vanadis_vec_copy_in<uint32_t>(stack_data, 0);
+        vanadis_vec_copy_in<uint64_t>(stack_data, 0);
 
         for ( size_t i = 0; i < aux_data_block.size(); ++i ) {
             stack_data.push_back(aux_data_block[i]);

--- a/src/sst/elements/vanadis/inst/vjl.h
+++ b/src/sst/elements/vanadis/inst/vjl.h
@@ -41,7 +41,7 @@ public:
     const char* getInstCode() const override { return "JL"; }
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
-        snprintf(buffer, buffer_size, "JL      %" PRIu64 "", takenAddress);
+        snprintf(buffer, buffer_size, "JL      %" PRIu64 " (0x%llx)", takenAddress, takenAddress);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {

--- a/src/sst/elements/vanadis/inst/vjump.h
+++ b/src/sst/elements/vanadis/inst/vjump.h
@@ -43,7 +43,7 @@ public:
 
     void printToBuffer(char* buffer, size_t buffer_size) override
     {
-        snprintf(buffer, buffer_size, "JUMP    %" PRIu64 "", takenAddress);
+        snprintf(buffer, buffer_size, "JUMP    %" PRIu64 " / 0x%llx", takenAddress, takenAddress);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override { markExecuted(); }

--- a/src/sst/elements/vanadis/inst/vload.h
+++ b/src/sst/elements/vanadis/inst/vload.h
@@ -83,17 +83,17 @@ public:
         switch (regType) {
         case LOAD_INT_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "LOAD (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %20" PRId64 " (phys: %5" PRIu16
-                     " <- memory[%5" PRIu16 " + %20" PRId64 "])\n",
-                     getTransactionTypeString(memAccessType), isa_int_regs_out[0], isa_int_regs_in[0], offset,
-                     phys_int_regs_out[0], phys_int_regs_in[0], offset);
+                     "LOAD (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
+                     " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])\n",
+                     getTransactionTypeString(memAccessType), isa_int_regs_out[0], isa_int_regs_in[0], offset, offset,
+                     phys_int_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
         case LOAD_FP_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "LOADFP (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %20" PRId64 " (phys: %5" PRIu16
-                     " <- memory[%5" PRIu16 " + %20" PRId64 "])\n",
-                     getTransactionTypeString(memAccessType), isa_fp_regs_out[0], isa_int_regs_in[0], offset,
-                     phys_fp_regs_out[0], phys_int_regs_in[0], offset);
+                     "LOADFP (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
+                     " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])\n",
+                     getTransactionTypeString(memAccessType), isa_fp_regs_out[0], isa_int_regs_in[0], offset, offset,
+                     phys_fp_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
         }
     }

--- a/src/sst/elements/vanadis/inst/vpcaddi.h
+++ b/src/sst/elements/vanadis/inst/vpcaddi.h
@@ -38,17 +38,18 @@ public:
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(
             buffer, buffer_size,
-            "PCADDI  %5" PRIu16 " <- 0x%llx + imm=%" PRId64 " (phys: %5" PRIu16 " <- 0x%llx + %" PRId64 ")",
-            isa_int_regs_out[0], getInstructionAddress(), imm_value, phys_int_regs_out[0], getInstructionAddress(), imm_value);
+            "PCADDI  %5" PRIu16 " <- 0x%llx + imm=%" PRId64 " (phys: %5" PRIu16 " <- 0x%llx + %" PRId64 ") = 0x%llx",
+            isa_int_regs_out[0], getInstructionAddress(), imm_value, phys_int_regs_out[0], getInstructionAddress(), imm_value,
+					getInstructionAddress() + imm_value);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=%p) PCADDI phys: out=%" PRIu16 " in=0x%llx / imm=%" PRId64
-                        ", isa: out=%" PRIu16 "\n",
+                        ", isa: out=%" PRIu16 " = 0x%llx\n",
                         (void*)getInstructionAddress(), phys_int_regs_out[0], getInstructionAddress(), imm_value,
-                        isa_int_regs_out[0]);
+                        isa_int_regs_out[0], (static_cast<int64_t>(getInstructionAddress()) + imm_value));
 #endif
 
 		if(VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format) {

--- a/src/sst/elements/vanadis/lsq/vlsqseq.h
+++ b/src/sst/elements/vanadis/lsq/vlsqseq.h
@@ -438,12 +438,21 @@ public:
 
                     if (out->getVerboseLevel() >= 16) {
                         char* payload_print = new char[256];
-                        snprintf(payload_print, 256, "0x%x 0x%x 0x%x 0x%x", (ev->data.size() > 0 ? ev->data[0] : 0),
-                                 (ev->data.size() > 1 ? ev->data[1] : 0), (ev->data.size() > 2 ? ev->data[2] : 0),
-                                 (ev->data.size() > 3 ? ev->data[3] : 0));
+								char* payload_print_inner = new char[256];
 
-                        out->verbose(CALL_INFO, 16, 0, "-> payload (first 4 bytes): %s\n", payload_print);
+								payload_print[0] = '\0';
+								payload_print_inner[0] = '\0';
+
+								for( int s = 0; s < std::min((int)ev->data.size(), 8); ++s) {
+									std::strncpy(payload_print_inner, payload_print, 256);
+	                        snprintf(payload_print, 256, "%s 0x%02x", payload_print_inner, ev->data[s]);
+								}
+
+                        out->verbose(CALL_INFO, 16, 0, "-> payload (first %d bytes): %s\n",
+									std::min((int)ev->data.size(), 8), payload_print);
+
                         delete[] payload_print;
+								delete[] payload_print_inner;
                     }
 
                     if ((*op_q_itr)->isLoad()) { // TODO it better be since this is a ReadResp

--- a/src/sst/elements/vanadis/tests/basic_vanadis.py
+++ b/src/sst/elements/vanadis/tests/basic_vanadis.py
@@ -99,9 +99,14 @@ if app_args != "":
 else:
 	print("No application arguments found, continuing with argc=0")
 
-decode0     = v_cpu_0.setSubComponent( "decoder0", "vanadis.VanadisMIPSDecoder" )
+vanadis_isa = os.getenv("VANADIS_ISA", "MIPS")
+vanadis_decoder = "vanadis.Vanadis" + vanadis_isa + "Decoder"
+vanadis_os_hdlr = "vanadis.Vanadis" + vanadis_isa + "OSHandler"
+
+decode0     = v_cpu_0.setSubComponent( "decoder0", vanadis_decoder )
+#os_hdlr     = decode0.setSubComponent( "os_handler", vanadis_os_hdlr )
 os_hdlr     = decode0.setSubComponent( "os_handler", "vanadis.VanadisMIPSOSHandler" )
-branch_pred = decode0.setSubComponent( "branch_unit", "vanadis.VanadisBasicBranchUnit")
+branch_pred = decode0.setSubComponent( "branch_unit", "vanadis.VanadisBasicBranchUnit" )
 
 decode0.addParams({
 	"uop_cache_entries" : 1536,

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -875,8 +875,17 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
             rob->pop();
 
 #ifdef VANADIS_BUILD_DEBUG
-            output->verbose(CALL_INFO, 8, 0, "----> Retire: 0x%0llx / %s\n", rob_front->getInstructionAddress(),
-                            rob_front->getInstCode());
+				if(output->getVerboseLevel() >= 8) {
+					char* inst_asm_buffer = new char[32768];
+	        		rob_front->printToBuffer(inst_asm_buffer, 32768);
+
+					output->verbose(CALL_INFO, 8, 0, "----> Retire: 0x%0llx / %s\n", rob_front->getInstructionAddress(),
+									inst_asm_buffer);
+
+//                            rob_front->getInstCode());
+
+					delete[] inst_asm_buffer;
+				}
 #endif
             if (pipelineTrace != nullptr) {
                 fprintf(pipelineTrace, "0x%08llx %s\n", rob_front->getInstructionAddress(), rob_front->getInstCode());


### PR DESCRIPTION
- Improves micro-op print out/debugging generation in Vanadis
- Allows debug print outs for load payloads returning to the LSQ
- Configures 64b aux-vector for RISCV ELF binaries (this results in major bugs if still at 32b)