### PR TITLE
Provide Option in RISCV Decoder to Halt on Decode Fault

### DIFF
--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -1282,7 +1282,11 @@ protected:
                     case 0x1:
                     {
                         // REMW
-                        // TODO - Implement
+								output->verbose(CALL_INFO, 16, 0, "----> REMW %" PRIu16 " <- %" PRIu16 " %% %" PRIu16 "\n",
+									rd, rs1, rs2);
+								bundle->addInstruction(new VanadisModuloInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, true>(
+                           ins_address, hw_thr, options, rd, rs1, rs2));
+                        decode_fault = false;
                     } break;
                     };
                 } break;
@@ -1292,7 +1296,11 @@ protected:
                     case 0x1:
                     {
                         // REMUW
-                        // TODO - Implement
+								output->verbose(CALL_INFO, 16, 0, "----> REMUW %" PRIu16 " <- %" PRIu16 " %% %" PRIu16 "\n",
+									rd, rs1, rs2);
+								bundle->addInstruction(new VanadisModuloInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32, false>(
+                           ins_address, hw_thr, options, rd, rs1, rs2));
+                        decode_fault = false;
                     } break;
                     }
                 }; break;
@@ -1744,7 +1752,15 @@ protected:
                             case 0x0:
                             {
                                 // SUBW
-                                output->verbose(CALL_INFO, 16, 0, "------> RVC SUBW\n");
+		                           uint16_t rvc_rs2  = expand_rvc_int_register(extract_rs2_rvc(ins));
+      		                    uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
+
+										  output->verbose(CALL_INFO, 16, 0, "------> RVC SUBW %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n",
+											 rvc_rs1, rvc_rs1, rvc_rs2);
+
+										  bundle->addInstruction(new VanadisSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(ins_address,
+												hw_thr, options, rvc_rs1, rvc_rs1, rvc_rs2, false));
+										decode_fault = false;
 
                             } break;
                             case 0x20:

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -43,6 +43,8 @@ public:
       {"predecode_cache_entries",
        "Number of cache lines that a cached prior to decoding (these support "
        "loading from cache prior to decode)"},
+      {"halt_on_decode_fault",
+		"Fatal error if a decode fault occurs, used for debugging and not recommmended default is 0 (false)", "0"},
       {"stack_start_address",
        "Sets the start of the stack and dynamic program segments"})
 
@@ -58,6 +60,8 @@ public:
         // if not, we will fall back to ELF reading at the core level to work this
         // out
         setInstructionPointer(params.find<uint64_t>("entry_point", 0));
+
+		  fatal_decode_fault = params.find<bool>("halt_on_decode_fault", false);
     }
 
     ~VanadisRISCV64Decoder() {}
@@ -558,6 +562,7 @@ public:
 
 protected:
     const VanadisDecoderOptions* options;
+    bool fatal_decode_fault;
     uint64_t                     start_stack_address;
     uint16_t                     icache_max_bytes_per_cycle;
     uint16_t                     max_decodes_per_cycle;
@@ -2070,13 +2075,17 @@ protected:
             output->verbose(
                 CALL_INFO, 16, 0, "[decode] -> 16bit RVC format / ins-op-code-family: %" PRIu32 " / 0x%x\n", op_code,
                 op_code);
-            if ( decode_fault ) { output->fatal(CALL_INFO, -1, "STOP\n"); }
+//            if ( decode_fault ) { output->fatal(CALL_INFO, -1, "STOP\n"); }
         }
 
-        //		  if(decode_fault) {
-        //				bundle->addInstruction(new VanadisInstructionDecodeFault(ins_address, hw_thr,
-        // options));
-        //			}
+
+		  if(fatal_decode_fault) {
+				output->fatal(CALL_INFO, 16, 0, "[decode] -> decode fault detected at 0x%llx / thr: %" PRIu32 ", set to fatal on detect\n", ins_address,
+					hw_thr);
+		  }
+        		  if(decode_fault) {
+       			bundle->addInstruction(new VanadisInstructionDecodeFault(ins_address, hw_thr, options));
+       			}
     }
 
     uint16_t expand_rvc_int_register(const uint16_t reg_in) const { return reg_in + 8; }

