### PR TITLE
Added component Samba.SimpleTLB

### DIFF
--- a/src/sst/elements/Samba/Makefile.am
+++ b/src/sst/elements/Samba/Makefile.am
@@ -18,7 +18,9 @@ libSamba_la_SOURCES = \
 	TLBhierarchy.cc \
 	PageTableWalker.h \
 	PageTableWalker.cc \
-	PageFaultHandler.h
+	PageFaultHandler.h \
+	SimpleTLB.cc \
+	SimpleTLB.h 
 
 
 libSamba_la_CPPFLAGS = \

--- a/src/sst/elements/Samba/PageTableWalker.h
+++ b/src/sst/elements/Samba/PageTableWalker.h
@@ -53,23 +53,24 @@ namespace SST { namespace SambaComponent{
 
 		int fault_level; // indicates the step where the page fault handler is at
 
-		int sizes; // This indicates the number of sizes supported
+		int sizes; // number of levels of page table (TODO, JVOROBY: RENAME THIS)
 
 		uint64_t * page_size; // By default, lets assume 4KB pages
 
 		int * assoc; // This represents the associativiety
 
-		Address_t *** tags; // This will hold the tags
-
-		bool *** valid; // This will hold the status of tags
-
-		int *** lru; // This will hold the lru positions
+        // === PTWC data: arranged like so: [PTWC_level][set][ent_in_set]
+		Address_t *** tags; 
+		bool *** valid; 
+		int *** lru; // lru positions
 
 		SST::Link * to_mem; // This links the Page table walker to the memory hierarchy
 
-		int * hold; // This is used to tell the TLB hierarchy to stall, to emulate overhead of page fault handler
 
-		int * shootdown; // This is used to indicate TLB hierarchy that TLB shootdown from other cores is in progress
+        //== Signals: pointers are set using setHold(), etc, by the class that created this (TLBHierarchy)
+        //      we set (*hold=0 or *hold=1) to indicate holding
+		int * hold; // tells TLB hierarchy to stall, to emulate overhead of page fault handler
+		int * shootdown; // indicates to TLB hierarchy that TLB shootdown from other cores is in progress
 
 //		int shootdownId;
 
@@ -83,24 +84,19 @@ namespace SST { namespace SambaComponent{
 //		uint64_t tlb_shootdown_time;
 
 
-		// ------------- Note that we assume that for each Samba componenet instance, all units run the same VMA, thus all share the same page table
+		// ------------- Note that we assume that for each Samba component instance, all units run the same VMA, thus all share the same page table
 		// ------------- Our assumption is based on the fact that Ariel instances (mapped one-to-one to Samba instances) can only run one application
 
 		// Holds CR3 value of current context
 		Address_t *CR3;
 		int *cr3_init;
 
-		// Holds the PGD physical pointers, the key is the 9 bits 39-47, i.e., VA/(4096*512*512*512)
-		std::map<Address_t, Address_t> * PGD;
-
-		// Holds the PUD physical pointers, the key is the 9 bits 30-38, i.e., VA/(4096*512*512)
-		std::map<Address_t, Address_t> * PUD;
-
-		// Holds the PMD physical pointers, the key is the 9 bits 21-29, i.e., VA/(4096*512)
-		std::map<Address_t, Address_t> * PMD;
-
-		// Holds the PTE physical pointers, the key is the 9 bits 12-20, i.e., VA/(4096)
-		std::map<Address_t, Address_t> * PTE; // This should give you the exact physical address of the page
+		// Holds the PGD, PUD, PMT, PTE physical pointers
+		std::map<Address_t, Address_t> * PGD; // key is 9 bits 39-47, i.e., VA/(4096*512*512*512)
+		std::map<Address_t, Address_t> * PUD; // key is 9 bits 30-38, i.e., VA/(4096*512*512)
+		std::map<Address_t, Address_t> * PMD; // key is 9 bits 21-29, i.e., VA/(4096*512)
+		std::map<Address_t, Address_t> * PTE; // key is 9 bits 12-20, i.e., VA/(4096)         
+                                              // PTE should give you the exact physical address of the page
 
 
 		// The structures below are used to quickly check if the page is mapped or not

--- a/src/sst/elements/Samba/PageTableWalker.h
+++ b/src/sst/elements/Samba/PageTableWalker.h
@@ -50,19 +50,54 @@ namespace SST { namespace SambaComponent{
 		Output* output;
 
 		int coreId;
-
 		int fault_level; // indicates the step where the page fault handler is at
+
 
 		int sizes; // number of levels of page table (TODO, JVOROBY: RENAME THIS)
 
-		uint64_t * page_size; // By default, lets assume 4KB pages
+        //=== Params
+		int os_page_size; // This is a hack for the size of the frames returned by the OS, by default
+		int latency; // indicates the latency in cycles
+		int emulate_faults; // if set, the page faults will be communicated to page fault handler
+		int upper_link_latency; // This indicates the upper link latency
+		int max_outstanding; // indicates the number of maximum outstanding misses
+		int max_width; // indicates the number of maximum accesses on the same cycle
+		int parallel_mode; // very specific case for L1 PageTableWalker in case of overlapping with accessing the cache
+		int self_connected; // his parameter indidicates if the PTW is self-connected or actually connected to the memory hierarchy
+		int page_walk_latency; // this is really nothing than the page walk latency in case of having no walkers
 
-		int * assoc; // This represents the associativiety
+		uint32_t ptw_confined;
+
+
+        //=== Per-page-table-level Params
+        //- Each var is an array, one entry for each level of page table
+        //- var[0] is the value for the leaf page table entry,
+        //- in a 4-level page table, var[3] would be the root of the page table? (JVOROBY: TODO, figure out details)
+        //
+		uint64_t * page_size; // By default, lets assume 4KB pages
+        
+
+        //=== Page table walk cache parameters, for each level of PTWC:
+		int* size;  // Number of entries in i-th level PTWC (param)
+		int* assoc; // associativity of i-th PTWC (param)
+		int* sets;  // number of sets in i-th PTWC (calculated)
 
         // === PTWC data: arranged like so: [PTWC_level][set][ent_in_set]
 		Address_t *** tags; 
 		bool *** valid; 
 		int *** lru; // lru positions
+
+
+        // == Stats
+		int hits; // number of hits
+		int misses; // number of misses
+
+
+		int *page_placement; // JVOROBY: is set by TLBhierarchy. Seems to be unused?
+		uint64_t *timeStamp; //JVOROBY: UNUSED??
+
+
+
 
 		SST::Link * to_mem; // This links the Page table walker to the memory hierarchy
 
@@ -74,7 +109,7 @@ namespace SST { namespace SambaComponent{
 
 //		int shootdownId;
 
-		int num_pages_migrated;
+		int num_pages_migrated; // JVOROBY: used for shootdowns?
 
 		//std::vector<Address_t, int> buffer;
 		int *hasInvalidAddrs;
@@ -117,7 +152,6 @@ namespace SST { namespace SambaComponent{
 		SST::Link * s_EventChan;
 
 
-
 		bool stall; // This indicates the page table walker is stalling due to a fault
 
 		Address_t stall_addr; // stores the address for which ptw was stalled
@@ -128,54 +162,65 @@ namespace SST { namespace SambaComponent{
 		int stall_at_PMD;
 		int stall_at_PTE;
 
-		int  * sets; //stores the number of sets
 
-		int* size; // Number of entries
+        //=======================================================================
+        //
+        //           BUFFERS FOR REQUESTS TRAVELLING UP AND DOWN TLBS
+        //
+        //=======================================================================
 
-		int hits; // number of hits
+        //    //  note: the _size buffers holds the size of the relevant page,
+        //    //  i.e 1 for 4k, 2 for 2M, 3 for 1GB (if using standard page sizes)
 
-		int misses; // number of misses
+        //    // === Holds incoming requests, "input queue"
+        //    std::vector<MemHierarchy::MemEventBase *> not_serviced;
 
-		int os_page_size; // This is a hack for the size of the frames returned by the OS, by default
+        //    // === Holds a copy of requests that have missed in this level, and have been sent into the next level down.
+        //    //  events are erased when they are fulfilled, and returned into `this->pushed_back`
+        //    std::vector<MemHierarchy::MemEventBase *> pending_misses; 
 
-		int latency; // indicates the latency in cycles
+        //    // === Holds requests that have gotten the data they need, but we need to wait the duration of the latency before returning
+        //    std::map<MemHierarchy::MemEventBase *, SST::Cycle_t, MemEventPtrCompare> ready_by; 
+        //    std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> ready_by_size; // keeps track of requests' sizes inside this structure
 
-		int emulate_faults; // if set, the page faults will be communicated to page fault handler
 
-		int *page_placement;
+        //    // === Buffers for sending requests up/down TLB hierarchy:
+        //    
+        //    // When we miss, we send requests to next level down through `next_level->push_request()` or `PTW->push_request()`
+        //    
+        //    // completed requests from deeper in TLB hierarchy will be returned into `this->pushed_back`
+        //    std::vector<MemHierarchy::MemEventBase *> pushed_back; // translation for requests, returned from lower-level structures
+        //    std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // page_sizes of the returned translations
 
-		uint64_t *timeStamp;
+        //    // when we're finished with a request, we send it back up the hierarchy by inserting into `service_back`
+        //    // - pointer is wired up to `pushed_back` buffers of the next level up at TLB in constructor of TLBHierarchy
+        //    std::vector<MemHierarchy::MemEventBase *> * service_back; // used to pass ready requests back to the previous level
+        //    std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * service_back_size; // page_size of ready requests for next level up
+        //
 
-		int upper_link_latency; // This indicates the upper link latency
 
-		int max_outstanding; // indicates the number of maximum outstanding misses
-
-		int max_width; // indicates the number of maximum accesses on the same cycle
-
-		int parallel_mode; // very specific case for L1 PageTableWalker in case of overlapping with accessing the cache
+        // === Holds incoming requests, "input queue"
+        std::vector<MemHierarchy::MemEventBase *> not_serviced;
 
 		std::vector<MemHierarchy::MemEventBase *> * service_back; // This is used to pass ready requests back to the previous level
-
 		std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * service_back_size; // This is used to pass the size of the  requests back to the previous level
 
-		std::map<MemHierarchy::MemEventBase *, SST::Cycle_t, MemEventPtrCompare > ready_by; // this one is used to keep track of requests that are delayed inside this structure, compensating for latency
 
-		std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> ready_by_size; // this one is used to keep track of requests' sizes inside this structure
+        // === Holds requests that have gotten the data they need, but we need to wait the duration of the latency before returning
+        std::map<MemHierarchy::MemEventBase *, SST::Cycle_t, MemEventPtrCompare> ready_by; 
+        std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> ready_by_size; // keeps track of requests' sizes inside this structure
 
-		std::vector<MemHierarchy::MemEventBase *> pushed_back; // This is what we got returned from other structures
 
-		std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // This is the sizes of the translations we got returned from other structures
 
 		std::vector<MemHierarchy::MemEventBase *> pending_misses; // This the number of pending misses, only erased when pushed back from next level
 
-		std::vector<MemHierarchy::MemEventBase *> not_serviced; // This holds those accesses not serviced yet
 
 
-		int self_connected; // his parameter indidicates if the PTW is self-connected or actually connected to the memory hierarchy
+        //==== JVOROBY: these appear to be unused? There's no lower-level TLB below the PTW, so noone to push-back to us
+		// std::vector<MemHierarchy::MemEventBase *> pushed_back; // This is what we got returned from other structures
+		// std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // This is the sizes of the translations we got returned from other structures
 
-		int page_walk_latency; // this is really nothing than the page walk latency in case of having no walkers
 
-		long long int mmu_id=0;
 
 		SST::Cycle_t currTime;
 
@@ -215,8 +260,6 @@ namespace SST { namespace SambaComponent{
 
 		uint64_t *local_memory_size;
 
-		uint32_t ptw_confined;
-
 		// Does the translation and updating the statistics of miss/hit
 		Address_t translate(Address_t vadd);
 
@@ -229,32 +272,35 @@ namespace SST { namespace SambaComponent{
 
 		void setLineSize(uint64_t size) { line_size = size; }
 
-		// invalidate PTWC
-		void invalidate(Address_t vadd, int id);
 
-		// shootdown ack
-		void sendShootdownAck(int delay, int page_swapping_delay);
+        // ===== PTWC Methods
 
-		// Find if it exists
-		bool check_hit(Address_t vadd, int struct_id);
+		void invalidate(Address_t vadd, int id);  // invalidate PTWC
+		void sendShootdownAck(int delay, int page_swapping_delay);  // shootdown ack
+		bool check_hit(Address_t vadd, int struct_id);  // Find if it exists
+		int find_victim_way(Address_t vadd, int struct_id);  // To insert the translaiton
+		void update_lru(Address_t vaddr, int struct_id);
+		void insert_way(Address_t vaddr, int way, int struct_id);
 
-		// To insert the translaiton
-		int find_victim_way(Address_t vadd, int struct_id);
+        // ====== Wire-up methods
+        // (for parent obj to set out pointers to their versions of the objects)
 
 		void setServiceBack( std::vector<MemHierarchy::MemEventBase *> * x) { service_back = x;}
-
 		void setHold(int * tmp) { hold = tmp; }
-
-		void setShootDownEvents(int * sd, int *iva, std::vector<std::pair<Address_t, int> > * x) { shootdown = sd; hasInvalidAddrs = iva; invalid_addrs = x;}
+		void setShootDownEvents(int * sd, int *iva, std::vector<std::pair<Address_t, int> > * x) 
+                { shootdown = sd; hasInvalidAddrs = iva; invalid_addrs = x;}
 
 		void setPagePlacement(int *page_plac) { page_placement = page_plac; }
-
 		void setTimeStamp(uint64_t *time) { timeStamp = time; }
 
-		void setLocalMemorySize(uint64_t *mem_size) { local_memory_size = mem_size;
+		void setLocalMemorySize(uint64_t *mem_size) { 
+            local_memory_size = mem_size;
 			//std::cerr << " PTW local memory size: " << *local_memory_size << std::endl;
 		}
 
+        //=========
+
+        // JVOROBY: Unused??
 		void initaitePageMigration(Address_t vaddress, Address_t paddress);
 
 		void recvResp(SST::Event* event);
@@ -263,19 +309,33 @@ namespace SST { namespace SambaComponent{
 
 		void setServiceBackSize( std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * x) { service_back_size = x;}
 
-		std::vector<MemHierarchy::MemEventBase *> * getPushedBack(){return & pushed_back;}
 
-		std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * getPushedBackSize(){return & pushed_back_size;}
+        //==== JVOROBY: these appear to be unused? There's no lower-level TLB below the PTW, so noone to push-back to us
+		//std::vector<MemHierarchy::MemEventBase *> * getPushedBack(){return & pushed_back;}
+		//std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * getPushedBackSize(){return & pushed_back_size;}
 
-		std::map<long long int, int> WSR_COUNT;
+
+        //===== Memory-request tracking structs
+        // Misses in PTWC generate mem events to actually query mem for the translations,
+        // which 
+        //
+
+        //Autoincrementing ID, used to index events held in the `WSR_` and `WID_` maps
+		long long int mmu_id=0;
+
+        // For a given page-walk memory request:
+		std::map<long long int, int> WSR_PT_LEVEL; // what level of the PT does it refer to (0 = PTE, 3 = PGD)
 		std::map<long long int, bool> WSR_READY;
 
 		std::map<long long int, Address_t> WID_Add;
-
 		std::map<long long int, MemHierarchy::MemEventBase*> WID_EV;
+
+        // Each Walk request generates a MemEvent that is sent out;
+        // This maps `memevent->getID()` to the corresponding `mmu_id`  used in the WSR_ and WID_ objects
 		std::map<id_type, long long int> MEM_REQ;
 
-		void update_lru(Address_t vaddr, int struct_id);
+        //=== Etc
+
 
 
 		Statistic<uint64_t>* statPageTableWalkerHits;
@@ -287,7 +347,6 @@ namespace SST { namespace SambaComponent{
 		int getHits(){return hits;}
 		int getMisses(){return misses;}
 
-		void insert_way(Address_t vaddr, int way, int struct_id);
 
 		// This one is to push a request to this structure
 		void push_request(MemHierarchy::MemEventBase * x) {not_serviced.push_back(x);}

--- a/src/sst/elements/Samba/Samba.h
+++ b/src/sst/elements/Samba/Samba.h
@@ -85,7 +85,8 @@ namespace SST {
                     {"parallel_mode_L%(levels)d", "this is for the corner case of having a one cycle overlap with accessing cache","0"},
                     {"page_walk_latency", "Each page table walk latency in nanoseconds", "50"},
                     {"self_connected", "Determines if the page walkers are acutally connected to memory hierarchy or just add fixed latency (self-connected)", "0"},
-                    {"emulate_faults", "This indicates if the page faults should be emulated through requesting pages from page fault handler", "0"}
+                    {"emulate_faults", "This indicates if the page faults should be emulated through requesting pages from page fault handler", "0"},
+                    {"verbose", "(uint) Output verbosity for warnings/errors. 0[fatal error only], 1[warnings], 2[full state dump on fatal error]","0"},
                 )
 
                 SST_ELI_DOCUMENT_PORTS(

--- a/src/sst/elements/Samba/SimpleTLB.cc
+++ b/src/sst/elements/Samba/SimpleTLB.cc
@@ -296,7 +296,11 @@ Addr SimpleTLB::translatePage(Addr virtPageAddr) {
     //TODO: send proper page fault here once implmemented
     //TODO: check MemEvent size?
     if(virtPageAddr < fixed_mapping_va_start || virtPageAddr >= fixed_mapping_va_start + fixed_mapping_len) {
-        out->fatal(CALL_INFO, -1, "Page fault: virtual addr 0x%lx is outside of mapped range: 0x%lx - 0x%lx\n", virtPageAddr, fixed_mapping_va_start, fixed_mapping_va_start + fixed_mapping_len-1);
+        ////Option 1: anything not explicitly mapped is page fault
+        //out->fatal(CALL_INFO, -1, "Page fault: virtual addr 0x%lx is outside of mapped range: 0x%lx - 0x%lx\n", virtPageAddr, fixed_mapping_va_start, fixed_mapping_va_start + fixed_mapping_len-1);
+        
+        ////Option 2: all other addresses get mapped to themselves (might be useful for e.g. faking multiprocess)
+        return virtPageAddr;
     }
 
 

--- a/src/sst/elements/Samba/SimpleTLB.cc
+++ b/src/sst/elements/Samba/SimpleTLB.cc
@@ -1,0 +1,313 @@
+// Copyright 2009-2021 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2021, NTESS
+// All rights reserved.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
+//
+
+/* Author: Janet Vorobyeva
+ * E-mail: jvoroby@sandia.gov
+ */
+
+
+
+#include <sst_config.h>
+#include "SimpleTLB.h"
+
+//#include <string>
+
+using namespace SST::Interfaces;
+using namespace SST;
+using namespace SST::SambaComponent;
+
+#include <sst/elements/memHierarchy/memEventBase.h>
+#include <sst/elements/memHierarchy/memEvent.h>
+using SST::MemHierarchy::MemEventBase;
+using SST::MemHierarchy::MemEvent;
+using SST::MemHierarchy::Addr;
+#include <sst/elements/memHierarchy/util.h>
+
+
+// VERBOSITIES (using definitions from memHierarchy/util.h
+#define _L1_  CALL_INFO,1,0   //INFO  (this one isnt in util.h for some reason)
+// #define _L2_  CALL_INFO,2,0   //warnings
+// #define _L3_  CALL_INFO,3,0   //external events
+// #define _L5_  CALL_INFO,5,0   //internal transitions
+// #define _L10_  CALL_INFO,10,0 //everything
+
+#define BOTTOM_N_BITS(N) ((~0UL) >> (64-(N)))
+#define PAGE_OFFSET_4K(ADDR) ((ADDR) & BOTTOM_N_BITS(12))
+
+
+
+SimpleTLB::SimpleTLB(SST::ComponentId_t id, SST::Params& params): Component(id) {
+
+    int verbosity = params.find<int>("verbose", 1);
+    //TODO: what is @f, @l, @p
+    //out = new SST::Output("SimpleTLB[@f:@l:@p] ", verbosity, 0, SST::Output::STDOUT);
+    out = new SST::Output("SimpleTLB[@f:@l:@p] ", verbosity, 0, SST::Output::STDOUT);
+    out->verbose(_L1_, "Creating SimpleTLB component...\n");
+
+	//int page_walk_latency = ((uint32_t) params.find<uint32_t>("page_walk_latency", 50));
+
+	int64_t simple_translation_offset_addr = params.find<int64_t>("offset_addr", 0);
+	if (simple_translation_offset_addr != 0) {
+        out->verbose(_L1_, "Creating SimpleTLB component...\n");
+    }
+
+
+    // ============== Parse fixed mapping params
+	fixed_mapping_va_start = params.find<Addr>("fixed_mapping_va_start", -1);
+	fixed_mapping_pa_start = params.find<Addr>("fixed_mapping_pa_start", -1);
+
+
+    //do unit nonsense for 'fixed_mapping_len'
+    //TODO: put this logic in its own function
+	std::string fixed_mapping_len_str =  params.find<std::string>("fixed_mapping_len", "0KiB");
+    //pass through fixByteUnits to change MB to MiB (and so on), need powers of 2
+    SST::MemHierarchy::fixByteUnits(fixed_mapping_len_str); //turn 'MB' to 'MiB'
+	UnitAlgebra fixed_mapping_len_ua = UnitAlgebra(fixed_mapping_len_str); //parse it
+
+    fixed_mapping_len = fixed_mapping_len_ua.getRoundedValue(); //extract int val
+    
+    //NOTE: printed string wont be accurate since we modified it in-place for fixByteUnits
+    if (!fixed_mapping_len_ua.hasUnits("") && !fixed_mapping_len_ua.hasUnits("B")) {
+        out->fatal(CALL_INFO, -1, "Invalid param: fixed_mapping_len - must have units of bytes (B). " 
+                                    "Ex: '8B', '40MB'; You entered: '%s'", fixed_mapping_len_str.c_str());
+    }
+
+
+
+    // if len == 0, mapping is disabled. Else: enable and sanity-check
+	if (fixed_mapping_len != 0) {
+        if(PAGE_OFFSET_4K(fixed_mapping_va_start) != 0)
+            { out->fatal(CALL_INFO, -1, "Error! 'fixed_mapping_va_start' not 4k aligned in %s. Got value '0x%lx'\n", 
+                    getName().c_str(), fixed_mapping_va_start); }
+        if(PAGE_OFFSET_4K(fixed_mapping_pa_start) != 0)
+            { out->fatal(CALL_INFO, -1, "Error! 'fixed_mapping_pa_start' not 4k aligned in %s. Got value '0x%lx'\n", 
+                    getName().c_str(), fixed_mapping_pa_start); }
+        if(PAGE_OFFSET_4K(fixed_mapping_len) != 0)
+            { out->fatal(CALL_INFO, -1, "Error! 'fixed_mapping_len' not 4k aligned in %s. Got value: '0x%lx'\n", 
+                    getName().c_str(), fixed_mapping_len); }
+
+        if(fixed_mapping_len < 0) {
+            out->fatal(CALL_INFO, -1, "Error! 'fixed_mapping_len' must not be negative in %s\n", getName().c_str());
+        }
+
+        out->verbose(_L1_, "Setting SimpleTLB with fixed mapping: %ldKB region at VA:0x%lx-0x%lx maps to PA:0x%lx\n",
+                        fixed_mapping_len / 1024, fixed_mapping_va_start, 
+                        fixed_mapping_va_start+fixed_mapping_len-1, fixed_mapping_pa_start);
+    }
+
+
+	//mmu_to_cache = (SST::Link **) malloc( sizeof(SST::Link *) * core_count );
+
+    //event_link = configureSelfLink(link_buffer, "1ns", new Event::Handler<PageTableWalker>(TLB[i]->getPTW(), &PageTableWalker::handleEvent));
+
+    // configure our link with a callback function that will be called whenever an event arrives
+    // Callback function gets true for link_low
+    link_high = configureLink("high_network", new Event::Handler<SimpleTLB, bool>(this, &SimpleTLB::handleEvent, false));
+    link_low = configureLink("low_network", new Event::Handler<SimpleTLB, bool>(this, &SimpleTLB::handleEvent, true));
+
+    // Failure usually means the user didn't connect the port in the input file
+    sst_assert(link_low, CALL_INFO, -1, "Error in %s: Link configuration failed\n", getName().c_str());
+    sst_assert(link_high, CALL_INFO, -1, "Error in %s: Link configuration failed\n", getName().c_str());
+
+
+
+
+
+	std::string cpu_clock = params.find<std::string>("clock", "1GHz");
+	registerClock( cpu_clock, new Clock::Handler<SimpleTLB>(this, &SimpleTLB::clockTick ) );
+
+
+}
+
+SimpleTLB::~SimpleTLB() {
+    delete out;
+}
+
+
+
+void SimpleTLB::init(unsigned int phase) {
+	// Pass-through init events between CPU and Memory/Caches
+
+    out->verbose(_L2_, "SimpleTLB::init() called\n");
+
+    SST::Event * ev;
+    while ((ev = link_high->recvInitData())) { //incoming from CPU, forward down
+        link_low->sendInitData(ev);
+    }
+
+    while ((ev = link_low->recvInitData())) { //incoming from mem/caches, forward up
+        link_high->sendInitData(ev);
+    }
+
+    /*  // == CODE COPIED FROM SAMBA: to snoop on cache-line size from mem init events
+     *
+        // snoop on requests coming up from from mem
+        SST::MemHierarchy::MemEventInit * mEv = dynamic_cast<SST::MemHierarchy::MemEventInit*>(ev);
+        if (mEv && mEv->getInitCmd() == SST::MemHierarchy::MemEventInit::InitCommand::Coherence) {
+            SST::MemHierarchy::MemEventInitCoherence * mEvC = static_cast<SST::MemHierarchy::MemEventInitCoherence*>(mEv);
+            TLB[i]->setLineSize(mEvC->getLineSize());
+    }
+    */
+}
+
+void SimpleTLB::handleEvent(SST::Event *ev, bool is_low) {
+    // We high and low links share event handlers
+
+    MemEventBase* m_event_base = dynamic_cast<MemEventBase*>(ev);
+
+    if (!m_event_base) {
+        out->fatal(CALL_INFO, -1, "Error! Bad Event Type received by %s!\n", getName().c_str());
+        return;
+    }
+
+
+
+    out->verbose(_L3_, "Got MemEventBase: %s\n", m_event_base->getVerboseString().c_str());
+
+    if (is_low) { //event from cache going back up, just forward it
+        out->verbose(_L3_, "Got mem event in SimpleTLB, forwarding to link_high\n");
+        link_high->send(m_event_base);
+
+
+
+
+    } else { //event going down from cpu
+        MemEvent* m_event = dynamic_cast<MemEvent*>(ev);
+
+
+        if (!m_event) {
+            out->verbose(_L5_, "Sending down memevent in SimpleTLB, not MemEvent, just forwarding to link_low\n");
+            link_low->send(ev);
+
+        } else { //Able to cast to a MemEvent
+            MemEvent *translated_m_event = translateMemEvent(m_event);
+
+            out->verbose(_L5_, "Sending down translated MemEvent in SimpleTLB to link_low\n");
+
+            delete m_event;
+            link_low->send(translated_m_event);
+
+            //out->verbose(_L3_, "Sending down memevent in SimpleTLB, vAddr 0x%lx, translating to 0x%lx, translating and forwarding to link_low\n", vAddr, transAddr);
+
+        }
+
+    }
+
+    // Receiver has the responsiblity for deleting events
+    // don't delete it since we're forwarding it
+    //delete mEvent;
+}
+
+
+
+// void SimpleTLB::init(unsigned int phase) {
+//     out->verbose(CALL_INFO, 1, 0, "Calling SimpleTLB init...\n");
+//
+// }
+
+
+bool SimpleTLB::clockTick(SST::Cycle_t x)
+{
+    //debug output first few times
+    static int debug_print_i = 0;
+    if (debug_print_i < 20) {
+        out->verbose(_L10_, "Calling SimpleTLB tick on cycle %ld...\n", x);
+        debug_print_i++;
+    }
+
+	// We tick the MMU hierarchy of each core
+	//for(uint32_t i = 0; i < core_count; ++i)
+		//TLB[i]->tick(x);
+
+
+    // return false to indicate clock handler shouldn't be disabled
+	return false;
+}
+
+
+
+// ========================== THE MEAT AND POTATOES =======================
+
+MemEvent* SimpleTLB::translateMemEvent(MemEvent *mEv) {
+    //TODO: this will eventually have to be async, returning some sort of status handle on a miss
+    //Creates translated copy of mEv
+    //does not delete mEv
+
+    Addr vAddr    = mEv->getVirtualAddress();
+    Addr mainAddr = mEv->getAddr();
+    Addr baseAddr = mEv->getBaseAddr();
+
+    if(vAddr != mainAddr) {
+        out->verbose(_L2_, "Unexpected: MemEvent's vAddr and Addr differ: %s\n", mEv->getVerboseString().c_str() );
+    }
+
+    Addr vPage =      mainAddr & ~BOTTOM_N_BITS(12);
+    Addr pageOffset = mainAddr &  BOTTOM_N_BITS(12);
+
+    // we'll need this to recreate translated base addr
+    int64_t cacheline_offset = mainAddr - baseAddr;
+
+
+    //======== Do the translation
+    //TODO: this will eventually have to be async, returning some sort of status handle on a miss
+    //
+    Addr pPage = translatePage(vPage); //offset by 1MiB, 0x10'0000
+
+
+
+    //======== Cleanup and return
+
+    //Stitch together result
+    Addr pAddr = pPage | pageOffset;
+    Addr pBaseAddr = pAddr - cacheline_offset;
+
+
+    MemEvent *new_mEv = mEv->clone();
+    new_mEv->setAddr(pAddr);
+    new_mEv->setBaseAddr(pBaseAddr);
+
+    //out->verbose(_L10_, "Orig. MemEvent  : %s\n", mEv->getVerboseString().c_str());
+    out->verbose(_L10_, "Transl. MemEvent: %s\n", new_mEv->getVerboseString().c_str());
+
+
+    return new_mEv;
+}
+
+
+Addr SimpleTLB::translatePage(Addr virtPageAddr) {
+    //TODO: later this will have to be async
+    //TODO: return status on page fault, stall
+
+    if(fixed_mapping_len == 0) { // If mapping disabled, just keep same addrs
+        return virtPageAddr;
+    }
+
+    //Else, we have a proper mapping
+    //check bounds
+    //TODO: send proper page fault here once implmemented
+    //TODO: check MemEvent size?
+    if(virtPageAddr < fixed_mapping_va_start || virtPageAddr >= fixed_mapping_va_start + fixed_mapping_len) {
+        out->fatal(CALL_INFO, -1, "Page fault: virtual addr 0x%lx is outside of mapped range: 0x%lx - 0x%lx\n", virtPageAddr, fixed_mapping_va_start, fixed_mapping_va_start + fixed_mapping_len-1);
+    }
+
+
+    // Add the VA->PA offset. This should work correctly whether
+    // PA or VA are > or <, since everything is uint64_t
+    Addr pPageAddr = virtPageAddr + (fixed_mapping_pa_start - fixed_mapping_va_start);
+
+    //Addr pPage = virtPageAddr + SST::MemHierarchy::mebi; //offset by 1MiB, 0x10'0000
+    //Addr pPage = vPage + 0x400; //offset by 1KB
+
+    assert((pPageAddr & BOTTOM_N_BITS(12)) == 0); //we should have enforced this by the time we get here
+
+    return pPageAddr;
+}

--- a/src/sst/elements/Samba/SimpleTLB.h
+++ b/src/sst/elements/Samba/SimpleTLB.h
@@ -1,0 +1,161 @@
+#ifndef SIMPLETLB_H
+#define SIMPLETLB_H
+
+#include <sst/core/sst_types.h>
+#include <sst/core/event.h>
+#include <sst/core/component.h>
+#include <sst/core/link.h>
+#include <sst/core/timeConverter.h>
+#include <sst/core/interfaces/simpleMem.h>
+// 
+// #include <sst/core/output.h>
+
+// #include <cstring>
+// #include <string>
+// #include <fstream>
+// #include <sstream>
+// #include <map>
+// 
+// #include <stdio.h>
+// #include <stdint.h>
+// #include <poll.h>
+// 
+// #include "TLBhierarchy.h"
+// #include "PageTableWalker.h"
+// #include "PageFaultHandler.h"
+
+#include <sst/elements/memHierarchy/memEventBase.h>
+#include <sst/elements/memHierarchy/memEvent.h>
+#include <sst/elements/memHierarchy/util.h>
+
+using namespace std;
+
+namespace SST {
+    namespace SambaComponent {
+
+        class SimpleTLB : public SST::Component {
+            public:
+
+                // REGISTER THIS COMPONENT INTO THE ELEMENT LIBRARY                                               
+                SST_ELI_REGISTER_COMPONENT(                                                                       
+                    SimpleTLB,                           // Component class                                        
+                    "Samba",             // Component library (for Python/library lookup)          
+                    "SimpleTLB",                         // Component name (for Python/library lookup)             
+                    SST_ELI_ELEMENT_VERSION(1,0,0),     // Version of the component (not related to SST version)  
+                    "Simple TLB Component",     // Description                                            
+                    COMPONENT_CATEGORY_UNCATEGORIZED    // Category                                               
+                )                                                                                                 
+
+
+                SST_ELI_DOCUMENT_STATISTICS(
+                    { "tlb_hits",        "Number of TLB hits", "requests", 1},   // Name, Desc, Enable Level
+                    { "tlb_misses",      "Number of TLB misses", "requests", 1},   // Name, Desc, Enable Level
+                    // { "total_waiting",   "The total waiting time", "cycles", 1},   // Name, Desc, Enable Level
+                    // { "write_requests",  "Stat write_requests", "requests", 1},
+                    // { "tlb_shootdown",   "Number of TLB clears because of page-frees", "shootdowns", 2 },
+                    // { "tlb_page_allocs", "Number of pages allocated by the memory manager", "pages", 2 }
+                )
+
+                SST_ELI_DOCUMENT_PARAMS(
+                    {"verbose", "(uint) Output verbosity for warnings/errors. 0[fatal error only], 1[warnings], 2[full state dump on fatal error]","1"},
+
+                    {"fixed_mapping_va_start", "Translate only this region of virt. addresses. 4kb-aligned", "0xFFFFFFFF_FFFFFFFF"},
+                    {"fixed_mapping_pa_start", "Translate to this region of phys. addresses. 4kb-aligned", "0xFFFFFFFF_FFFFFFFF"},
+                    {"fixed_mapping_len",      "Size in bytes of region to translate. (4kb-aligned)", "0KiB"},
+
+                    // {"corecount", "Number of CPU cores to emulate, i.e., number of private Sambas", "1"},
+                    // {"levels", "Number of TLB levels per Samba", "1"},
+                    // {"perfect", "This is set to 1, when modeling an ideal TLB hierachy with 100\% hit rate", "0"},
+                    // {"os_page_size", "This represents the size of frames the OS allocates in KB", "4"}, // This is a hack, assuming the OS allocated only one page size, this will change later
+                    // {"sizes_L%(levels)", "Number of page sizes supported by Samba", "1"},
+                    // {"page_size%(sizes)_L%(levels)d", "the page size of the supported page size number x in level y","4"},
+                    // {"max_outstanding_L%(levels)d", "the number of max outstanding misses","1"},
+                    // {"max_width_L%(levels)d", "the number of accesses on the same cycle","1"},
+                    // {"size%(sizes)_L%(levels)d", "the number of entries of page size number x on level y","1"},
+                    // {"upper_link_L%(levels)d", "the latency of the upper link connects to this structure","0"},
+                    // {"assoc%(sizes)_L%(levels)d", "the associativity of size number X in Level Y", "1"},
+                    // {"clock", "the clock frequency", "1GHz"},
+                    // {"latency_L%(levels)d", "the access latency in cycles for this level of memory","1"},
+                    // {"parallel_mode_L%(levels)d", "this is for the corner case of having a one cycle overlap with accessing cache","0"},
+                    // {"page_walk_latency", "Each page table walk latency in nanoseconds", "50"},
+                    // {"self_connected", "Determines if the page walkers are acutally connected to memory hierarchy or just add fixed latency (self-connected)", "0"},
+                    // {"emulate_faults", "This indicates if the page faults should be emulated through requesting pages from page fault handler", "0"},
+                )
+
+                // {"Port name", "Description", { "list of event types that the port can handle"} }  
+                SST_ELI_DOCUMENT_PORTS(
+                    {"high_network", "Link to cpu", {"MemHierarchy.MemEventBase"}},
+                    {"low_network", "Link toward caches", {"MemHierarchy.MemEventBase"}},
+
+
+                    //{"cpu_to_mmu%(corecount)d", "Each Samba has link to its core", {}},
+                    //{"mmu_to_cache%(corecount)d", "Each Samba to its corresponding cache", {}},
+                    //{"ptw_to_mem%(corecount)d", "Each TLB hierarchy has a link to the memory for page walking", {}},
+                    //{"alloc_link_%(corecount)d", "Each core's link to an allocation tracker (e.g. memSieve)", {}}
+
+                    //{"port",  "Link to another component", { "simpleElementExample.basicEvent", ""} }
+
+                )
+
+
+
+                // Constructor. Components receive a unique ID and the set of parameters that were assigned in the Python input.
+                SimpleTLB(SST::ComponentId_t id, SST::Params& params);
+                ~SimpleTLB();
+
+
+                // Event handler, called when an event is received on high or low link
+                void handleEvent(SST::Event *ev, bool is_low);
+                                                                                
+                // Clock handler, called on each clock cycle                    
+                virtual bool clockTick(SST::Cycle_t);                            
+                                                                                
+                // Init?? Called by someone?? Used to pass mem/cache init events back and forth
+				void init(unsigned int phase);
+                                                                                
+                // Statistic                                                    
+                //Statistic<uint64_t>* bytesReceived;                             
+                Statistic<uint64_t>* statReadRequests; //NOT IMPLEMENTED
+                                                                                
+                                                                                
+                                                                                
+
+
+
+
+            private:
+                // SST Output object, for printing, error messages, etc.        
+                SST::Output* out;                                               
+
+                // Links                                                        
+                SST::Link* link_high;  // to cpu
+                SST::Link* link_low;  // to cpu
+
+                //Params for fixed-region translation (For quick-and-dirty virtual memory)
+                uint64_t                fixed_mapping_len; // fixed mapping is active and values are validated iff (len != 0)
+                SST::MemHierarchy::Addr fixed_mapping_va_start;
+                SST::MemHierarchy::Addr fixed_mapping_pa_start;
+
+                //Transates mEv, returns new m_ev
+                //TODO: this will need to return either the result, or some sort of stall-handle in case of a TLB miss
+                SST::MemHierarchy::MemEvent* translateMemEvent(SST::MemHierarchy::MemEvent *mEv);
+
+                SST::MemHierarchy::Addr translatePage(SST::MemHierarchy::Addr virtPageAddr);
+
+                //SST::Link * event_link; // Note that this is a self-link for events
+                //SST::Link ** cpu_to_mmu;
+                //SST::Link ** mmu_to_cache;
+                //SST::Link ** ptw_to_mem;
+
+
+
+                //SST::Link** Samba_link;
+
+
+
+        };
+
+    }
+}
+
+#endif /* SIMPLETLB_H */

--- a/src/sst/elements/Samba/TLBUnit.cc
+++ b/src/sst/elements/Samba/TLBUnit.cc
@@ -55,9 +55,10 @@ TLB::TLB(ComponentId_t id, int tlb_id, TLB * Next_level, int Level, SST::Params&
 
 	std::string LEVEL = std::to_string(level);
 
+
+    // === Init params
+
 	std::string cpu_clock = params.find<std::string>("clock", "1GHz");
-
-
 
 	page_walk_latency = ((uint32_t) params.find<uint32_t>("page_walk_latency", 50));
 
@@ -67,83 +68,89 @@ TLB::TLB(ComponentId_t id, int tlb_id, TLB * Next_level, int Level, SST::Params&
 
 	latency = ((uint32_t) params.find<uint32_t>("latency_L"+LEVEL, 1));
 
-	// This indicates the number of page sizes supported for this level
+	// number of page sizes supported for this level (i.e. 4kb, or also 2MB & 1GB)
 	sizes = ((uint32_t) params.find<uint32_t>("sizes_L"+LEVEL, 1));
 
 	parallel_mode = ((uint32_t) params.find<uint32_t>("parallel_mode_L"+LEVEL, 0));
 
 	upper_link_latency = ((uint32_t) params.find<uint32_t>("upper_link_L"+LEVEL, 0));
 
-
-	char* subID = (char*) malloc(sizeof(char) * 32);
-	sprintf(subID, "Core%d_L%d", tlb_id,level);
-
-
-	// The stats that will appear, not that these stats are going to be part of the Samba unit
-	statTLBHits = registerStatistic<uint64_t>( "tlb_hits", subID);
-	statTLBMisses = registerStatistic<uint64_t>( "tlb_misses", subID );
-	statTLBShootdowns = registerStatistic<uint64_t>( "tlb_shootdown", subID );
-
 	max_width = ((uint32_t) params.find<uint32_t>("max_width_L"+LEVEL, 4));
-
 
 	perfect = ((uint32_t) params.find<uint32_t>("perfect", 0));
 
 	os_page_size = ((uint32_t) params.find<uint32_t>("os_page_size", 4));
 
+
+    // === Init statistics
+
+	char* subID = (char*) malloc(sizeof(char) * 32);
+	sprintf(subID, "Core%d_L%d", tlb_id,level);
+
+	// The stats that will appear, not that these stats are going to be part of the Samba unit
+	statTLBHits =       registerStatistic<uint64_t>( "tlb_hits",      subID);
+	statTLBMisses =     registerStatistic<uint64_t>( "tlb_misses",    subID );
+	statTLBShootdowns = registerStatistic<uint64_t>( "tlb_shootdown", subID );
+
+    free(subID);
+
+
+    // === Init Counters
+    
+	hits=misses=0;
+
+
+    // === Per page-size params =======================================
+    
+    
+    // params
 	size = new int[sizes];
 	assoc = new int[sizes];
 	page_size = new uint64_t[sizes];
 	sets = new int[sizes];
-	tags = new Address_t**[sizes];
+
+    // data arrays `foo[page_sizes][set][way]`
+	tags  = new Address_t**[sizes];
 	valid = new bool**[sizes];
-	lru = new int **[sizes];
+	lru   = new int **[sizes];
 
-
+    //Loop over each supported page size, getting params
 	for(int i=0; i < sizes; i++)
 	{
 
 		size[i] =  ((uint32_t) params.find<uint32_t>("size"+std::to_string(i+1) + "_L"+LEVEL, 1));
-
-
 		assoc[i] =  ((uint32_t) params.find<uint32_t>("assoc"+std::to_string(i+1) +  "_L"+LEVEL, 1));
-
-
 		page_size[i] = 1024 * ((uint64_t) params.find<uint64_t>("page_size"+ std::to_string(i+1) + "_L" + LEVEL, 4));
 
 
 		// Here we add the supported page size and the structure index
 		SIZE_LOOKUP[page_size[i]/1024]=i;
 
-
 		// We define the number of sets for that structure of page size number i
 		sets[i] = size[i]/assoc[i];
 
 	}
 
-	hits=misses=0;
 
-
-
+    //Loop over each supported page size, initializing subarrays for tags/valid/lru
 	for(int id=0; id< sizes; id++)
 	{
 
-		tags[id] = new Address_t*[sets[id]];
-
+		tags[id]  = new Address_t*[sets[id]];
 		valid[id] = new bool*[sets[id]];
-
-		lru[id] = new int*[sets[id]];
+		lru[id]   = new int*[sets[id]];
 
 		for(int i=0; i < sets[id]; i++)
 		{
-			tags[id][i]=new Address_t[assoc[id]];
-			valid[id][i]=new bool[assoc[id]];
-			lru[id][i]=new int[assoc[id]];
+			tags[id][i]  = new Address_t[assoc[id]];
+			valid[id][i] = new bool[assoc[id]];
+			lru[id][i]   = new int[assoc[id]];
+
 			for(int j=0; j<assoc[id];j++)
 			{
-				tags[id][i][j]=-1;
-				valid[id][i][j]=true;
-				lru[id][i][j]=j;
+				tags [id][i][j] = -1;
+				valid[id][i][j] = true;
+				lru  [id][i][j] = j;
 			}
 		}
 
@@ -161,7 +168,8 @@ void TLB::setPTW(PageTableWalker * Next_level) {
     PTW=Next_level;
 }
 
-// This is the most important function, which works like the heart of the TLBUnit, called on every cycle to check if any completed requests or new requests at this cycle.
+// This is the most important function, which works like the heart of the TLBUnit, 
+// called on every cycle to check if any completed requests or new requests at this cycle.
 bool TLB::tick(SST::Cycle_t x)
 {
 
@@ -171,13 +179,14 @@ bool TLB::tick(SST::Cycle_t x)
 	{
 
 
-            MemHierarchy::MemEventBase * ev = pushed_back.back();
+        MemHierarchy::MemEventBase * ev = pushed_back.back();
 
 		Address_t addr = ((MemEvent*) ev)->getVirtualAddress();
 
 
 		// Double checking that we actually still don't have it inserted
-		// Insert the translation into all structures with same or smaller size page support. Note that smaller page sizes will still have the same translation with offset derived from address
+		// Insert the translation into all structures with same or smaller size page support. 
+        // Note that smaller page sizes will still have the same translation with offset derived from address
 		std::map<long long int, int>::iterator lu_st, lu_en;
 		lu_st=SIZE_LOOKUP.begin();
 		lu_en=SIZE_LOOKUP.end();
@@ -212,7 +221,8 @@ bool TLB::tick(SST::Cycle_t x)
 			st++;
 		}
 
-		// Note that here we are sustitiuing for latency of checking the tag before proceeing to the next level, we also add the upper link latency for the round trip
+		// Note that here we are substituting for latency of checking the tag before proceeding 
+        // to the next level, we also add the upper link latency for the round trip
 		ready_by[ev]= x + latency + 2*upper_link_latency;
 
 		// We also track the size of tthe ready request
@@ -244,14 +254,15 @@ bool TLB::tick(SST::Cycle_t x)
 
 
 
-	// The actual dipatching process... here we take a request and place it in the right queue based on being miss or hit and the number of pending misses
+	// The actual dispatching process... here we take a request and place it 
+    // in the right queue based on being miss or hit and the number of pending misses
 	std::vector<MemHierarchy::MemEventBase*>::iterator st_1,en_1;
 	st_1 = not_serviced.begin();
 	en_1 = not_serviced.end();
 
 	int dispatched=0;
 
-	// Iteravte over the requests passed from higher levels
+	// Iterate over the requests passed from higher levels
 	for(;st_1!=not_serviced.end(); st_1++)
 	{
 		dispatched++;
@@ -260,7 +271,7 @@ bool TLB::tick(SST::Cycle_t x)
 		if(dispatched > max_width)
 			break;
 
-                MemHierarchy::MemEventBase * ev = *st_1;
+        MemHierarchy::MemEventBase * ev = *st_1;
 		Address_t addr = ((MemEvent*) ev)->getVirtualAddress();
 
 
@@ -277,7 +288,7 @@ bool TLB::tick(SST::Cycle_t x)
 				break;
 			}
 
-		// If it hist in any page size structure, we update the lru position of the translation and update statistics
+		// If it hits in any page size structure, we update the lru position of the translation and update statistics
 		if(hit)
 		{
 
@@ -330,7 +341,7 @@ bool TLB::tick(SST::Cycle_t x)
 						next_level->push_request(ev);
 						st_1 = not_serviced.erase(st_1);
 					}
-					else // Passs it to the page table walker
+					else // Pass it to the page table walker
 					{
 						PTW->push_request(ev);
 						st_1 = not_serviced.erase(st_1);

--- a/src/sst/elements/Samba/TLBUnit.h
+++ b/src/sst/elements/Samba/TLBUnit.h
@@ -37,69 +37,84 @@ class TLB : public ComponentExtension
 
 	int level; // This indicates the level of the TLB Unit
 
+    // === Params
 	int perfect; // This indidicates if the TLB is perfect or not, perfect is used to measure performance overhead over an ideal TLB hierarchy
+	int sizes; // number of pages sizes (i.e. 3 for 4kb+2MB+1GB) supported in this level of TLB
 
-	int sizes; // This indicates the number of sizes supported
+	int emulate_faults;     // If set, then page faults will send requests to page fault handler
+	int os_page_size;       // This is a hack for the size of the frames returned by the OS, by default
+	int latency;            // latency in cycles
+	int upper_link_latency; // upper link latency (in cycles?)
+	int max_outstanding;    // number of maximum outstanding misses
+	int max_width;          // number of maximum accesses on the same cycle
+	int parallel_mode;      // very specific case for L1 TLB in case of overlapping with accessing the cache
+	int page_walk_latency;  // this is really nothing other than the page walk latency in case of having no walkers
 
-	uint64_t * page_size; // By default, lets assume 4KB pages
+    // === Per page-type params (set separately for each separate type of huge-page of huge-pages)
+	uint64_t * page_size; // for each [pg-type], size of that page in bytes (so the standard 4k/2M/1G would be 1024 * [4,2048,1048576]
 
-	int * assoc; // This represents the associativiety
+	int * size;  // Number of TLB entries, indexed by [pg-type]
+	int * assoc; // associativity of entries, for     [pg-type]
+	int * sets;  // stores the number of sets, by     [pg-type]
 
-	Address_t *** tags; // This will hold the tags
+    // === Cache data for TLB entries
+    // - separate cache for each size of page
+    // - accessed as `tags[page_size][set][way]`
+	Address_t *** tags;
+	bool ***valid; // status of the tags
+	int *** lru;   // lru positions
 
-	bool ***valid; //This will hold the status of the tags
 
-	int *** lru; // This will hold the lru positions
+    // === Counters
+	int hits; // number of hits
+	int misses; // number of misses
 
+
+    // === Links to other levels
 	TLB * next_level; // a pointer to the next level Samba structure
-
 	PageTableWalker * PTW; // This is a pointer to the PTW in case of being last level
 
+
+    // === ???
 	std::map<long long int, int> SIZE_LOOKUP; // This structure checks if a size is supported inside the structure, and its index structure
 
 	std::map< Address_t, std::map< MemHierarchy::MemEventBase *, int, MemEventPtrCompare>> SAME_MISS; // This tracks the misses for the same location and deduplicates them
 	std::map<Address_t, int> PENDING_MISS; // This tracks the addresses of the current master misses (other contained misses are tracked in SAME_MISS)
 
-	int  * sets; //stores the number of sets
 
-	int* size; // Number of entries
+    //=======================================================================
+    //
+    //           BUFFERS FOR REQUESTS TRAVELLING UP AND DOWN TLBS
+    //
+    //=======================================================================
 
-	int hits; // number of hits
+    //  note: the _size buffers holds the size of the relevant page,
+    //  i.e 1 for 4k, 2 for 2M, 3 for 1GB (if using standard page sizes)
 
-	int misses; // number of misses
+    // === Holds incoming requests, "input queue"
+	std::vector<MemHierarchy::MemEventBase *> not_serviced;
 
-	int emulate_faults; // If set, then page faults will send requests to page fault handler
+    // === Holds a copy of requests that have missed in this level, and have been sent into the next level down.
+    //  events are erased when they are fulfilled, and returned into `this->pushed_back`
+	std::vector<MemHierarchy::MemEventBase *> pending_misses; 
 
-	int os_page_size; // This is a hack for the size of the frames returned by the OS, by default
-
-	int latency; // indicates the latency in cycles
-
-	int upper_link_latency; // This indicates the upper link latency
-
-	int max_outstanding; // indicates the number of maximum outstanding misses
-
-	int max_width; // indicates the number of maximum accesses on the same cycle
-
-	int parallel_mode; // very specific case for L1 TLB in case of overlapping with accessing the cache
-
-	std::vector<MemHierarchy::MemEventBase *> * service_back; // This is used to pass ready requests back to the previous level
-
-	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * service_back_size; // This is used to pass the size of the  requests back to the previous level
-
-	std::map<MemHierarchy::MemEventBase *, SST::Cycle_t, MemEventPtrCompare> ready_by; // this one is used to keep track of requests that are delayed inside this structure, compensating for latency
-
-	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> ready_by_size; // this one is used to keep track of requests' sizes inside this structure
-
-	std::vector<MemHierarchy::MemEventBase *> pushed_back; // This is what we got returned from other structures
-
-	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // This is the sizes of the translations we got returned from other structures
-
-	std::vector<MemHierarchy::MemEventBase *> pending_misses; // This the number of pending misses, only erased when pushed back from next level
-
-	std::vector<MemHierarchy::MemEventBase *> not_serviced; // This holds those accesses not serviced yet
+    // === Holds requests that have gotten the data they need, but we need to wait the duration of the latency before returning
+	std::map<MemHierarchy::MemEventBase *, SST::Cycle_t, MemEventPtrCompare> ready_by; 
+	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> ready_by_size; // keeps track of requests' sizes inside this structure
 
 
-	int page_walk_latency; // this is really nothing than the page walk latency in case of having no walkers
+    // === Buffers for sending requests up/down TLB hierarchy:
+    
+    // requests sent lower in TLB hierarchy, will be returned into `this->pushed_back` by lower levels
+	std::vector<MemHierarchy::MemEventBase *> pushed_back; // translation for requests, returned from lower-level structures
+	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // page_sizes of the returned translations
+
+    // when we're finished with a request, we send it back up the hierarchy by inserting into `service_back`
+    // - pointer is wired up to `pushed_back` buffers of the next level up at TLB in constructor of TLBHierarchy
+	std::vector<MemHierarchy::MemEventBase *> * service_back; // used to pass ready requests back to the previous level
+	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * service_back_size; // page_size of ready requests for next level up
+
+
 
 	public:
 
@@ -123,12 +138,13 @@ class TLB : public ComponentExtension
 	// To insert the translaiton
 	int find_victim_way(Address_t vadd, int struct_id);
 
+    // === Called by parent to wire up TLB levels to each other
+    // this TLB will push completed requests into service_back (sending them back up the levels towards core)
 	void setServiceBack( std::vector<MemHierarchy::MemEventBase *> * x) { service_back = x;}
-
 	void setServiceBackSize( std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * x) { service_back_size = x;}
 
+    // lower-levels will return answered requests into this->pushed_back
 	std::vector<MemHierarchy::MemEventBase *> * getPushedBack(){return & pushed_back;}
-
 	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> * getPushedBackSize(){return & pushed_back_size;}
 
 	void update_lru(Address_t vaddr, int struct_id);

--- a/src/sst/elements/Samba/TLBUnit.h
+++ b/src/sst/elements/Samba/TLBUnit.h
@@ -105,7 +105,9 @@ class TLB : public ComponentExtension
 
     // === Buffers for sending requests up/down TLB hierarchy:
     
-    // requests sent lower in TLB hierarchy, will be returned into `this->pushed_back` by lower levels
+    // When we miss, we send requests to next level down through `next_level->push_request()` or `PTW->push_request()`
+    
+    // completed requests from deeper in TLB hierarchy will be returned into `this->pushed_back`
 	std::vector<MemHierarchy::MemEventBase *> pushed_back; // translation for requests, returned from lower-level structures
 	std::map<MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> pushed_back_size; // page_sizes of the returned translations
 

--- a/src/sst/elements/Samba/TLBhierarchy.cc
+++ b/src/sst/elements/Samba/TLBhierarchy.cc
@@ -111,7 +111,7 @@ TLBhierarchy::TLBhierarchy(ComponentId_t id, int tlb_id, int Levels, Params& par
 	{
 		// Initiating all levels of this hierarcy
 		TLB_CACHE[levels] = loadComponentExtension<TLB>(coreID, nullptr, levels, params);
-	        TLB_CACHE[levels]->setPTW(PTW);
+	    TLB_CACHE[levels]->setPTW(PTW);
 		TLB * prev=TLB_CACHE[levels];
 		for(int level=levels-1; level >= 1; level--)
 		{

--- a/src/sst/elements/Samba/TLBhierarchy.h
+++ b/src/sst/elements/Samba/TLBhierarchy.h
@@ -47,87 +47,76 @@ namespace SST { namespace SambaComponent{
 	class TLBhierarchy : public ComponentExtension
 	{
 
-		// This keeps track of which core the TLB belongs to, here we assume typical private TLBs as in current x86 processor
-		int coreID;
-
-		// Which level, this can be any value starting from 0 for L1 and up to N, in an N+1 levels TLB system
-		int levels;
-
 		Output * output;
 
-		// If faults are emulated
-	    int emulate_faults;
+        // ==== Params
 
-	    // Enable page migration if Opal is used
-		int page_placement;
-
-	    int max_shootdown_width;
-
-		SST::Link * to_cache;
+		int coreID;  // This keeps track of which core the TLBhierarchy belongs to, 
+                     //     we assume typical private TLBs as in current x86 processor
+		int levels;  // number of TLB levels, 2 will make an L1 and L2
+		int latency; // The access latency in ns
 
 
-		SST::Link * to_cpu;
-
-		std::map<int, TLB *> TLB_CACHE; //1-indexed, TLB_CACHE[1] is L1 TLB
-
-		// Here is the defintion of the page table walker of the TLB hierarchy
-		PageTableWalker * PTW;
-
-
-		std::string clock_frequency_str;
-
-		// Holds the current time
-		SST::Cycle_t curr_time;
-
-		// This vector holds the current requests to be translated
-		std::vector<SST::MemHierarchy::MemEventBase *> mem_reqs;
-
-		// This tells TLB hierarchy to stall due to emulated page fault
-		int hold;
-
-		// This tells TLB hierarchy to invalidate all TLB entries due to TLB Shootdown from other cores
-		int shootdown;
-
+        //=== Params that only apply if emulate_faults is true
+	    int emulate_faults; // whether page faults are emulated
+        
+		int page_placement; // Enable page migration if Opal is used
 		int shootdown_delay;
-
 		int page_swapping_delay;
-
-		int hasInvalidAddrs;
-
-		// This vector holds the invalidation requests
-		std::vector<std::pair<Address_t, int> > invalid_addrs;
-
-		// This vector holds the current requests to be translated
-		std::map<SST::MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> mem_reqs_sizes;
-
-
-		// This mapping is used to track the time spent of translating each request
-		std::map<SST::Event *, uint64_t> time_tracker;
-		// The access latency in ns
-		int latency;
-
-		// This represents the maximum number of outstanding requests for this structure
-		int max_outstanding;
-
-		uint64_t timeStamp;
-
+	    int max_shootdown_width;
+		uint64_t memory_size;
 		uint32_t ptw_confined;
 
-		// Holds CR3 value of current context
+
+        // === Objects (links and child classes)
+		SST::Link * to_cache;
+		SST::Link * to_cpu;
+
+		std::map<int, TLB *> TLB_CACHE; // TLB objects for each level: 1-indexed, (i.e. TLB_CACHE[1] is L1 TLB)
+		PageTableWalker * PTW;          // page table walker of the TLB hierarchy
+
+
+		SST::Cycle_t curr_time; // Holds the current time
+
+
+        //==== Signals 
+        //- these will be set to 1 or 0 to change our behavior
+        //- pointers are passed to our children so they can set these
+        
+		int hold;       // tells TLB hierarchy to stall due to emulated page fault
+		int shootdown;  // tells TLB hierarchy to invalidate all TLB entries due to TLB Shootdown from other cores
+
+        // Referenced by pageTableWalker using pointer passing?
+		int hasInvalidAddrs;
+
+        //passed to pagetablewalker?? not used???
+		uint64_t timeStamp;
+
+
+        //======== Event buffers?
+
+		std::vector<SST::MemHierarchy::MemEventBase *> mem_reqs; // holds the current requests to be translated
+
+		std::vector<std::pair<Address_t, int> > invalid_addrs;  // holds the invalidation requests
+		std::map<SST::MemHierarchy::MemEventBase *, long long int, MemEventPtrCompare> mem_reqs_sizes;
+                                                        // holds the current requests to be translated
+		std::map<SST::Event *, uint64_t> time_tracker;   // used to track time spent on translating each request
+		
+		// This represents the maximum number of outstanding requests for this structure
+		//int max_outstanding; //TODO: TEMP JVOROBY 2021.11: i think this is unused? will try to rebuild without it
+
+
+        //======= Page table stuff:
+
+		// Holds CR3 value of current context (i.e. base of page table)
 		Address_t *CR3;
-		//
-		// Holds the PGD physical pointers, the key is the 9 bits 39-47, i.e., VA/(4096*512*512*512)
-		std::map<Address_t, Address_t> * PGD;
 
-		// Holds the PUD physical pointers, the key is the 9 bits 30-38, i.e., VA/(4096*512*512)
-		std::map<Address_t, Address_t> * PUD;
-
-		// Holds the PMD physical pointers, the key is the 9 bits 21-29, i.e., VA/(4096*512)
-		std::map<Address_t, Address_t> * PMD;
-
-		// Holds the PTE physical pointers, the key is the 9 bits 12-20, i.e., VA/(4096)
-		std::map<Address_t, Address_t> * PTE; // This should give you the exact physical address of the page
-
+		// Holds the PGD, PUD, PMT, PTE physical pointers
+		std::map<Address_t, Address_t> * PGD; // key is 9 bits 39-47, i.e., VA/(4096*512*512*512)
+		std::map<Address_t, Address_t> * PUD; // key is 9 bits 30-38, i.e., VA/(4096*512*512)
+		std::map<Address_t, Address_t> * PMD; // key is 9 bits 21-29, i.e., VA/(4096*512)
+		std::map<Address_t, Address_t> * PTE; // key is 9 bits 12-20, i.e., VA/(4096)         
+                                              // PTE should give you the exact physical address of the page
 
 		// The structures below are used to quickly check if the page is mapped or not
 		std::map<Address_t,int> * MAPPED_PAGE_SIZE4KB;
@@ -141,7 +130,6 @@ namespace SST { namespace SambaComponent{
 		std::map<Address_t,int> *PENDING_PAGE_FAULTS_PTE;
 		std::map<Address_t,int> *PENDING_SHOOTDOWN_EVENTS;
 
-		uint64_t memory_size;
 
 		public:
 

--- a/src/sst/elements/Samba/TLBhierarchy.h
+++ b/src/sst/elements/Samba/TLBhierarchy.h
@@ -68,7 +68,7 @@ namespace SST { namespace SambaComponent{
 
 		SST::Link * to_cpu;
 
-		std::map<int, TLB *> TLB_CACHE;
+		std::map<int, TLB *> TLB_CACHE; //1-indexed, TLB_CACHE[1] is L1 TLB
 
 		// Here is the defintion of the page table walker of the TLB hierarchy
 		PageTableWalker * PTW;
@@ -154,11 +154,22 @@ namespace SST { namespace SambaComponent{
 		void handleEvent_CPU(SST::Event * event);
 
 
-		void setPageTablePointers( Address_t * cr3, std::map<Address_t, Address_t> * pgd,  std::map<Address_t, Address_t> * pud,  std::map<Address_t, Address_t> * pmd, std::map<Address_t, Address_t> * pte,
-				std::map<Address_t,int> * gb,  std::map<Address_t,int> * mb,  std::map<Address_t,int> * kb, std::map<Address_t,int> * pr, int *cr3I, std::map<Address_t,int> *pf_pgd,
-				std::map<Address_t,int> *pf_pud,  std::map<Address_t,int> *pf_pmd, std::map<Address_t,int> * pf_pte)
+		void setPageTablePointers(  Address_t * cr3, 
+                                    std::map<Address_t, Address_t> * pgd,  
+                                    std::map<Address_t, Address_t> * pud,  
+                                    std::map<Address_t, Address_t> * pmd, 
+                                    std::map<Address_t, Address_t> * pte,
+                                    std::map<Address_t,int> * gb,  
+                                    std::map<Address_t,int> * mb,  
+                                    std::map<Address_t,int> * kb, 
+                                    std::map<Address_t,int> * pr, 
+                                    int *cr3I, 
+                                    std::map<Address_t,int> *pf_pgd,
+                                    std::map<Address_t,int> *pf_pud,  
+                                    std::map<Address_t,int> *pf_pmd, 
+                                    std::map<Address_t,int> * pf_pte)
 		{
-	                CR3 = cr3;
+                        CR3 = cr3;
                         PGD = pgd;
                         PUD = pud;
                         PMD = pmd;

--- a/src/sst/elements/Samba/tests/simpletlb_test.py
+++ b/src/sst/elements/Samba/tests/simpletlb_test.py
@@ -1,0 +1,106 @@
+import sst
+
+# Define SST core options
+sst.setProgramOption("timebase", "1ps")
+sst.setProgramOption("stopAtCycle", "0 ns")
+
+
+memory_mb = 1024 #1GB
+virt_region_size_mb = 128
+
+# Define the simulation components
+comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
+comp_cpu.addParams({
+	"verbose" : 1,
+})
+cpugen = comp_cpu.setSubComponent("generator", "miranda.GUPSGenerator")
+cpugen.addParams({
+	"verbose" : 0,
+	"count" : 10000,
+	"max_address" : virt_region_size_mb
+})
+
+
+comp_l1cache = sst.Component("l1cache", "memHierarchy.Cache")
+comp_l1cache.addParams({
+        "access_latency_cycles" : "2",
+        "cache_frequency" : "2 Ghz",
+        "replacement_policy" : "lru",
+        "coherence_protocol" : "MESI",
+        "associativity" : "4",
+        "cache_line_size" : "64",
+        "prefetcher" : "cassini.StridePrefetcher",
+        "L1" : "1",
+        "cache_size" : "8KB",
+        "debug" : "1",          
+        "debug_level" : "10",    
+        "debug_addresses": "[]",
+        "verbose": "1",
+})
+
+# Tell SST what statistics handling we want
+sst.setStatisticLoadLevel(2)
+# Enable statistics outputs
+comp_cpu.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+comp_l1cache.enableAllStatistics({"type":"sst.AccumulatorStatistic"})
+#comp_l1cache.enableStatistics(["GetS_recv","GetX_recv"])
+
+
+
+# ====== Memory
+comp_memctrl = sst.Component("memory", "memHierarchy.MemController")
+comp_memctrl.addParams({
+      "clock" : "1GHz"
+})
+memory = comp_memctrl.setSubComponent("backend", "memHierarchy.simpleMem")
+memory.addParams({
+    "access_time" : "50 ns",
+    "mem_size" : str(memory_mb * 1024 * 1024) + "B",
+})
+
+
+# ====== Custom TLB component
+comp_tlb = sst.Component("comp_TLB", "Samba.SimpleTLB")
+comp_tlb.addParams({
+    "verbose": 1,
+    "fixed_mapping_va_start": "0x0",
+    "fixed_mapping_pa_start": "0xF000000",
+    "fixed_mapping_len": "128MB",
+})
+
+
+
+
+#=========== SetupLinks
+# Define the simulation links
+#link_cpu_mmu_link = sst.Link("link_cpu_mmu_link")
+#link_cpu_mmu_link.connect( (comp_cpu, "cache_link", "50ps"), (mmu, "cpu_to_mmu0", "50ps") )
+#
+#link_mmu_cache_link = sst.Link("link_mmu_cache_link")
+#link_mmu_cache_link.connect( (mmu, "mmu_to_cache0", "50ps"), (comp_l1cache, "high_network_0", "50ps") )
+
+def makeLink(name, portA, portB):
+    'ports should be tuple like `(component, "port_name", "50ps")`'
+    link = sst.Link(name)
+    link.connect(portA,portB)
+
+#===== Interpose TLB between cpu and cache
+makeLink("link_cpu_tlb",
+        (comp_cpu, "cache_link", "50ps"), (comp_tlb, "high_network", "50ps"))
+
+makeLink("link_tlb_l1cache",
+        (comp_tlb, "low_network", "50ps"), (comp_l1cache, "high_network_0", "50ps"))
+
+
+##===== Alternately, self-loop the TLB and connect cpu to cache
+#makeLink("link_cpu_l1cache",
+#        (comp_cpu, "cache_link", "50ps"), (comp_l1cache, "high_network_0", "50ps"))
+#
+#makeLink("linkself_tlb",
+#        (comp_tlb, "link_high", "50ps"), (comp_tlb, "link_low", "50ps"))
+
+
+# === CPU to mem
+makeLink("link_l1cache_membus",
+        (comp_l1cache, "low_network_0", "50ps"), (comp_memctrl, "direct_link", "50ps"))
+

--- a/src/sst/elements/Samba/tests/simpletlb_test.py
+++ b/src/sst/elements/Samba/tests/simpletlb_test.py
@@ -6,7 +6,10 @@ sst.setProgramOption("stopAtCycle", "0 ns")
 
 
 memory_mb = 1024 #1GB
-virt_region_size_mb = 128
+virt_region_size_mb = 256
+KB=1024
+MB=1024 * KB
+GB=1024 * MB
 
 # Define the simulation components
 comp_cpu = sst.Component("cpu", "miranda.BaseCPU")
@@ -17,7 +20,7 @@ cpugen = comp_cpu.setSubComponent("generator", "miranda.GUPSGenerator")
 cpugen.addParams({
 	"verbose" : 0,
 	"count" : 10000,
-	"max_address" : virt_region_size_mb
+	"max_address" : str(virt_region_size_mb * MB) + "B",
 })
 
 
@@ -62,7 +65,7 @@ memory.addParams({
 # ====== Custom TLB component
 comp_tlb = sst.Component("comp_TLB", "Samba.SimpleTLB")
 comp_tlb.addParams({
-    "verbose": 1,
+    "verbose": 3,
     "fixed_mapping_va_start": "0x0",
     "fixed_mapping_pa_start": "0xF000000",
     "fixed_mapping_len": "128MB",


### PR DESCRIPTION
Adds Samba.SimpleTLB component. (Currently more of a trivial-virtual-memory-remapper than a TLB; the name is aspirational)

Can be placed between CPU and caches in the usual way using ports `high_network` and `low_network`, where it should transparently allow memory accesses to pass by default.
Can specify a fixed region of memory to remap elsewhere with the following params:
```
    "fixed_mapping_va_start": "0x0",                  
    "fixed_mapping_pa_start": "0xF000000",            
    "fixed_mapping_len": "128MB",            
```
Any request into the specified virtual address region get re-mapped, all others pass through unchanged.


NOTE: All the actual code additions are in SimpleTLB.cc and SimpleTLB.h
Edits to PageTableWalker.\*, TLBUnit.\*, TLBhierarchy.\*, Samba.\* are me going through and re-documenting old code.
