### PR TITLE
Propagate 64b support to emulated OS in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -94,6 +94,7 @@ lsq/vlsq.h \
 lsq/vlsqseq.h \
 lsq/vlsqstd.h \
 lsq/vmemwriterec.h \
+os/vosbittype.h \
 os/vcpuos.h \
 os/vmipscpuos.h \
 os/vriscvcpuos.h \

--- a/src/sst/elements/vanadis/inst/vjlr.h
+++ b/src/sst/elements/vanadis/inst/vjlr.h
@@ -66,9 +66,9 @@ public:
         takenAddress = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
 
 		  // TODO remove this code and check?
-        if ((takenAddress & 0x3) != 0) {
-            flagError();
-        }
+//        if ((takenAddress & 0x3) != 0) {
+//            flagError();
+//        }
 
         markExecuted();
     }

--- a/src/sst/elements/vanadis/os/callev/voscallaccessev.h
+++ b/src/sst/elements/vanadis/os/callev/voscallaccessev.h
@@ -17,6 +17,7 @@
 #define _H_VANADIS_SYSCALL_ACCESS
 
 #include "os/voscallev.h"
+#include "os/vosbittype.h"
 
 namespace SST {
 namespace Vanadis {
@@ -24,8 +25,8 @@ namespace Vanadis {
 class VanadisSyscallAccessEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallAccessEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallAccessEvent(uint32_t core, uint32_t thr, const uint64_t path, const uint64_t mode)
-        : VanadisSyscallEvent(core, thr), path_ptr(path), access_mode(mode) {}
+    VanadisSyscallAccessEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, const uint64_t path, const uint64_t mode)
+        : VanadisSyscallEvent(core, thr, bittype), path_ptr(path), access_mode(mode) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_ACCESS; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallbrk.h
+++ b/src/sst/elements/vanadis/os/callev/voscallbrk.h
@@ -17,6 +17,7 @@
 #define _H_VANADIS_SYSCALL_BRK
 
 #include "os/voscallev.h"
+#include "os/vosbittype.h"
 
 namespace SST {
 namespace Vanadis {
@@ -24,8 +25,8 @@ namespace Vanadis {
 class VanadisSyscallBRKEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallBRKEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallBRKEvent(uint32_t core, uint32_t thr, uint64_t newBrkAddr, bool zero_mem = false)
-        : VanadisSyscallEvent(core, thr), newBrk(newBrkAddr), zero_memory(zero_mem) {}
+    VanadisSyscallBRKEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t newBrkAddr, bool zero_mem = false)
+        : VanadisSyscallEvent(core, thr, bittype), newBrk(newBrkAddr), zero_memory(zero_mem) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_BRK; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallclose.h
+++ b/src/sst/elements/vanadis/os/callev/voscallclose.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallCloseEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallCloseEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallCloseEvent(uint32_t core, uint32_t thr, int32_t file_id)
-        : VanadisSyscallEvent(core, thr), close_file_descriptor(file_id) {}
+    VanadisSyscallCloseEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int32_t file_id)
+        : VanadisSyscallEvent(core, thr, bittype), close_file_descriptor(file_id) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_CLOSE; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallexitgrp.h
+++ b/src/sst/elements/vanadis/os/callev/voscallexitgrp.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallExitGroupEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallExitGroupEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallExitGroupEvent(uint32_t core, uint32_t thr, uint64_t rc)
-        : VanadisSyscallEvent(core, thr), return_code(rc) {}
+    VanadisSyscallExitGroupEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t rc)
+        : VanadisSyscallEvent(core, thr, bittype), return_code(rc) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_EXIT_GROUP; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallfstat.h
+++ b/src/sst/elements/vanadis/os/callev/voscallfstat.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallFstatEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallFstatEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallFstatEvent(uint32_t core, uint32_t thr, int fd, uint64_t s_addr)
-        : VanadisSyscallEvent(core, thr), file_id(fd), fstat_struct_addr(s_addr) {}
+    VanadisSyscallFstatEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int fd, uint64_t s_addr)
+        : VanadisSyscallEvent(core, thr, bittype), file_id(fd), fstat_struct_addr(s_addr) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_FSTAT; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallgettime64.h
+++ b/src/sst/elements/vanadis/os/callev/voscallgettime64.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallGetTime64Event : public VanadisSyscallEvent {
 public:
     VanadisSyscallGetTime64Event() : VanadisSyscallEvent() {}
-    VanadisSyscallGetTime64Event(uint32_t core, uint32_t thr, int64_t clk_id, uint64_t time_addr)
-        : VanadisSyscallEvent(core, thr), clock_id(clk_id), timestruct_addr(time_addr) {}
+    VanadisSyscallGetTime64Event(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int64_t clk_id, uint64_t time_addr)
+        : VanadisSyscallEvent(core, thr, bittype), clock_id(clk_id), timestruct_addr(time_addr) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_GETTIME64; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallioctl.h
+++ b/src/sst/elements/vanadis/os/callev/voscallioctl.h
@@ -24,9 +24,9 @@ namespace Vanadis {
 class VanadisSyscallIOCtlEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallIOCtlEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallIOCtlEvent(uint32_t core, uint32_t thr, int64_t file_d, bool o_read, bool o_write,
+    VanadisSyscallIOCtlEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int64_t file_d, bool o_read, bool o_write,
                              uint64_t io_request, uint64_t io_driver, uint64_t data_ptr, uint64_t data_len)
-        : VanadisSyscallEvent(core, thr), fd(file_d), op_read(o_read), op_write(o_write), io_op(io_request),
+        : VanadisSyscallEvent(core, thr, bittype), fd(file_d), op_read(o_read), op_write(o_write), io_op(io_request),
           io_drv(io_driver), ptr(data_ptr), ptr_len(data_len) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_IOCTL; }

--- a/src/sst/elements/vanadis/os/callev/voscallmmap.h
+++ b/src/sst/elements/vanadis/os/callev/voscallmmap.h
@@ -24,16 +24,13 @@
 namespace SST {
 namespace Vanadis {
 
-// void *mmap(void *addr, size_t length, int prot, int flags,
-//                  int fd, off_t offset);
-
 class VanadisSyscallMemoryMapEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallMemoryMapEvent() : VanadisSyscallEvent() {}
 
-    VanadisSyscallMemoryMapEvent(uint32_t core, uint32_t thr, uint64_t addr, uint64_t len, int64_t prot, int64_t flags,
+    VanadisSyscallMemoryMapEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t addr, uint64_t len, int64_t prot, int64_t flags,
                                  uint64_t stack_p, uint64_t offset_multiplier)
-        : VanadisSyscallEvent(core, thr), address(addr), length(len), page_prot(prot), alloc_flags(flags),
+        : VanadisSyscallEvent(core, thr, bittype), address(addr), length(len), page_prot(prot), alloc_flags(flags),
           stack_pointer(stack_p), offset_units(offset_multiplier) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_MMAP; }

--- a/src/sst/elements/vanadis/os/callev/voscallopen.h
+++ b/src/sst/elements/vanadis/os/callev/voscallopen.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallOpenEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallOpenEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallOpenEvent(uint32_t core, uint32_t thr, uint64_t path_ptr, uint64_t flags, uint64_t mode)
-        : VanadisSyscallEvent(core, thr), open_path_ptr(path_ptr), open_flags(flags), open_mode(mode) {}
+    VanadisSyscallOpenEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t path_ptr, uint64_t flags, uint64_t mode)
+        : VanadisSyscallEvent(core, thr, bittype), open_path_ptr(path_ptr), open_flags(flags), open_mode(mode) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_OPEN; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallopenat.h
+++ b/src/sst/elements/vanadis/os/callev/voscallopenat.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallOpenAtEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallOpenAtEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallOpenAtEvent(uint32_t core, uint32_t thr, uint64_t dirfd, uint64_t path_ptr, uint64_t flags)
-        : VanadisSyscallEvent(core, thr), openat_dirfd(dirfd), openat_path_ptr(path_ptr), openat_flags(flags) {}
+    VanadisSyscallOpenAtEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t dirfd, uint64_t path_ptr, uint64_t flags)
+        : VanadisSyscallEvent(core, thr, bittype), openat_dirfd(dirfd), openat_path_ptr(path_ptr), openat_flags(flags) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_OPENAT; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallread.h
+++ b/src/sst/elements/vanadis/os/callev/voscallread.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallReadEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallReadEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallReadEvent(uint32_t core, uint32_t thr, int64_t fd, uint64_t buff_ptr, int64_t count)
-        : VanadisSyscallEvent(core, thr), read_fd(fd), read_buff_addr(buff_ptr), read_count(count) {}
+    VanadisSyscallReadEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int64_t fd, uint64_t buff_ptr, int64_t count)
+        : VanadisSyscallEvent(core, thr, bittype), read_fd(fd), read_buff_addr(buff_ptr), read_count(count) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_READ; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallreadlink.h
+++ b/src/sst/elements/vanadis/os/callev/voscallreadlink.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallReadLinkEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallReadLinkEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallReadLinkEvent(uint32_t core, uint32_t thr, uint64_t path_ptr, uint64_t buff_ptr, int64_t size)
-        : VanadisSyscallEvent(core, thr), readlink_path_ptr(path_ptr), readlink_buff_ptr(buff_ptr),
+    VanadisSyscallReadLinkEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t path_ptr, uint64_t buff_ptr, int64_t size)
+        : VanadisSyscallEvent(core, thr, bittype), readlink_path_ptr(path_ptr), readlink_buff_ptr(buff_ptr),
           readlink_buff_size(size) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_READLINK; }

