### PR TITLE
Fix for Decoder Bugs on Vanadis

### DIFF
--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -606,6 +606,9 @@ protected:
                 case 0:
                 {
                     // LB
+						  output->verbose(CALL_INFO, 16, 0, "----> LB %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 1, true, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -614,6 +617,9 @@ protected:
                 case 1:
                 {
                     // LH
+						  output->verbose(CALL_INFO, 16, 0, "----> LH %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 2, true, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -622,6 +628,9 @@ protected:
                 case 2:
                 {
                     // LW
+						  output->verbose(CALL_INFO, 16, 0, "----> LW %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 4, true, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -630,6 +639,9 @@ protected:
                 case 3:
                 {
                     // LD
+						  output->verbose(CALL_INFO, 16, 0, "----> LD %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 8, true, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -638,6 +650,9 @@ protected:
                 case 4:
                 {
                     // LBU
+						  output->verbose(CALL_INFO, 16, 0, "----> LBU %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 1, false, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -646,6 +661,9 @@ protected:
                 case 5:
                 {
                     // LHU
+						  output->verbose(CALL_INFO, 16, 0, "----> LHU %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 2, false, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -654,6 +672,9 @@ protected:
                 case 6:
                 {
                     // LWU
+						  output->verbose(CALL_INFO, 16, 0, "----> LWU %" PRIu16 " <- %" PRIu16 " %" PRId64 "\n",
+								rd, rs1, simm64);
+
                     bundle->addInstruction(new VanadisLoadInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rd, 4, false, MEM_TRANSACTION_NONE,
                         LOAD_INT_REGISTER));
@@ -672,7 +693,11 @@ protected:
 
                 if ( func_code < 4 ) {
                     // shift to get the power of 2 number of bytes to store
-                    const uint32_t store_bytes = 1 << func_code;
+                    const uint32_t store_bytes = 1 << func_code3;
+
+						  output->verbose(CALL_INFO, 16, 0, "----> STORE width: %" PRIu32 " bytes == (1 << %" PRIu32 ") %" PRIu16 " -> memory[ %" PRIu16 " + %" PRId64 " / (0x%llx)]\n",
+								store_bytes, func_code3, rs2, rs1, simm64, simm64);
+
                     bundle->addInstruction(new VanadisStoreInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rs2, store_bytes, MEM_TRANSACTION_NONE,
                         STORE_INT_REGISTER));
@@ -691,6 +716,9 @@ protected:
                 {
                     // ADDI
                     processI<int64_t>(ins, op_code, rd, rs1, func_code3, simm64);
+
+						  output->verbose(CALL_INFO, 16, 0, "------> ADDI %" PRIu16 " <- %" PRIu16 " + %" PRId64 "\n",
+								rd, rs1, simm64);
 
                     bundle->addInstruction(new VanadisAddImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
                         ins_address, hw_thr, options, rd, rs1, simm64));
@@ -1055,7 +1083,7 @@ protected:
 								rs1, rs2, simm64);
                     bundle->addInstruction(new VanadisBranchRegCompareInstruction<
                                            VanadisRegisterFormat::VANADIS_FORMAT_INT64, REG_COMPARE_LT>(
-                        ins_address, hw_thr, options, 4, rs1, rs2, simm64, VANADIS_NO_DELAY_SLOT));
+                        ins_address, hw_thr, options, 4, rs1, rs2, simm64, VANADIS_NO_DELAY_SLOT, true));
                     decode_fault = false;
                 } break;
                 case 5:
@@ -1065,7 +1093,7 @@ protected:
 								rs1, rs2, simm64);
                     bundle->addInstruction(new VanadisBranchRegCompareInstruction<
                                            VanadisRegisterFormat::VANADIS_FORMAT_INT64, REG_COMPARE_GTE>(
-                        ins_address, hw_thr, options, 4, rs1, rs2, simm64, VANADIS_NO_DELAY_SLOT));
+                        ins_address, hw_thr, options, 4, rs1, rs2, simm64, VANADIS_NO_DELAY_SLOT, true));
                     decode_fault = false;
                 } break;
                 case 6:
@@ -1116,7 +1144,7 @@ protected:
                         // ADDW
                         // TODO - check register ordering
                         bundle->addInstruction(
-                            new VanadisAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64, true>(
+                            new VanadisAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1125,14 +1153,14 @@ protected:
                         // MULW
                         // TODO - check register ordering
                         bundle->addInstruction(
-                            new VanadisMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+                            new VanadisMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                     } break;
                     case 0x20:
                     {
                         // SUBW
                         // TODO - check register ordering
-                        bundle->addInstruction(new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+                        bundle->addInstruction(new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                             ins_address, hw_thr, options, rd, rs1, rs2, true));
                         decode_fault = false;
                     } break;
@@ -1146,7 +1174,7 @@ protected:
                         // SLLW
                         // TODO - check register ordering
                         bundle->addInstruction(
-                            new VanadisShiftLeftLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+                            new VanadisShiftLeftLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1159,7 +1187,7 @@ protected:
                     {
                         // DIVW
                         bundle->addInstruction(
-                            new VanadisDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64, true>(
+                            new VanadisDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1173,7 +1201,7 @@ protected:
                         // SRLW
                         // TODO - check register ordering
                         bundle->addInstruction(
-                            new VanadisShiftRightLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+                            new VanadisShiftRightLogicalInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1181,7 +1209,7 @@ protected:
                     {
                         // DIVUW
                         bundle->addInstruction(
-                            new VanadisDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64, false>(
+                            new VanadisDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1190,7 +1218,7 @@ protected:
                         // SRAW
                         // TODO - check register ordering
                         bundle->addInstruction(
-                            new VanadisShiftRightArithmeticInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
+                            new VanadisShiftRightArithmeticInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                 ins_address, hw_thr, options, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
@@ -1604,7 +1632,7 @@ protected:
                     case 0xC00:
                     {
                         // Arith
-                        uint16_t rvc_rd  = expand_rvc_int_register(extract_rs2_rvc(ins));
+                        uint16_t rvc_rs2 = expand_rvc_int_register(extract_rs2_rvc(ins));
                         uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
 
                         switch ( ins & 0x1000 ) {
@@ -1618,40 +1646,40 @@ protected:
                                 // SUB
                                 output->verbose(
                                     CALL_INFO, 16, 0, "--------> RVC SUB %" PRIu16 " <- %" PRIu16 " - %" PRIu16 "\n",
-                                    rvc_rd, rvc_rd, rvc_rs1);
+                                    rvc_rs1, rvc_rs1, rvc_rs2);
                                 bundle->addInstruction(
                                     new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
-                                        ins_address, hw_thr, options, rvc_rd, rvc_rd, rvc_rs1, true));
+                                        ins_address, hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2, true));
                                 decode_fault = false;
                             } break;
                             case 0x20:
                             {
                                 // XOR
                                 output->verbose(
-                                    CALL_INFO, 16, 0, "--------> RVC XOR %" PRIu16 " <- %" PRIu16 " - %" PRIu16 "\n",
-                                    rvc_rd, rvc_rd, rvc_rs1);
+                                    CALL_INFO, 16, 0, "--------> RVC XOR %" PRIu16 " <- %" PRIu16 " ^ %" PRIu16 "\n",
+                                    rvc_rs1, rvc_rs1, rvc_rs2);
                                 bundle->addInstruction(
-                                    new VanadisXorInstruction(ins_address, hw_thr, options, rvc_rd, rvc_rd, rvc_rs1));
+                                    new VanadisXorInstruction(ins_address, hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2));
                                 decode_fault = false;
                             } break;
                             case 0x40:
                             {
                                 // OR
                                 output->verbose(
-                                    CALL_INFO, 16, 0, "--------> RVC OR %" PRIu16 " <- %" PRIu16 " - %" PRIu16 "\n",
-                                    rvc_rd, rvc_rd, rvc_rs1);
+                                    CALL_INFO, 16, 0, "--------> RVC OR %" PRIu16 " <- %" PRIu16 " | %" PRIu16 "\n",
+                                    rvc_rs1, rvc_rs1, rvc_rs2);
                                 bundle->addInstruction(
-                                    new VanadisOrInstruction(ins_address, hw_thr, options, rvc_rd, rvc_rd, rvc_rs1));
+                                    new VanadisOrInstruction(ins_address, hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2));
                                 decode_fault = false;
                             } break;
                             case 0x60:
                             {
                                 // AND
                                 output->verbose(
-                                    CALL_INFO, 16, 0, "--------> RVC AND %" PRIu16 " <- %" PRIu16 " - %" PRIu16 "\n",
-                                    rvc_rd, rvc_rd, rvc_rs1);
+                                    CALL_INFO, 16, 0, "--------> RVC AND %" PRIu16 " <- %" PRIu16 " & %" PRIu16 "\n",
+                                    rvc_rs1, rvc_rs1, rvc_rs2);
                                 bundle->addInstruction(
-                                    new VanadisAndInstruction(ins_address, hw_thr, options, rvc_rd, rvc_rd, rvc_rs1));
+                                    new VanadisAndInstruction(ins_address, hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2));
                                 decode_fault = false;
                             } break;
                             }
@@ -1670,14 +1698,14 @@ protected:
                             case 0x20:
                             {
                                 // ADDW
-		                           uint16_t rvc_rd  = expand_rvc_int_register(extract_rs2_rvc(ins));
+		                           uint16_t rvc_rs2  = expand_rvc_int_register(extract_rs2_rvc(ins));
       		                    uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
 
 										  output->verbose(CALL_INFO, 16, 0, "------> RVC ADDW %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n",
-											 rvc_rs1, rvc_rs1, rvc_rd);
+											 rvc_rs1, rvc_rs1, rvc_rs2);
 
 										  bundle->addInstruction(new VanadisAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(ins_address,
-												hw_thr, options, rvc_rs1, rvc_rs1, rvc_rd));
+												hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2));
 										decode_fault = false;
 
                             } break;
@@ -1764,8 +1792,8 @@ protected:
                     if ( imm_8 != 0 ) { imm_final |= 0xFFFFFFFFFFFFFE00; }
 
                     output->verbose(
-                        CALL_INFO, 16, 0, "----> decode RVC BNEZ %" PRIu16 " jump to: 0x%llx\n", rvc_rs1,
-                        ins_address + imm_final);
+                        CALL_INFO, 16, 0, "----> decode RVC BNEZ %" PRIu16 " jump to: 0x%llx + 0x%llx = 0x%llx\n", rvc_rs1,
+                        ins_address, imm_final, ins_address + imm_final);
 
                     bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<
                                            VanadisRegisterFormat::VANADIS_FORMAT_INT64, REG_COMPARE_NEQ>(
@@ -2093,7 +2121,7 @@ protected:
 
         const int32_t ins_i32 = static_cast<int32_t>(ins);
         imm                   = static_cast<T>(
-            sign_extend12(((ins_i32 & VANADIS_RISCV_RD_MASK) >> 6) | ((ins_i32 & VANADIS_RISCV_FUNC7_MASK) >> 24)));
+            sign_extend12(((ins_i32 & VANADIS_RISCV_RD_MASK) >> 7) | ((ins_i32 & VANADIS_RISCV_FUNC7_MASK) >> 20)));
     }
 
     template <typename T>

