### PR TITLE
Add Modulo Micro-Op and Improve Decoder Generation for RISC-V Vanadis

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -61,6 +61,7 @@ inst/vjr.h \
 inst/vjump.h \
 inst/vload.h \
 inst/vmemflagtype.h \
+inst/vmod.h \
 inst/vmovci.h \
 inst/vmul.h \
 inst/vmuli.h \

--- a/src/sst/elements/vanadis/inst/vinstall.h
+++ b/src/sst/elements/vanadis/inst/vinstall.h
@@ -22,6 +22,7 @@
 #include "inst/vaddiu.h"
 #include "inst/vdivmod.h"
 #include "inst/vdiv.h"
+#include "inst/vmod.h"
 #include "inst/vmul.h"
 #include "inst/vmuli.h"
 #include "inst/vmulsplit.h"

--- a/src/sst/elements/vanadis/inst/vmod.h
+++ b/src/sst/elements/vanadis/inst/vmod.h
@@ -1,0 +1,116 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _H_VANADIS_MOD
+#define _H_VANADIS_MOD
+
+#include "inst/vinst.h"
+
+namespace SST {
+namespace Vanadis {
+
+template<VanadisRegisterFormat register_format, bool perform_signed>
+class VanadisModuloInstruction : public VanadisInstruction {
+public:
+    VanadisModuloInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+                          const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(addr, hw_thr, isa_opts, 2, 1, 2, 1, 0, 0, 0, 0) {
+
+        isa_int_regs_in[0] = src_1;
+        isa_int_regs_in[1] = src_2;
+        isa_int_regs_out[0] = dest;
+    }
+
+    VanadisModuloInstruction* clone() override { return new VanadisModuloInstruction(*this); }
+    VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_DIV; }
+
+    const char* getInstCode() const override {
+        if (perform_signed) {
+            return "MOD";
+        } else {
+            return "MODU";
+        }
+    }
+
+    void printToBuffer(char* buffer, size_t buffer_size) override {
+        snprintf(buffer, buffer_size,
+                 "%s    %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16
+                 ")",
+                 getInstCode(), isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_out[0],
+                 phys_int_regs_in[0], phys_int_regs_in[1]);
+    }
+
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
+#ifdef VANADIS_BUILD_DEBUG
+        output->verbose(CALL_INFO, 16, 0,
+                        "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                        " / in=%" PRIu16 ", %" PRIu16 "\n",
+                        (void*)getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0],
+                        phys_int_regs_in[1], isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
+#endif
+
+		if( VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format ) {
+			if(perform_signed) {
+         	const int64_t src_1 = regFile->getIntReg<int64_t>(phys_int_regs_in[0]);
+         	const int64_t src_2 = regFile->getIntReg<int64_t>(phys_int_regs_in[1]);
+
+				if(0 == src_2) {
+					regFile->setIntReg<int64_t>(phys_int_regs_out[0], src_1);
+				} else {
+            	regFile->setIntReg<int64_t>(phys_int_regs_out[0], ((src_1) % (src_2)));
+				}
+			} else {
+            const uint64_t src_1 = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
+            const uint64_t src_2 = regFile->getIntReg<uint64_t>(phys_int_regs_in[1]);
+
+				if(0 == src_2) {
+					regFile->setIntReg<uint64_t>(phys_int_regs_out[0], src_1);
+				} else {
+	         	regFile->setIntReg<uint64_t>(phys_int_regs_out[0], ((src_1) % (src_2)));
+				}
+			}
+	   } else if( VanadisRegisterFormat::VANADIS_FORMAT_INT32 == register_format ) {
+			if(perform_signed) {
+            const int32_t src_1 = regFile->getIntReg<int32_t>(phys_int_regs_in[0]);
+            const int32_t src_2 = regFile->getIntReg<int32_t>(phys_int_regs_in[1]);
+
+				if(0 == src_2) {
+            regFile->setIntReg<int32_t>(phys_int_regs_out[0], src_1);
+				} else {
+            regFile->setIntReg<int32_t>(phys_int_regs_out[0], ((src_1) % (src_2)));
+				}
+			} else {
+            const uint32_t src_1 = regFile->getIntReg<uint32_t>(phys_int_regs_in[0]);
+            const uint32_t src_2 = regFile->getIntReg<uint32_t>(phys_int_regs_in[1]);
+
+				if(0 == src_2) {
+            regFile->setIntReg<uint32_t>(phys_int_regs_out[0], src_1);
+				} else {
+            regFile->setIntReg<uint32_t>(phys_int_regs_out[0], ((src_1) % (src_2)));
+				}
+			}
+		} else {
+			flagError();
+      }
+
+	   markExecuted();
+    }
+
+};
+
+} // namespace Vanadis
+} // namespace SST
+
+#endif

--- a/src/sst/elements/vanadis/inst/vslli.h
+++ b/src/sst/elements/vanadis/inst/vslli.h
@@ -38,12 +38,20 @@ public:
 
     VanadisShiftLeftLogicalImmInstruction* clone() override { return new VanadisShiftLeftLogicalImmInstruction(*this); }
     VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
-    const char* getInstCode() const override { return "SLLI"; }
+    const char* getInstCode() const override {
+		if(register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64) {
+			return "SLLI64";
+		} else if(register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT32) {
+			return "SLLI32";
+		} else{
+			return "SLLI";
+		}
+	}
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
-                 "SLLI    %5" PRIu16 " <- %5" PRIu16 " << imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
-                 " << %" PRId64 ")",
+                 "%6s  %5" PRIu16 " <- %5" PRIu16 " << imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
+                 " << %" PRId64 ")", getInstCode(),
                  isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0],
                  imm_value);
     }
@@ -51,9 +59,9 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
-                        "Execute: (addr=%p) SLLI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
+                        "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
                         ", isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
-                        (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
+                        (void*)getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
         assert(imm_value > 0);

--- a/src/sst/elements/vanadis/inst/vsrli.h
+++ b/src/sst/elements/vanadis/inst/vsrli.h
@@ -41,12 +41,20 @@ public:
     }
 
     VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
-    const char* getInstCode() const override { return "SRLI"; }
+    const char* getInstCode() const override {
+		if(register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT32) {
+			return "SRLI32";
+		} else if( register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64 ) {
+			return "SRLI64";
+		} else {
+
+		return "SRLI"; }
+	}
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
-                 "SRLI    %5" PRIu16 " <- %5" PRIu16 " >> imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
-                 " >> %" PRId64 ")",
+                 "%6s   %5" PRIu16 " <- %5" PRIu16 " >> imm=%" PRId64 " (phys: %5" PRIu16 " <- %5" PRIu16
+                 " >> %" PRId64 ")", getInstCode(),
                  isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0],
                  imm_value);
     }
@@ -54,9 +62,9 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
-                        "Execute: (addr=%p) SRLI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
+                        "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRId64
                         ", isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
-                        (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
+                        (void*)getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
                         isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif
         assert(imm_value > 0);


### PR DESCRIPTION
Makes following changes:

- Improve print/debugging output for `SLLI`, `SLRI` and `W` variants
- Adds support for basic arithmetic over 64b values in decoder
- Creates modulo micro-op for RISCV in 64b (including signed/unsigned) because split `DIV/MOD` operation is for MIPSO32