--- a/src/sst/elements/vanadis/os/callev/voscallsta.h
+++ b/src/sst/elements/vanadis/os/callev/voscallsta.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallSetThreadAreaEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallSetThreadAreaEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallSetThreadAreaEvent(uint32_t core, uint32_t thr, uint64_t ta)
-        : VanadisSyscallEvent(core, thr), ta_ptr(ta) {}
+    VanadisSyscallSetThreadAreaEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t ta)
+        : VanadisSyscallEvent(core, thr, bittype), ta_ptr(ta) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_SET_THREAD_AREA; }
 

--- a/src/sst/elements/vanadis/os/callev/voscalluname.h
+++ b/src/sst/elements/vanadis/os/callev/voscalluname.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallUnameEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallUnameEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallUnameEvent(uint32_t core, uint32_t thr, uint64_t uname_info_adr)
-        : VanadisSyscallEvent(core, thr), uname_info_addr(uname_info_adr) {}
+    VanadisSyscallUnameEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t uname_info_adr)
+        : VanadisSyscallEvent(core, thr, bittype), uname_info_addr(uname_info_adr) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_UNAME; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallunmap.h
+++ b/src/sst/elements/vanadis/os/callev/voscallunmap.h
@@ -28,8 +28,8 @@ class VanadisSyscallMemoryUnMapEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallMemoryUnMapEvent() : VanadisSyscallEvent() {}
 