--- a/src/sst/elements/vanadis/inst/vbcmp.h
+++ b/src/sst/elements/vanadis/inst/vbcmp.h
@@ -61,18 +61,19 @@ public:
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
-                 "BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16 ", %" PRIu16 " offset: %" PRId64 "\n",
+                 "BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16 ", %" PRIu16 " offset: %" PRId64 " = 0x%llx\n",
                  convertCompareTypeToString(compare_type), isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_in[0],
-                 phys_int_regs_in[1], offset);
+                 phys_int_regs_in[1], offset, getInstructionAddress() + offset);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16
-                        ", %" PRIu16 " offset: %" PRId64 "\n",
+                        ", %" PRIu16 " offset: %" PRId64 " = 0x%llx\n",
                         getInstructionAddress(), convertCompareTypeToString(compare_type), isa_int_regs_in[0],
-                        isa_int_regs_in[1], phys_int_regs_in[0], phys_int_regs_in[1], offset);
+                        isa_int_regs_in[1], phys_int_regs_in[0], phys_int_regs_in[1], offset,
+								getInstructionAddress() + offset);
 #endif
         bool compare_result = false;
 

--- a/src/sst/elements/vanadis/inst/vbcmpi.h
+++ b/src/sst/elements/vanadis/inst/vbcmpi.h
@@ -42,16 +42,18 @@ public:
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
-                 "BCMPI isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64 " / offset: %" PRId64 "\n",
-                 isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset);
+                 "BCMPI isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64 " / offset: %" PRId64 " = 0x%llx\n",
+                 isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset,
+						static_cast<int64_t>(getInstructionAddress()) + offset);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
                         "Execute: (addr=0x%0llx) BCMPI isa-in: %" PRIu16 " / phys-in: %" PRIu16 " / imm: %" PRId64
