### PR TITLE
Switch FP Compare for MIPS to Special Micro-Op in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -50,6 +50,7 @@ inst/vfpconv.h \
 inst/vfpdiv.h \
 inst/vfpmul.h \
 inst/vfpscmp.h \
+inst/vfpsignlogic.h \
 inst/vfpsub.h \
 inst/vgpr2fp.h \
 inst/vinstall.h \
@@ -61,6 +62,7 @@ inst/vjr.h \
 inst/vjump.h \
 inst/vload.h \
 inst/vmemflagtype.h \
+inst/vmipsfpscmp.h \
 inst/vmod.h \
 inst/vmovci.h \
 inst/vmul.h \

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -2214,7 +2214,7 @@ protected:
                             case 0x2:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2223,7 +2223,7 @@ protected:
                             case 0xC:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2232,7 +2232,7 @@ protected:
                             case 0xE:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2248,7 +2248,7 @@ protected:
                             case 0x2:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2257,7 +2257,7 @@ protected:
                             case 0xC:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2266,7 +2266,7 @@ protected:
                             case 0xE:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2282,7 +2282,7 @@ protected:
                             case 0x2:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2291,7 +2291,7 @@ protected:
                             case 0xC:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2300,7 +2300,7 @@ protected:
                             case 0xE:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2316,7 +2316,7 @@ protected:
                             case 0x2:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_eq);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_EQ, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2325,7 +2325,7 @@ protected:
                             case 0xC:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lt);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;
@@ -2334,7 +2334,7 @@ protected:
                             case 0xE:
                                 MIPS_INC_DECODE_STAT(stat_decode_cop1_lte);
 
-                                bundle->addInstruction(new VanadisFPSetRegCompareInstruction<
+                                bundle->addInstruction(new VanadisMIPSFPSetRegCompareInstruction<
                                                        REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
                                     ins_addr, hw_thr, options, MIPS_FP_STATUS_REG, fs, ft));
                                 insertDecodeFault = false;

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -1410,6 +1410,24 @@ protected:
 								rd, rs1, rs2));
 							decode_fault = false;
 						} break;
+					case 5:
+						{
+							// FSUB.D
+							output->verbose(CALL_INFO, 16, 0, "-----> FSUB.D %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n",
+								rd, rs1, rs2);
+							bundle->addInstruction(new VanadisFPSubInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options,
+								rd, rs1, rs2));
+							decode_fault = false;
+						} break;
+					case 9:
+						{
+							// FMUL.D
+							output->verbose(CALL_INFO, 16, 0, "-----> FMUL.D %" PRIu16 " <- %" PRIu16 " * %" PRIu16 "\n",
+								rd, rs1, rs2);
+							bundle->addInstruction(new VanadisFPMultiplyInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options,
+								rd, rs1, rs2));
+							decode_fault = false;
+						} break;
 					case 17:
 						{
 							switch(func_code3) {
@@ -1458,6 +1476,14 @@ protected:
 								output->verbose(CALL_INFO, 16, 0, "-----> FLE.D %" PRIu16 " <- %" PRIu16 " <= %" PRIu16 "\n",
 									rd, rs1, rs2);
 								bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options, rd, rs1, rs2));