-    VanadisSyscallMemoryUnMapEvent(uint32_t core, uint32_t thr, uint64_t addr, uint64_t len)
-        : address(addr), length(len) {}
+    VanadisSyscallMemoryUnMapEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t addr, uint64_t len)
+		  : VanadisSyscallEvent(core, thr, bittype), address(addr), length(len) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_UNMAP; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallwrite.h
+++ b/src/sst/elements/vanadis/os/callev/voscallwrite.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallWriteEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallWriteEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallWriteEvent(uint32_t core, uint32_t thr, int64_t fd, uint64_t buff_addr, int64_t buff_count)
-        : VanadisSyscallEvent(core, thr), write_fd(fd), write_buffer(buff_addr), write_count(buff_count) {}
+    VanadisSyscallWriteEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int64_t fd, uint64_t buff_addr, int64_t buff_count)
+        : VanadisSyscallEvent(core, thr, bittype), write_fd(fd), write_buffer(buff_addr), write_count(buff_count) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_WRITE; }
 

--- a/src/sst/elements/vanadis/os/callev/voscallwritev.h
+++ b/src/sst/elements/vanadis/os/callev/voscallwritev.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallWritevEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallWritevEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallWritevEvent(uint32_t core, uint32_t thr, int64_t fd, uint64_t iovec_addr, int64_t iovec_count)
-        : VanadisSyscallEvent(core, thr), writev_fd(fd), writev_iovec_addr(iovec_addr), writev_iov_count(iovec_count) {}
+    VanadisSyscallWritevEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, int64_t fd, uint64_t iovec_addr, int64_t iovec_count)
+        : VanadisSyscallEvent(core, thr, bittype), writev_fd(fd), writev_iovec_addr(iovec_addr), writev_iov_count(iovec_count) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_WRITEV; }
 

--- a/src/sst/elements/vanadis/os/callev/vosinitbrk.h
+++ b/src/sst/elements/vanadis/os/callev/vosinitbrk.h
@@ -24,8 +24,8 @@ namespace Vanadis {
 class VanadisSyscallInitBRKEvent : public VanadisSyscallEvent {
 public:
     VanadisSyscallInitBRKEvent() : VanadisSyscallEvent() {}
-    VanadisSyscallInitBRKEvent(uint32_t core, uint32_t thr, uint64_t newBrkAddr)
-        : VanadisSyscallEvent(core, thr), newBrk(newBrkAddr) {}
+    VanadisSyscallInitBRKEvent(uint32_t core, uint32_t thr, VanadisOSBitType bittype, uint64_t newBrkAddr)
+        : VanadisSyscallEvent(core, thr, bittype), newBrk(newBrkAddr) {}
 
     VanadisSyscallOp getOperation() { return SYSCALL_OP_INIT_BRK; }
 

--- a/src/sst/elements/vanadis/os/vmipscpuos.h
+++ b/src/sst/elements/vanadis/os/vmipscpuos.h
@@ -77,7 +77,7 @@ public:
         case SYSCALL_INIT_PARAM_INIT_BRK: {
             uint64_t* param_val_64 = (uint64_t*)param_val;
             output->verbose(CALL_INFO, 8, 0, "set initial brk point (init) event (0x%llx)\n", (*param_val_64));
-            os_link->sendInitData(new VanadisSyscallInitBRKEvent(core_id, hw_thr, (*param_val_64)));
+            os_link->sendInitData(new VanadisSyscallInitBRKEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, (*param_val_64)));
         } break;
         }
     }
