### PR TITLE
Fix RVC Decoder Bugs for Immediates in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/inst/vsrai.h
+++ b/src/sst/elements/vanadis/inst/vsrai.h
@@ -59,7 +59,9 @@ public:
                         (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
-        assert(imm_value > 0);
+//        assert(imm_value > 0);
+
+		  if(imm_value > 0) {
 
         switch (register_format) {
         case VanadisRegisterFormat::VANADIS_FORMAT_INT64: {
@@ -76,6 +78,10 @@ public:
             flagError();
         } break;
         }
+		  } else {
+				// Shift by ZERO is error?
+				flagError();
+		  }
 
         markExecuted();
     }


### PR DESCRIPTION
- Fixes RVC immediate decode errors for several instructions
- Adds `ECALL` / `SYSCALL` for `set_tid`
- Adds `ECALL`/ `SYSCALL` for `exit_group`
- Fixes up decoder generate for RVC `EBREAK` instruction
- Fixes incorrect immediate generate for `SRAI` instruction in RV32 and RV64