+								decode_fault = false;
+							} break;
+						case 0x1:
+							{
+								// FLT.D
+								output->verbose(CALL_INFO, 16, 0, "-----> FLT.D %" PRIu16 " <- %" PRIu16 " < %" PRIu16 "\n",
+									rd, rs1, rs2);
+								bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options, rd, rs1, rs2));
 								decode_fault = false;
 							} break;
 						}

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -689,7 +689,21 @@ protected:
             } break;
             case 0x7:
             {
+					processI<int64_t>(ins, op_code, rd, rs1, func_code3, simm64);
+
                 // Floating point load
+					switch(func_code3) {
+					case 0x3:
+						{
+							// FLD
+							output->verbose(CALL_INFO, 16, 0, "----> FLD %" PRIu16 " <- memory[ %" PRIu16 " + %" PRId64 " ]\n",
+								rd, rs1, simm64);
+							bundle->addInstruction(new VanadisLoadInstruction(
+                        ins_address, hw_thr, options, rs1, simm64, rd, 8, true, MEM_TRANSACTION_NONE,
+                        LOAD_FP_REGISTER));
+                    decode_fault = false;
+						} break;
+					}
             } break;
             case 0x23:
             {
@@ -1382,7 +1396,74 @@ protected:
             case 0x53:
             {
                 // floating point arithmetic
-            } break;
+					processR(ins, op_code, rd, rs1, rs2, func_code3, func_code7);
+
+					output->verbose(CALL_INFO, 16, 0, "---> func_code3=%" PRIu32 " / func_code7=%" PRIu32 "\n", func_code3, func_code7);
+
+					switch(func_code7) {
+					case 0x1:
+						{
+							// FADD.D
+							output->verbose(CALL_INFO, 16, 0, "-----> FADD.D %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n",
+								rd, rs1, rs2);
+							bundle->addInstruction(new VanadisFPAddInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options,
+								rd, rs1, rs2));
+							decode_fault = false;
+						} break;
+					case 17:
+						{
+							switch(func_code3) {
+							case 0:
+								{
+									output->verbose(CALL_INFO, 16, 0, "-----> FSGNJ.D %" PRIu16 " <- %" PRIu16 " / %" PRIu16 "\n", rd, rs1, rs2);
+									bundle->addInstruction(new VanadisFPSignLogicInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_COPY>(
+										ins_address, hw_thr, options, rd, rs1, rs2));
+									decode_fault = false;
+								} break;
+							case 1:
+								{
+									output->verbose(CALL_INFO, 16, 0, "-----> FSGNJN.D %" PRIu16 " <- %" PRIu16 " / %" PRIu16 "\n", rd, rs1, rs2);
+									bundle->addInstruction(new VanadisFPSignLogicInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_NEG>(
+										ins_address, hw_thr, options, rd, rs1, rs2));
+									decode_fault = false;
+								} break;
+							case 2:
+								{
+									output->verbose(CALL_INFO, 16, 0, "-----> FSGNJX.D %" PRIu16 " <- %" PRIu16 " / %" PRIu16 "\n", rd, rs1, rs2);
+									bundle->addInstruction(new VanadisFPSignLogicInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_XOR>(
+										ins_address, hw_thr, options, rd, rs1, rs2));
+									decode_fault = false;
+								} break;
+							}
+						}  break;
+					case 0x50:
+						{
+							switch(func_code3) {
+							case 0x0:
+								{
+									// FLE.S
+								output->verbose(CALL_INFO, 16, 0, "-----> FLE.S %" PRIu16 " <- %" PRIu16 " <= %" PRIu16 "\n",
+									rd, rs1, rs2);
+//								bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options, rd, rs1, rs2));
+//								decode_fault = false;
+								} break;
+							}
+						} break;
+					case 0x51:
+						{
+						switch(func_code3) {
+						case 0x0:
+							{
+								// FLE.D
+								output->verbose(CALL_INFO, 16, 0, "-----> FLE.D %" PRIu16 " <- %" PRIu16 " <= %" PRIu16 "\n",
+									rd, rs1, rs2);
+								bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, VanadisRegisterFormat::VANADIS_FORMAT_FP64>(ins_address, hw_thr, options, rd, rs1, rs2));
+								decode_fault = false;
+							} break;
+						}
+						} break;
+            	}
+				} break;
             case 0x43:
             {
                 // FMADD

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -1,0 +1,189 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _H_VANADIS_FP_SET_REG_COMPARE
+#define _H_VANADIS_FP_SET_REG_COMPARE
+
+#include "inst/vcmptype.h"
+#include "inst/vinst.h"
+#include "inst/vregfmt.h"
+#include "util/vfpreghandler.h"
+
+namespace SST {
+namespace Vanadis {
+
+template<VanadisRegisterCompareType compare_type, VanadisRegisterFormat register_format>
+class VanadisFPSetRegCompareInstruction : public VanadisInstruction {
+public:
+    VanadisFPSetRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+                                      const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
+        : VanadisInstruction(
+            addr, hw_thr, isa_opts, 0, 1, 0, 1,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            0,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            0) {
+
+        if ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) {
+            isa_fp_regs_in[0] = src_1;
+            isa_fp_regs_in[1] = src_1 + 1;
+            isa_fp_regs_in[2] = src_2;
+            isa_fp_regs_in[3] = src_2 + 1;
+            isa_int_regs_out[0] = dest;
+        } else {
+            isa_fp_regs_in[0] = src_1;
+            isa_fp_regs_in[1] = src_2;
+            isa_int_regs_out[0] = dest;
+        }
+    }
+
+    VanadisFPSetRegCompareInstruction* clone() override { return new VanadisFPSetRegCompareInstruction(*this); }
+
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
+
+    virtual const char* getInstCode() const override {
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64: {
+            switch (compare_type) {
+            case REG_COMPARE_EQ:
+                return "FP64CMPEQ";
+            case REG_COMPARE_NEQ:
+                return "FP64CMPNEQ";
+            case REG_COMPARE_LT:
+                return "FP64CMPLT";
+            case REG_COMPARE_LTE:
+                return "FP64CMPLTE";
+            case REG_COMPARE_GT:
+                return "FP64CMPGT";
+            case REG_COMPARE_GTE:
+                return "FP64CMPGTE";
+            default:
+                return "FP64CMPUKN";
+            }
+        } break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32: {
+            switch (compare_type) {
+            case REG_COMPARE_EQ:
+                return "FP32CMPEQ";
+            case REG_COMPARE_NEQ:
+                return "FP32CMPNEQ";
+            case REG_COMPARE_LT:
+                return "FP32CMPLT";
+            case REG_COMPARE_LTE:
+                return "FP32CMPLTE";
+            case REG_COMPARE_GT:
+                return "FP32CMPGT";
+            case REG_COMPARE_GTE:
+                return "FP32CMPGTE";
+            default:
+                return "FP32CMPUKN";
+            }
+        } break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+            return "FPINT64ACMP";
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+            return "FPINT32CMP";
+		  default:
+	         return "FPCNVUNK";
+        }
+    }
+
+    void printToBuffer(char* buffer, size_t buffer_size) override {
+        snprintf(buffer, buffer_size,
+                 "FPCMPST (op: %s, %s) isa-out: %" PRIu16 " isa-in: %" PRIu16 ", %" PRIu16 " / phys-out: %" PRIu16
+                 " phys-in: %" PRIu16 ", %" PRIu16 "\n",
+                 convertCompareTypeToString(compare_type), registerFormatToString(register_format), isa_int_regs_out[0],
+                 isa_fp_regs_in[0], isa_fp_regs_in[1], phys_int_regs_out[0], phys_fp_regs_in[0], phys_fp_regs_in[1]);
+    }
+
+    template <typename T> bool performCompare(SST::Output* output, VanadisRegisterFile* regFile) {
+        const T left_value = ((8 == sizeof(T)) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()))
+                                 ? combineFromRegisters<T>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1])
+                                 : regFile->getFPReg<T>(phys_fp_regs_in[0]);
+        const T right_value = ((8 == sizeof(T)) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()))
+                                  ? combineFromRegisters<T>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3])
+                                  : regFile->getFPReg<T>(phys_fp_regs_in[1]);
+
+        switch (compare_type) {
+        case REG_COMPARE_EQ:
+            return (left_value == right_value);
+        case REG_COMPARE_NEQ:
+            return (left_value != right_value);
+        case REG_COMPARE_LT:
+            return (left_value < right_value);
+        case REG_COMPARE_LTE:
+            return (left_value <= right_value);
+        case REG_COMPARE_GT:
+            return (left_value > right_value);
+        case REG_COMPARE_GTE:
+            return (left_value >= right_value);
+        default:
+            output->fatal(CALL_INFO, -1, "Unknown compare type.\n");
+            return false;
+        }
+    }
+
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override {
+#ifdef VANADIS_BUILD_DEBUG
+        char* int_register_buffer = new char[256];
+        char* fp_register_buffer = new char[256];
+
+        writeIntRegs(int_register_buffer, 256);
+        writeFPRegs(fp_register_buffer, 256);
+
+        output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s (%s) int: %s / fp: %s\n", getInstructionAddress(),
+                        getInstCode(), convertCompareTypeToString(compare_type), int_register_buffer,
+                        fp_register_buffer);
+
+        delete[] int_register_buffer;
+        delete[] fp_register_buffer;
+#endif
+        bool compare_result = false;
+
+        switch (register_format) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
+            compare_result = performCompare<float>(output, regFile);
+            break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
+            compare_result = performCompare<double>(output, regFile);
+            break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+            compare_result = performCompare<int32_t>(output, regFile);
+            break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+            compare_result = performCompare<int64_t>(output, regFile);
+            break;
+        default:
+            output->fatal(CALL_INFO, -1, "Unknown data format type.\n");
+        }
+
+		  regFile->setIntReg<uint64_t>(phys_int_regs_out[0], compare_result ? 1 : 0);
+
+		  if(output->getVerboseLevel() >= 16) {
+        if (compare_result) {
+            output->verbose(CALL_INFO, 16, 0, "---> result: true\n");
+        } else {
+            output->verbose(CALL_INFO, 16, 0, "---> result: false\n");
+        }
+        }
+
+        markExecuted();
+    }
+};
+
+} // namespace Vanadis
+} // namespace SST
+
+#endif