@@ -109,7 +109,7 @@ public:
             const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
             int64_t readlink_size = regFile->getIntReg<uint64_t>(phys_reg_6);
 
-            call_ev = new VanadisSyscallReadLinkEvent(core_id, hw_thr, readlink_path, readlink_buff_ptr, readlink_size);
+            call_ev = new VanadisSyscallReadLinkEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, readlink_path, readlink_buff_ptr, readlink_size);
         } break;
 
         case VANADIS_SYSCALL_MIPS_READ: {
@@ -122,7 +122,7 @@ public:
             const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
             int64_t read_count = regFile->getIntReg<int64_t>(phys_reg_6);
 
-            call_ev = new VanadisSyscallReadEvent(core_id, hw_thr, read_fd, read_buff_ptr, read_count);
+            call_ev = new VanadisSyscallReadEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, read_fd, read_buff_ptr, read_count);
         } break;
 
         case VANADIS_SYSCALL_MIPS_ACCESS: {
@@ -134,7 +134,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to access( 0x%llx, %" PRIu64 " )\n",
                             path_ptr, access_mode);
-            call_ev = new VanadisSyscallAccessEvent(core_id, hw_thr, path_ptr, access_mode);
+            call_ev = new VanadisSyscallAccessEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, path_ptr, access_mode);
         } break;
 
         case VANADIS_SYSCALL_MIPS_BRK: {
@@ -143,7 +143,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to brk( value: %" PRIu64 " ), zero: %s\n",
                             newBrk, brk_zero_memory ? "yes" : "no");
-            call_ev = new VanadisSyscallBRKEvent(core_id, hw_thr, newBrk, brk_zero_memory);
+            call_ev = new VanadisSyscallBRKEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, newBrk, brk_zero_memory);
         } break;
 
         case VANADIS_SYSCALL_MIPS_SET_THREAD_AREA: {
@@ -158,7 +158,7 @@ public:
                 (*tls_address) = thread_area_ptr;
             }
 
-            call_ev = new VanadisSyscallSetThreadAreaEvent(core_id, hw_thr, thread_area_ptr);
+            call_ev = new VanadisSyscallSetThreadAreaEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, thread_area_ptr);
         } break;
 
         case VANADIS_SYSCALL_MIPS_RM_INOTIFY: {
@@ -181,7 +181,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to uname()\n");
 
-            call_ev = new VanadisSyscallUnameEvent(core_id, hw_thr, uname_addr);
+            call_ev = new VanadisSyscallUnameEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, uname_addr);
         } break;
 
         case VANADIS_SYSCALL_MIPS_FSTAT: {
@@ -194,7 +194,7 @@ public:
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to fstat( %" PRId32 ", %" PRIu64 " )\n",
                             file_handle, fstat_addr);
 
-            call_ev = new VanadisSyscallFstatEvent(core_id, hw_thr, file_handle, fstat_addr);
+            call_ev = new VanadisSyscallFstatEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, file_handle, fstat_addr);
         } break;
 
         case VANADIS_SYSCALL_MIPS_CLOSE: {
@@ -203,7 +203,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to close( %" PRIu32 " )\n", close_file);
 
-            call_ev = new VanadisSyscallCloseEvent(core_id, hw_thr, close_file);
+            call_ev = new VanadisSyscallCloseEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, close_file);
         } break;
 
         case VANADIS_SYSCALL_MIPS_OPEN: {
@@ -220,7 +220,7 @@ public:
                             "[syscall-handler] found a call to open( 0x%llx, %" PRIu64 ", %" PRIu64 " )\n",
                             open_path_ptr, open_flags, open_mode);
 