-                        " / offset: %" PRId64 "\n",
-                        getInstructionAddress(), isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset);
+                        " / offset: %" PRId64 " = (0x%llx) \n",
+                        getInstructionAddress(), isa_int_regs_in[0], phys_int_regs_in[0], imm_value, offset,
+								static_cast<int64_t>(getInstructionAddress()) + offset);
 #endif
         bool compare_result = false;
 

--- a/src/sst/elements/vanadis/inst/vload.h
+++ b/src/sst/elements/vanadis/inst/vload.h
@@ -83,16 +83,16 @@ public:
         switch (regType) {
         case LOAD_INT_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "LOAD (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
+                     "LOAD (%s, %" PRIu16 " bytes)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
                      " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])\n",
-                     getTransactionTypeString(memAccessType), isa_int_regs_out[0], isa_int_regs_in[0], offset, offset,
+                     getTransactionTypeString(memAccessType), load_width, isa_int_regs_out[0], isa_int_regs_in[0], offset, offset,
                      phys_int_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
         case LOAD_FP_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "LOADFP (%s)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
+                     "LOADFP (%s, %" PRIu16 " bytes)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64 " (0x%llx) (phys: %5" PRIu16
                      " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])\n",
-                     getTransactionTypeString(memAccessType), isa_fp_regs_out[0], isa_int_regs_in[0], offset, offset,
+                     getTransactionTypeString(memAccessType), load_width, isa_fp_regs_out[0], isa_int_regs_in[0], offset, offset,
                      phys_fp_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
         }

--- a/src/sst/elements/vanadis/inst/vstore.h
+++ b/src/sst/elements/vanadis/inst/vstore.h
@@ -91,16 +91,16 @@ public:
         switch (regType) {
         case STORE_INT_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "STORE (%s)   %5" PRIu16 " -> memory[%5" PRIu16 " + %" PRId64 "] (phys: %5" PRIu16
+                     "STORE (%s, %" PRIu16 " bytes)   %5" PRIu16 " -> memory[%5" PRIu16 " + %" PRId64 "] (phys: %5" PRIu16
                      " -> memory[%5" PRIu16 " + %" PRId64 "])",
-                     getTransactionTypeString(memAccessType), isa_int_regs_in[1], isa_int_regs_in[0], offset,
+                     getTransactionTypeString(memAccessType), store_width, isa_int_regs_in[1], isa_int_regs_in[0], offset,
                      phys_int_regs_in[1], phys_int_regs_in[0], offset);
         } break;
         case STORE_FP_REGISTER: {
             snprintf(buffer, buffer_size,
-                     "STOREFP (%s)   %5" PRIu16 " -> memory[%5" PRIu16 " + %" PRId64 "] (phys: %5" PRIu16
+                     "STOREFP (%s, %" PRIu16 " bytes))   %5" PRIu16 " -> memory[%5" PRIu16 " + %" PRId64 "] (phys: %5" PRIu16
                      " -> memory[%5" PRIu16 " + %" PRId64 "])",
-                     getTransactionTypeString(memAccessType), isa_fp_regs_in[0], isa_int_regs_in[0], offset,
+                     getTransactionTypeString(memAccessType), store_width, isa_fp_regs_in[0], isa_int_regs_in[0], offset,
                      phys_fp_regs_in[0], phys_int_regs_in[0], offset);
         } break;
         }