--- a/src/sst/elements/vanadis/inst/vadd.h
+++ b/src/sst/elements/vanadis/inst/vadd.h
@@ -37,11 +37,25 @@ public:
     VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
     const char* getInstCode() const override {
+		  if(VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format ) {
+        if (perform_signed) {
+            return "ADD32";
+        } else {
+            return "ADDU32";
+        }
+		  } else if( VanadisRegisterFormat::VANADIS_FORMAT_INT64 == register_format ) {
+        if (perform_signed) {
+            return "ADD64";
+        } else {
+            return "ADDU64";
+        }
+		  } else {
         if (perform_signed) {
             return "ADD";
         } else {
             return "ADDU";
         }
+ 		  }
     }
 
     void printToBuffer(char* buffer, size_t buffer_size) override {

--- a/src/sst/elements/vanadis/inst/vsub.h
+++ b/src/sst/elements/vanadis/inst/vsub.h
@@ -35,12 +35,20 @@ public:
 
     VanadisSubInstruction* clone() override { return new VanadisSubInstruction(*this); }
     VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
-    const char* getInstCode() const override { return "SUB"; }
+    const char* getInstCode() const override {
+		if(register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT32) {
+			return "SUB32";
+		} else if(register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64) {
+			return "SUB64";
+		} else {
+			return "SUB";
+		}
+	}
 
     void printToBuffer(char* buffer, size_t buffer_size) override {
         snprintf(buffer, buffer_size,
-                 "SUB   %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16
-                 ")",
+                 "%6s %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " - %5" PRIu16
+                 ")", getInstCode(),
                  isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_out[0], phys_int_regs_in[0],
                  phys_int_regs_in[1]);
     }
@@ -48,9 +56,9 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0,
-                        "Execute: (addr=%p) SUB phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                        "Execute: (addr=%p) %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
                         " / in=%" PRIu16 ", %" PRIu16 "\n",
-                        (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
+                        (void*)getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                         isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);
 #endif
         switch (register_format) {

--- a/src/sst/elements/vanadis/tests/small/basic-math/Makefile
+++ b/src/sst/elements/vanadis/tests/small/basic-math/Makefile
@@ -3,10 +3,10 @@ CXX=mipsel-linux-musl-gcc
 all: sqrt-double sqrt-float
 
 sqrt-double: sqrt-double.c
-	$(CXX) -o sqrt-double -static sqrt-double.c
+	$(CXX) -o sqrt-double -O3 -static sqrt-double.c
 
 sqrt-float: sqrt-float.c
-	$(CXX) -o sqrt-float -static sqrt-float.c
+	$(CXX) -o sqrt-float -O3 -static sqrt-float.c
 
 clean:
 	rm sqrt-double sqrt-float

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double.c
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double.c
@@ -22,11 +22,11 @@ double squareRoot(double n) {
 	for(i = 1; i*i <=n; ++i);
   	for(--i; i*i < n; i += precision);
 
-   	return i;
+   return i;
 }
 
 int main( int argc, char* argv[] ) {
-   	int n = 24;
+   int n = 24;
 
 	for( int i = 1; i < n; ++i ) {
 		printf("Square root of %d = %30.12f\n", i,

--- a/src/sst/elements/vanadis/vanadis.h
+++ b/src/sst/elements/vanadis/vanadis.h
@@ -207,7 +207,7 @@ private:
 
     int performFetch(const uint64_t cycle);
     int performDecode(const uint64_t cycle);
-    int performIssue(const uint64_t cycle);
+    int performIssue(const uint64_t cycle, uint32_t& rob_start, bool& found_store, bool& found_load);
     int performExecute(const uint64_t cycle);
     int performRetire(VanadisCircularQueue<VanadisInstruction*>* rob, const uint64_t cycle);
     int allocateFunctionalUnit(VanadisInstruction* ins);


### PR DESCRIPTION
- Provides a parameter to the RISCV decoder to decide if code should halt on decode faults (used for debugging), default no. This should help the `STOP` condition in #1767 
- Improves print out for debugging ADD and SUB micro-ops (shows their data size widths)