-            call_ev = new VanadisSyscallOpenEvent(core_id, hw_thr, open_path_ptr, open_flags, open_mode);
+            call_ev = new VanadisSyscallOpenEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, open_path_ptr, open_flags, open_mode);
         } break;
 
         case VANADIS_SYSCALL_MIPS_OPENAT: {
@@ -234,7 +234,7 @@ public:
             uint64_t openat_flags = regFile->getIntReg<uint64_t>(phys_reg_6);
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to openat()\n");
-            call_ev = new VanadisSyscallOpenAtEvent(core_id, hw_thr, openat_dirfd, openat_path_ptr, openat_flags);
+            call_ev = new VanadisSyscallOpenAtEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, openat_dirfd, openat_path_ptr, openat_flags);
         } break;
 
         case VANADIS_SYSCALL_MIPS_WRITEV: {
@@ -250,7 +250,7 @@ public:
             output->verbose(CALL_INFO, 8, 0,
                             "[syscall-handler] found a call to writev( %" PRId64 ", 0x%llx, %" PRId64 " )\n", writev_fd,
                             writev_iovec_ptr, writev_iovec_count);
-            call_ev = new VanadisSyscallWritevEvent(core_id, hw_thr, writev_fd, writev_iovec_ptr, writev_iovec_count);
+            call_ev = new VanadisSyscallWritevEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, writev_fd, writev_iovec_ptr, writev_iovec_count);
         } break;
 
         case VANADIS_SYSCALL_MIPS_EXIT_GROUP: {
@@ -259,7 +259,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to exit_group( %" PRId64 " )\n",
                             exit_code);
-            call_ev = new VanadisSyscallExitGroupEvent(core_id, hw_thr, exit_code);
+            call_ev = new VanadisSyscallExitGroupEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, exit_code);
         } break;
 
         case VANADIS_SYSCALL_MIPS_WRITE: {
@@ -275,7 +275,7 @@ public:
             output->verbose(CALL_INFO, 8, 0,
                             "[syscall-handler] found a call to write( %" PRId64 ", 0x%llx, %" PRIu64 " )\n", write_fd,
                             write_buff, write_count);
-            call_ev = new VanadisSyscallWriteEvent(core_id, hw_thr, write_fd, write_buff, write_count);
+            call_ev = new VanadisSyscallWriteEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, write_fd, write_buff, write_count);
         } break;
 
         case VANADIS_SYSCALL_MIPS_SET_TID: {
@@ -359,7 +359,7 @@ public:
                             "\n",
                             is_read ? 'y' : 'n', is_write ? 'y' : 'n', data_size, io_op, io_driver);
 
-            call_ev = new VanadisSyscallIOCtlEvent(core_id, hw_thr, fd, is_read, is_write, io_op, io_driver, ptr,
+            call_ev = new VanadisSyscallIOCtlEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, fd, is_read, is_write, io_op, io_driver, ptr,
                                                    data_size);
         } break;
 
@@ -404,7 +404,7 @@ public:
             if ((0 == unmap_addr)) {
                 recvOSEvent(new VanadisSyscallResponse(-22));
             } else {
-                call_ev = new VanadisSyscallMemoryUnMapEvent(core_id, hw_thr, unmap_addr, unmap_len);
+                call_ev = new VanadisSyscallMemoryUnMapEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, unmap_addr, unmap_len);
             }
         } break;
 
@@ -429,7 +429,7 @@ public:
                             ", sp: 0x%llx (> 4 arguments) )\n",
                             map_addr, map_len, map_prot, map_flags, stack_ptr);
 
-            call_ev = new VanadisSyscallMemoryMapEvent(core_id, hw_thr, map_addr, map_len, map_prot, map_flags,
+            call_ev = new VanadisSyscallMemoryMapEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, map_addr, map_len, map_prot, map_flags,
                                                        stack_ptr, 4096);
         } break;
 
@@ -444,7 +444,7 @@ public:
                             "[syscall-handler] found a call to clock_gettime64( %" PRId64 ", 0x%llx )\n", clk_type,
                             time_addr);
 