--- a/src/sst/elements/vanadis/inst/vfpsignlogic.h
+++ b/src/sst/elements/vanadis/inst/vfpsignlogic.h
@@ -1,0 +1,323 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+
+#ifndef _H_VANADIS_FP_SIGN_LOGIC
+#define _H_VANADIS_FP_SIGN_LOGIC
+
+#include <cmath>
+
+#include "inst/vinst.h"
+#include "inst/vregfmt.h"
+#include "util/vfpreghandler.h"
+
+namespace SST {
+namespace Vanadis {
+
+enum class VanadisFPSignLogicOperation
+{
+    SIGN_COPY,
+    SIGN_XOR,
+	 SIGN_NEG
+};
+
+template <VanadisRegisterFormat register_format, VanadisFPSignLogicOperation sign_op>
+class VanadisFPSignLogicInstruction : public VanadisInstruction
+{
+public:
+    VanadisFPSignLogicInstruction(
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint16_t src_1, const uint16_t src_2) :
+        VanadisInstruction(
+            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
+             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
+                ? 4
+                : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
+             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
+                ? 2
+                : 1,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
+             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
+                ? 4
+                : 2,
+            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
+             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
+                ? 2
+                : 1)
+    {
+
+        if ( (register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
+             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()) ) {
+            isa_fp_regs_in[0]  = src_1;
+            isa_fp_regs_in[1]  = src_1 + 1;
+            isa_fp_regs_in[2]  = src_2;
+            isa_fp_regs_in[3]  = src_2 + 1;
+            isa_fp_regs_out[0] = dest;
+            isa_fp_regs_out[1] = dest + 1;
+        }
+        else {
+            isa_fp_regs_in[0]  = src_1;
+            isa_fp_regs_in[1]  = src_2;
+            isa_fp_regs_out[0] = dest;
+        }
+    }
+
+    VanadisFPSignLogicInstruction* clone() override { return new VanadisFPSignLogicInstruction(*this); }
+    VanadisFunctionalUnitType      getInstFuncType() const override { return INST_FP_ARITH; }
+
+    const char* getInstCode() const override
+    {
+        switch ( register_format ) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
+            return "FP64SIGN";
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
+            return "FP32SIGN";
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
+            return "FPERROR";
+        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
+            return "FPERROR";
+        }
+
+        return "FPERROR";
+    }
+
+    void printToBuffer(char* buffer, size_t buffer_size) override
+    {
+        snprintf(
+            buffer, buffer_size,
+            "MUL     %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 ")",
+            isa_fp_regs_out[0], isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0], phys_fp_regs_in[0],
+            phys_fp_regs_in[1]);
+    }
+
+    template <typename T>
+    void perform_sign_copy(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = regFile->getFPReg<T>(phys_fp_regs_in[0]);
+        T src_2 = regFile->getFPReg<T>(phys_fp_regs_in[1]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_2_neg ) {
+					src_1 = src_1_neg ? src_1 : (-src_1);
+				} else {
+					src_1 = src_1_neg ? (-src_1) : (src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> take-sign-from: %f to: %f = %f\n", src_2, src_1, src_1);
+
+            regFile->setFPReg<T>(phys_fp_regs_out[0], src_1);
+        }
+    }
+
+    template <typename T>
+    void perform_sign_neg(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = regFile->getFPReg<T>(phys_fp_regs_in[0]);
+        T src_2 = regFile->getFPReg<T>(phys_fp_regs_in[1]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_2_neg ) {
+					src_1 = src_1_neg ? (-src_1) : (src_1);
+				} else {
+					src_1 = src_1_neg ? (src_1) : (-src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> neg-sign-from: %f to: %f = %f\n", src_2, src_1, src_1);
+
+            regFile->setFPReg<T>(phys_fp_regs_out[0], src_1);
+        }
+    }
+
+    template <typename T>
+    void perform_sign_xor(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = regFile->getFPReg<T>(phys_fp_regs_in[0]);
+        T src_2 = regFile->getFPReg<T>(phys_fp_regs_in[1]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_1_neg ^ src_2_neg ) {
+					src_1 = (src_1 > 0) ? (-src_1) : src_1;
+				} else {
+					src_1 = (src_1 > 0) ? src_1 : (-src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> xor-sign-from: %f and %f = %f\n", src_2, src_1, src_1);
+
+            regFile->setFPReg<T>(phys_fp_regs_out[0], src_1);
+        }
+    }
+
+    template <typename T>
+    void perform_sign_copy_split(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = combineFromRegisters<T>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+        T src_2 = combineFromRegisters<T>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_2_neg ) {
+					src_1 = src_1_neg ? src_1 : (-src_1);
+				} else {
+					src_1 = src_1_neg ? (-src_1) : (src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> take-sign-from: %f to: %f = %f\n", src_2, src_1, src_1);
+
+            fractureToRegisters<T>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1);
+        }
+    }
+
+    template <typename T>
+    void perform_sign_neg_split(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = combineFromRegisters<T>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+        T src_2 = combineFromRegisters<T>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_2_neg ) {
+					src_1 = src_1_neg ? (-src_1) : (src_1);
+				} else {
+					src_1 = src_1_neg ? (src_1) : (-src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> neg-sign-from: %f to: %f = %f\n", src_2, src_1, src_1);
+
+            fractureToRegisters<T>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1);
+        }
+    }
+
+    template <typename T>
+    void perform_sign_xor_split(SST::Output* output, VanadisRegisterFile* regFile)
+    {
+        T src_1 = combineFromRegisters<T>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+        T src_2 = combineFromRegisters<T>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+
+        if ( std::isnormal(src_1) || std::isnormal(src_2) ) {
+            // true is negative
+				const bool src_1_neg = std::signbit(src_1);
+				const bool src_2_neg = std::signbit(src_2);
+
+            if ( src_1_neg ^ src_2_neg ) {
+					src_1 = (src_1 > 0) ? (-src_1) : src_1;
+				} else {
+					src_1 = (src_1 > 0) ? src_1 : (-src_1);
+				}
+
+            output->verbose(CALL_INFO, 16, 0, "---> xor-sign-from: %f and %f = %f\n", src_2, src_1, src_1);
+
+            fractureToRegisters<T>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1);
+        }
+    }
+
+    void execute(SST::Output* output, VanadisRegisterFile* regFile) override
+    {
+#ifdef VANADIS_BUILD_DEBUG
+        char* int_register_buffer = new char[256];
+        char* fp_register_buffer  = new char[256];
+
+        writeIntRegs(int_register_buffer, 256);
+        writeFPRegs(fp_register_buffer, 256);
+
+        output->verbose(
+            CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(), getInstCode(),
+            int_register_buffer, fp_register_buffer);
+
+        delete[] int_register_buffer;
+        delete[] fp_register_buffer;
+#endif
+
+        switch ( register_format ) {
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
+        {
+            switch ( sign_op ) {
+            case VanadisFPSignLogicOperation::SIGN_COPY:
+            {
+                perform_sign_copy<float>(output, regFile);
+            } break;
+				case VanadisFPSignLogicOperation::SIGN_XOR:
+				{
+					perform_sign_xor<float>(output, regFile);
+				} break;
+				case VanadisFPSignLogicOperation::SIGN_NEG:
+				{
+					perform_sign_neg<float>(output, regFile);
+				} break;
+            }
+        } break;
+        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
+        {
+            switch ( sign_op ) {
+            case VanadisFPSignLogicOperation::SIGN_COPY:
+            {
+                if ( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
+                    perform_sign_copy_split<double>(output, regFile);
+                }
+                else {
+                    perform_sign_copy<double>(output, regFile);
+                }
+            } break;
+				case VanadisFPSignLogicOperation::SIGN_XOR:
+				{
+					if ( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
+						perform_sign_xor_split<double>(output, regFile);
+					} else {
+						perform_sign_xor<double>(output, regFile);
+					}
+				} break;
+				case VanadisFPSignLogicOperation::SIGN_NEG:
+				{
+					if ( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
+						perform_sign_neg_split<double>(output, regFile);
+					} else {
+						perform_sign_neg<double>(output, regFile);
+					}
+				} break;
+            }
+        } break;
+        default:
+        {
+            output->verbose(CALL_INFO, 16, 0, "Unknown floating point type.\n");
+            flagError();
+        } break;
+        }
+
+        markExecuted();
+    }
+};
+
+} // namespace Vanadis
+} // namespace SST
+
+#endif