--- a/src/sst/elements/vanadis/inst/vxori.h
+++ b/src/sst/elements/vanadis/inst/vxori.h
@@ -40,16 +40,15 @@ public:
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(
             buffer, buffer_size,
-            "XORI    %5" PRIu16 " <- %5" PRIu16 " ^ imm=%" PRIu64 " (phys: %5" PRIu16 " <- %5" PRIu16 " ^ %" PRIu64 ")",
-            isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value);
+            "XORI    %5" PRIu16 " <- %5" PRIu16 " ^ imm=%" PRIu64 " (phys: %5" PRIu16 " <- %5" PRIu16 " ^ %" PRIu64 " (0x%llx))",
+            isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value, imm_value);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
-                        "Execute: (addr=%p) XORI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRIu64
-                        ", isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
-                        (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
+                        "Execute: (addr=%p) XORI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRIu64 " / (0x%llx) , isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
+                        (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value, imm_value,
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
         const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -833,7 +833,7 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
 
 #ifdef VANADIS_BUILD_DEBUG
                 output->verbose(CALL_INFO, 8, 0,
-                                "----> speculated addr: 0x%llx / result addr: 0x%llx / "
+                                "----> Retire: speculated addr: 0x%llx / result addr: 0x%llx / "
                                 "pipeline-clear: %s\n",
                                 spec_ins->getSpeculatedAddress(), pipeline_reset_addr,
                                 perform_pipeline_clear ? "yes" : "no");


### PR DESCRIPTION
Fixes several issues on Vanadis:

- Fixes 32b instruction operands issue (when using 64b registers)
- Adds additional print outs for loads and stores to help debugging
- Adds prints for speculation target addresses at retirement
- Fixes register ordering problem in RVC `AND`, `OR` etc