-            call_ev = new VanadisSyscallGetTime64Event(core_id, hw_thr, clk_type, time_addr);
+            call_ev = new VanadisSyscallGetTime64Event(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, clk_type, time_addr);
         } break;
 
         case VANADIS_SYSCALL_MIPS_RT_SETSIGMASK: {

--- a/src/sst/elements/vanadis/os/vosbittype.h
+++ b/src/sst/elements/vanadis/os/vosbittype.h
@@ -1,0 +1,16 @@
+
+#ifndef _H_VANADIS_OS_BIT_TYPE
+#define _H_VANADIS_OS_BIT_TYPE
+
+namespace SST {
+namespace Vanadis {
+
+enum class VanadisOSBitType {
+   VANADIS_OS_32B,
+   VANADIS_OS_64B
+};
+
+}
+}
+
+#endif

--- a/src/sst/elements/vanadis/os/voscallev.h
+++ b/src/sst/elements/vanadis/os/voscallev.h
@@ -17,6 +17,7 @@
 #define _H_VANADIS_SYSCALL_EVENT
 
 #include "voscallfunc.h"
+#include "vosbittype.h"
 #include <sst/core/event.h>
 
 namespace SST {
@@ -29,15 +30,19 @@ public:
         thread_id = 0;
     }
 
-    VanadisSyscallEvent(uint32_t core, uint32_t thr) : SST::Event(), core_id(core), thread_id(thr) {}
+    VanadisSyscallEvent(uint32_t core, uint32_t thr) : SST::Event(), core_id(core), thread_id(thr),
+			bittage(VanadisOSBitType::VANADIS_OS_32B) {}
+    VanadisSyscallEvent(uint32_t core, uint32_t thr, VanadisOSBitType bit_type) : SST::Event(), core_id(core), thread_id(thr),
+			bittage(bit_type) {}
 
     ~VanadisSyscallEvent() {}
 
     virtual VanadisSyscallOp getOperation() { return SYSCALL_OP_UNKNOWN; };
     uint32_t getCoreID() const { return core_id; }
     uint32_t getThreadID() const { return thread_id; }
+    virtual VanadisOSBitType getOSBitType() const { return bittage; }
 
-private:
+protected:
     void serialize_order(SST::Core::Serialization::serializer& ser) override {
         Event::serialize_order(ser);
         ser& core_id;
@@ -48,6 +53,7 @@ private:
 
     uint32_t core_id;
     uint32_t thread_id;
+	 VanadisOSBitType bittage;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/os/voscallev.h
+++ b/src/sst/elements/vanadis/os/voscallev.h
@@ -47,6 +47,7 @@ protected:
         Event::serialize_order(ser);
         ser& core_id;
         ser& thread_id;
+		  ser& bittage;
     }
 
     ImplementSerializable(SST::Vanadis::VanadisSyscallEvent);

--- a/src/sst/elements/vanadis/os/vriscvcpuos.h
+++ b/src/sst/elements/vanadis/os/vriscvcpuos.h
@@ -29,12 +29,12 @@
 #define VANADIS_SYSCALL_RISCV_WRITE 4004
 #define VANADIS_SYSCALL_RISCV_ACCESS 4033
 #define VANADIS_SYSCALL_RISCV_BRK 4045
-#define VANADIS_SYSCALL_RISCV_IOCTL 4054
+#define VANADIS_SYSCALL_RISCV_IOCTL 29
 #define VANADIS_SYSCALL_RISCV_READLINK 4085
 #define VANADIS_SYSCALL_RISCV_MMAP 4090
 #define VANADIS_SYSCALL_RISCV_UNMAP 4091
 #define VANADIS_SYSCALL_RISCV_UNAME 4122
-#define VANADIS_SYSCALL_RISCV_WRITEV 4146
+#define VANADIS_SYSCALL_RISCV_WRITEV 66
 #define VANADIS_SYSCALL_RISCV_RT_SETSIGMASK 4195
 #define VANADIS_SYSCALL_RISCV_MMAP2 4210
 #define VANADIS_SYSCALL_RISCV_FSTAT 4215
@@ -79,7 +79,7 @@ public:
         case SYSCALL_INIT_PARAM_INIT_BRK: {
             uint64_t* param_val_64 = (uint64_t*)param_val;
             output->verbose(CALL_INFO, 8, 0, "set initial brk point (init) event (0x%llx)\n", (*param_val_64));
-            os_link->sendInitData(new VanadisSyscallInitBRKEvent(core_id, hw_thr, (*param_val_64)));
+            os_link->sendInitData(new VanadisSyscallInitBRKEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, (*param_val_64)));
         } break;
         }
     }
@@ -111,7 +111,7 @@ public:
             const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
             int64_t readlink_size = regFile->getIntReg<uint64_t>(phys_reg_6);
 
-            call_ev = new VanadisSyscallReadLinkEvent(core_id, hw_thr, readlink_path, readlink_buff_ptr, readlink_size);
+            call_ev = new VanadisSyscallReadLinkEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, readlink_path, readlink_buff_ptr, readlink_size);
         } break;
 
         case VANADIS_SYSCALL_RISCV_READ: {
@@ -124,7 +124,7 @@ public:
             const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
             int64_t read_count = regFile->getIntReg<int64_t>(phys_reg_6);
 
-            call_ev = new VanadisSyscallReadEvent(core_id, hw_thr, read_fd, read_buff_ptr, read_count);
+            call_ev = new VanadisSyscallReadEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, read_fd, read_buff_ptr, read_count);
         } break;
 
         case VANADIS_SYSCALL_RISCV_ACCESS: {
@@ -136,7 +136,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to access( 0x%llx, %" PRIu64 " )\n",
                             path_ptr, access_mode);