--- a/src/sst/elements/vanadis/inst/vinstall.h
+++ b/src/sst/elements/vanadis/inst/vinstall.h
@@ -96,7 +96,9 @@
 #include "inst/vfpdiv.h"
 #include "inst/vfpmul.h"
 #include "inst/vmipsfpscmp.h"
+#include "inst/vfpscmp.h"
 #include "inst/vfpsub.h"
+#include "inst/vfpsignlogic.h"
 
 // Truncate
 #include "inst/vtrunc.h"

--- a/src/sst/elements/vanadis/inst/vinstall.h
+++ b/src/sst/elements/vanadis/inst/vinstall.h
@@ -95,7 +95,7 @@
 #include "inst/vfpadd.h"
 #include "inst/vfpdiv.h"
 #include "inst/vfpmul.h"
-#include "inst/vfpscmp.h"
+#include "inst/vmipsfpscmp.h"
 #include "inst/vfpsub.h"
 
 // Truncate

--- a/src/sst/elements/vanadis/inst/vmipsfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vmipsfpscmp.h
@@ -13,8 +13,8 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#ifndef _H_VANADIS_FP_SET_REG_COMPARE
-#define _H_VANADIS_FP_SET_REG_COMPARE
+#ifndef _H_VANADIS_MIPS_FP_SET_REG_COMPARE
+#define _H_VANADIS_MIPS_FP_SET_REG_COMPARE
 
 #include "inst/vcmptype.h"
 #include "inst/vinst.h"