-            call_ev = new VanadisSyscallAccessEvent(core_id, hw_thr, path_ptr, access_mode);
+            call_ev = new VanadisSyscallAccessEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, path_ptr, access_mode);
         } break;
 
         case VANADIS_SYSCALL_RISCV_BRK: {
@@ -145,7 +145,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to brk( value: %" PRIu64 " ), zero: %s\n",
                             newBrk, brk_zero_memory ? "yes" : "no");
-            call_ev = new VanadisSyscallBRKEvent(core_id, hw_thr, newBrk, brk_zero_memory);
+            call_ev = new VanadisSyscallBRKEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, newBrk, brk_zero_memory);
         } break;
 
         case VANADIS_SYSCALL_RISCV_SET_THREAD_AREA: {
@@ -160,7 +160,7 @@ public:
                 (*tls_address) = thread_area_ptr;
             }
 
-            call_ev = new VanadisSyscallSetThreadAreaEvent(core_id, hw_thr, thread_area_ptr);
+            call_ev = new VanadisSyscallSetThreadAreaEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, thread_area_ptr);
         } break;
 
         case VANADIS_SYSCALL_RISCV_RM_INOTIFY: {
@@ -181,7 +181,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to uname()\n");
 
-            call_ev = new VanadisSyscallUnameEvent(core_id, hw_thr, uname_addr);
+            call_ev = new VanadisSyscallUnameEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, uname_addr);
         } break;
 
         case VANADIS_SYSCALL_RISCV_FSTAT: {
@@ -194,7 +194,7 @@ public:
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to fstat( %" PRId32 ", %" PRIu64 " )\n",
                             file_handle, fstat_addr);
 
-            call_ev = new VanadisSyscallFstatEvent(core_id, hw_thr, file_handle, fstat_addr);
+            call_ev = new VanadisSyscallFstatEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, file_handle, fstat_addr);
         } break;
 
         case VANADIS_SYSCALL_RISCV_CLOSE: {
@@ -203,7 +203,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to close( %" PRIu32 " )\n", close_file);
 
-            call_ev = new VanadisSyscallCloseEvent(core_id, hw_thr, close_file);
+            call_ev = new VanadisSyscallCloseEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, close_file);
         } break;
 
         case VANADIS_SYSCALL_RISCV_OPEN: {
@@ -220,7 +220,7 @@ public:
                             "[syscall-handler] found a call to open( 0x%llx, %" PRIu64 ", %" PRIu64 " )\n",
                             open_path_ptr, open_flags, open_mode);
 
-            call_ev = new VanadisSyscallOpenEvent(core_id, hw_thr, open_path_ptr, open_flags, open_mode);
+            call_ev = new VanadisSyscallOpenEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, open_path_ptr, open_flags, open_mode);
         } break;
 
         case VANADIS_SYSCALL_RISCV_OPENAT: {
@@ -234,23 +234,23 @@ public:
             uint64_t openat_flags = regFile->getIntReg<uint64_t>(phys_reg_6);
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to openat()\n");
-            call_ev = new VanadisSyscallOpenAtEvent(core_id, hw_thr, openat_dirfd, openat_path_ptr, openat_flags);
+            call_ev = new VanadisSyscallOpenAtEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, openat_dirfd, openat_path_ptr, openat_flags);
         } break;
 
         case VANADIS_SYSCALL_RISCV_WRITEV: {
-            const uint16_t phys_reg_4 = isaTable->getIntPhysReg(4);
-            int64_t writev_fd = regFile->getIntReg<int64_t>(phys_reg_4);
+            const uint16_t phys_reg_10 = isaTable->getIntPhysReg(10);
+            int64_t writev_fd = regFile->getIntReg<int64_t>(phys_reg_10);
 
-            const uint16_t phys_reg_5 = isaTable->getIntPhysReg(5);
-            uint64_t writev_iovec_ptr = regFile->getIntReg<uint64_t>(phys_reg_5);
+            const uint16_t phys_reg_11 = isaTable->getIntPhysReg(11);
+            uint64_t writev_iovec_ptr = regFile->getIntReg<uint64_t>(phys_reg_11);
 
-            const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
-            int64_t writev_iovec_count = regFile->getIntReg<int64_t>(phys_reg_6);
+            const uint16_t phys_reg_12 = isaTable->getIntPhysReg(12);
+            int64_t writev_iovec_count = regFile->getIntReg<int64_t>(phys_reg_12);
 
             output->verbose(CALL_INFO, 8, 0,
                             "[syscall-handler] found a call to writev( %" PRId64 ", 0x%llx, %" PRId64 " )\n", writev_fd,
                             writev_iovec_ptr, writev_iovec_count);
-            call_ev = new VanadisSyscallWritevEvent(core_id, hw_thr, writev_fd, writev_iovec_ptr, writev_iovec_count);
+            call_ev = new VanadisSyscallWritevEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, writev_fd, writev_iovec_ptr, writev_iovec_count);
         } break;
 
         case VANADIS_SYSCALL_RISCV_EXIT_GROUP: {
@@ -259,7 +259,7 @@ public:
 
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to exit_group( %" PRId64 " )\n",
                             exit_code);
-            call_ev = new VanadisSyscallExitGroupEvent(core_id, hw_thr, exit_code);
+            call_ev = new VanadisSyscallExitGroupEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, exit_code);
         } break;
 
         case VANADIS_SYSCALL_RISCV_WRITE: {
@@ -275,7 +275,7 @@ public:
             output->verbose(CALL_INFO, 8, 0,
                             "[syscall-handler] found a call to write( %" PRId64 ", 0x%llx, %" PRIu64 " )\n", write_fd,
                             write_buff, write_count);
-            call_ev = new VanadisSyscallWriteEvent(core_id, hw_thr, write_fd, write_buff, write_count);
+            call_ev = new VanadisSyscallWriteEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, write_fd, write_buff, write_count);
         } break;
 
         case VANADIS_SYSCALL_RISCV_SET_TID: {
@@ -331,14 +331,14 @@ public:
         } break;
 
         case VANADIS_SYSCALL_RISCV_IOCTL: {
-            const uint16_t phys_reg_4 = isaTable->getIntPhysReg(4);
-            int64_t fd = regFile->getIntReg<int64_t>(phys_reg_4);
+            const uint16_t phys_reg_10 = isaTable->getIntPhysReg(10);
+            int64_t fd = regFile->getIntReg<int64_t>(phys_reg_10);
 
-            const uint16_t phys_reg_5 = isaTable->getIntPhysReg(5);
-            uint64_t io_req = regFile->getIntReg<uint64_t>(phys_reg_5);
+            const uint16_t phys_reg_11 = isaTable->getIntPhysReg(11);
+            uint64_t io_req = regFile->getIntReg<uint64_t>(phys_reg_11);
 
-            const uint16_t phys_reg_6 = isaTable->getIntPhysReg(6);
-            uint64_t ptr = regFile->getIntReg<uint64_t>(phys_reg_6);
+            const uint16_t phys_reg_12 = isaTable->getIntPhysReg(12);
+            uint64_t ptr = regFile->getIntReg<uint64_t>(phys_reg_12);
 
             uint64_t access_type = (io_req & 0xE0000000) >> 29;
 
@@ -359,7 +359,7 @@ public:
                             "\n",
                             is_read ? 'y' : 'n', is_write ? 'y' : 'n', data_size, io_op, io_driver);
 
-            call_ev = new VanadisSyscallIOCtlEvent(core_id, hw_thr, fd, is_read, is_write, io_op, io_driver, ptr,
+            call_ev = new VanadisSyscallIOCtlEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, fd, is_read, is_write, io_op, io_driver, ptr,
                                                    data_size);
         } break;
 
@@ -404,7 +404,7 @@ public:
             if ((0 == unmap_addr)) {
                 recvOSEvent(new VanadisSyscallResponse(-22));
             } else {
-                call_ev = new VanadisSyscallMemoryUnMapEvent(core_id, hw_thr, unmap_addr, unmap_len);
+                call_ev = new VanadisSyscallMemoryUnMapEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, unmap_addr, unmap_len);
             }
         } break;
 
@@ -429,7 +429,7 @@ public:
                             ", sp: 0x%llx (> 4 arguments) )\n",
                             map_addr, map_len, map_prot, map_flags, stack_ptr);
 
-            call_ev = new VanadisSyscallMemoryMapEvent(core_id, hw_thr, map_addr, map_len, map_prot, map_flags,
+            call_ev = new VanadisSyscallMemoryMapEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, map_addr, map_len, map_prot, map_flags,
                                                        stack_ptr, 4096);
         } break;
 
@@ -444,7 +444,7 @@ public:
                             "[syscall-handler] found a call to clock_gettime64( %" PRId64 ", 0x%llx )\n", clk_type,
                             time_addr);
 
-            call_ev = new VanadisSyscallGetTime64Event(core_id, hw_thr, clk_type, time_addr);
+            call_ev = new VanadisSyscallGetTime64Event(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, clk_type, time_addr);
         } break;
 
         case VANADIS_SYSCALL_RISCV_RT_SETSIGMASK: {


### PR DESCRIPTION
- Propagates 64b support to emulated OS handlers in Vanadis
- Removes 4B alignment check for `JLR` micro-op jump targets, need to support 2B/16b targets for RISCV/RVC