@@ -28,9 +28,9 @@ namespace SST {
 namespace Vanadis {
 
 template<VanadisRegisterCompareType compare_type, VanadisRegisterFormat register_format>
-class VanadisFPSetRegCompareInstruction : public VanadisInstruction {
+class VanadisMIPSFPSetRegCompareInstruction : public VanadisInstruction {
 public:
-    VanadisFPSetRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+    VanadisMIPSFPSetRegCompareInstruction(const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
                                       const uint16_t dest, const uint16_t src_1, const uint16_t src_2)
         : VanadisInstruction(
             addr, hw_thr, isa_opts, 0, 0, 0, 0,
@@ -54,7 +54,7 @@ public:
         }
     }
 
-    VanadisFPSetRegCompareInstruction* clone() override { return new VanadisFPSetRegCompareInstruction(*this); }
+    VanadisMIPSFPSetRegCompareInstruction* clone() override { return new VanadisMIPSFPSetRegCompareInstruction(*this); }
 
     virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_FP_ARITH; }
 

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -21,11 +21,11 @@ def build_vanadis_test_matrix():
     testlist = []
 
     # Add the SDL file, test dir compiled elf file, and test run timeout to create the testlist
-    testlist.append(["basic_vanadis.py", "small/basic-io", "hello-world", 20])
+    testlist.append(["basic_vanadis.py", "small/basic-io", "hello-world", 120])
     testlist.append(["basic_vanadis.py", "small/basic-math", "sqrt-double", 300])
-    testlist.append(["basic_vanadis.py", "small/basic-math", "sqrt-float", 240])
-    testlist.append(["basic_vanadis.py", "small/basic-ops", "test-branch", 60])
-    testlist.append(["basic_vanadis.py", "small/basic-ops", "test-shift", 120])
+    testlist.append(["basic_vanadis.py", "small/basic-math", "sqrt-float", 300])
+    testlist.append(["basic_vanadis.py", "small/basic-ops", "test-branch", 300])
+    testlist.append(["basic_vanadis.py", "small/basic-ops", "test-shift", 300])
 
     # Process each line and crack up into an index, hash, options and sdl file
     for testnum, test_info in enumerate(testlist):


### PR DESCRIPTION
- Switches FP compare and set implementation to be a MIPS-specific micro-op (too different from other implementations)
- Increase timeouts for testing
