### PR TITLE
Enable Floating-Point Flags in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/decoder/vdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vdecoder.h
@@ -27,6 +27,7 @@
 #include "vbranch/vbranchunit.h"
 #include "velf/velfinfo.h"
 #include "vinsloader.h"
+#include "vfpflags.h"
 
 #include <cinttypes>
 #include <cstdint>
@@ -88,6 +89,7 @@ public:
         tls_ptr = 0;
 
         thread_rob = nullptr;
+		  fpflags = nullptr;
 
         icache_line_width = params.find<uint64_t>("icache_line_width", 64);
 
@@ -145,6 +147,10 @@ public:
         icache_line_width = ic_width;
         ins_loader->setCacheLineWidth(ic_width);
     }
+
+    void setFPFlags(VanadisFloatingPointFlags* new_fpflags) {
+		fpflags = new_fpflags;
+	 }
 
     bool acceptCacheResponse(SST::Output* output, SST::Interfaces::StandardMem::Request* req)
     {
@@ -220,6 +226,7 @@ protected:
     VanadisInstructionLoader* ins_loader;
     VanadisBranchUnit*        branch_predictor;
     VanadisCPUOSHandler*      os_handler;
+	 VanadisFloatingPointFlags* fpflags;
 
     bool canIssueStores;
     bool canIssueLoads;

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -1867,12 +1867,12 @@ protected:
                     {
                         if ( (0 == fd) && (MIPS_SPEC_COP_MASK_MTC == fr) ) {
                             bundle->addInstruction(
-                                new VanadisGPR2FPInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, fs, rt));
+                                new VanadisGPR2FPInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, fpflags, fs, rt));
                             insertDecodeFault = false;
                         }
                         else if ( (0 == fd) && (MIPS_SPEC_COP_MASK_MFC == fr) ) {
                             bundle->addInstruction(
-                                new VanadisFP2GPRInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, rt, fs));
+                                new VanadisFP2GPRInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, fpflags, rt, fs));
                             insertDecodeFault = false;
                         }
                         else if ( (0 == fd) && (MIPS_SPEC_COP_MASK_CF == fr) ) {
@@ -1894,7 +1894,7 @@ protected:
 
                             if ( fp_matched ) {
                                 bundle->addInstruction(new VanadisFP2GPRInstruction<int32_t, int32_t>(
-                                    ins_addr, hw_thr, options, rt, fp_ctrl_reg));
+                                    ins_addr, hw_thr, options, fpflags, rt, fp_ctrl_reg));
                                 insertDecodeFault = false;
                             }
                         }
@@ -1917,7 +1917,7 @@ protected:
 
                             if ( fp_matched ) {
                                 bundle->addInstruction(new VanadisGPR2FPInstruction<int32_t, int32_t>(
-                                    ins_addr, hw_thr, options, fp_ctrl_reg, rt));
+                                    ins_addr, hw_thr, options, fpflags, fp_ctrl_reg, rt));
                                 insertDecodeFault = false;
                             }
                         }
@@ -1925,22 +1925,22 @@ protected:
                             switch ( fr ) {
                             case 16:
                                 bundle->addInstruction(
-                                    new VanadisFPAddInstruction<float>(ins_addr, hw_thr, options, fd, fs, ft));
+                                    new VanadisFPAddInstruction<float>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                                 insertDecodeFault = false;
                                 break;
                             case 17:
                                 bundle->addInstruction(
-                                    new VanadisFPAddInstruction<double>(ins_addr, hw_thr, options, fd, fs, ft));
+                                    new VanadisFPAddInstruction<double>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                                 insertDecodeFault = false;
                                 break;
                             case 20:
                                 bundle->addInstruction(
-                                    new VanadisFPAddInstruction<int32_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                    new VanadisFPAddInstruction<int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                                 insertDecodeFault = false;
                                 break;
                             case 21:
                                 bundle->addInstruction(
-                                    new VanadisFPAddInstruction<int64_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                    new VanadisFPAddInstruction<int64_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                                 insertDecodeFault = false;
                                 break;
                             default:
@@ -1957,14 +1957,14 @@ protected:
                         {
                             bundle->addInstruction(
                                 new VanadisFP2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
-                                    ins_addr, hw_thr, options, fd, fs));
+                                    ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                         } break;
                         case 17:
                         {
                             bundle->addInstruction(
                                 new VanadisFP2FPInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
-                                    ins_addr, hw_thr, options, fd, fs));
+                                    ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                         } break;
                         }
@@ -1977,22 +1977,22 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPMultiplyInstruction<float>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPMultiplyInstruction<float>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPMultiplyInstruction<double>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPMultiplyInstruction<double>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPMultiplyInstruction<int32_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPMultiplyInstruction<int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPMultiplyInstruction<int64_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPMultiplyInstruction<int64_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         default:
@@ -2007,26 +2007,26 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP32>(
-                                    ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPDivideInstruction<float>(
+                                    ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
-                                    ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPDivideInstruction<double>(
+                                    ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT32>(
-                                    ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPDivideInstruction<int32_t>(
+                                    ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
-                                    ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPDivideInstruction<int64_t>(
+                                    ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
 
                             break;
@@ -2042,22 +2042,22 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPSubInstruction<float>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPSubInstruction<float>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPSubInstruction<double>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPSubInstruction<double>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPSubInstruction<int32_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPSubInstruction<int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPSubInstruction<int64_t>(ins_addr, hw_thr, options, fd, fs, ft));
+                                new VanadisFPSubInstruction<int64_t>(ins_addr, hw_thr, options, fpflags, fd, fs, ft));
                             insertDecodeFault = false;
                             break;
                         default:
@@ -2072,22 +2072,22 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<float, float>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<float, float>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<double, float>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<double, float>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int32_t, float>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int32_t, float>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int64_t, float>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int64_t, float>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         default:
@@ -2102,22 +2102,22 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<float, double>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<float, double>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<double, double>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<double, double>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int32_t, double>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int32_t, double>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int64_t, double>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int64_t, double>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         default:
@@ -2134,22 +2134,22 @@ protected:
                         switch ( fr ) {
                         case 16:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<float, int32_t>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<float, int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 17:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<double, int32_t>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<double, int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 20:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int32_t, int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         case 21:
                             bundle->addInstruction(
-                                new VanadisFPConvertInstruction<int64_t, int32_t>(ins_addr, hw_thr, options, fd, fs));
+                                new VanadisFPConvertInstruction<int64_t, int32_t>(ins_addr, hw_thr, options, fpflags, fd, fs));
                             insertDecodeFault = false;
                             break;
                         default:

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -1510,7 +1510,7 @@ protected:
                     output->verbose(
                         CALL_INFO, 16, 0, "-----> FADD.D %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n", rd, rs1, rs2);
                     bundle->addInstruction(
-                        new VanadisFPAddInstruction<double>(ins_address, hw_thr, options, rd, rs1, rs2));
+                        new VanadisFPAddInstruction<double>(ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                     decode_fault = false;
                 } break;
                 case 5:
@@ -1519,7 +1519,7 @@ protected:
                     output->verbose(
                         CALL_INFO, 16, 0, "-----> FSUB.D %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n", rd, rs1, rs2);
                     bundle->addInstruction(
-                        new VanadisFPSubInstruction<double>(ins_address, hw_thr, options, rd, rs1, rs2));
+                        new VanadisFPSubInstruction<double>(ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                     decode_fault = false;
                 } break;
                 case 9:
@@ -1528,7 +1528,7 @@ protected:
                     output->verbose(
                         CALL_INFO, 16, 0, "-----> FMUL.D %" PRIu16 " <- %" PRIu16 " * %" PRIu16 "\n", rd, rs1, rs2);
                     bundle->addInstruction(
-                        new VanadisFPMultiplyInstruction<double>(ins_address, hw_thr, options, rd, rs1, rs2));
+                        new VanadisFPMultiplyInstruction<double>(ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                     decode_fault = false;
                 } break;
                 case 17:
@@ -1542,7 +1542,7 @@ protected:
                         bundle->addInstruction(
                             new VanadisFPSignLogicInstruction<
                                 VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_COPY>(
-                                ins_address, hw_thr, options, rd, rs1, rs2));
+                                ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
                     case 1:
@@ -1553,7 +1553,7 @@ protected:
                         bundle->addInstruction(
                             new VanadisFPSignLogicInstruction<
                                 VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_NEG>(
-                                ins_address, hw_thr, options, rd, rs1, rs2));
+                                ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
                     case 2:
@@ -1564,7 +1564,7 @@ protected:
                         bundle->addInstruction(
                             new VanadisFPSignLogicInstruction<
                                 VanadisRegisterFormat::VANADIS_FORMAT_FP64, VanadisFPSignLogicOperation::SIGN_XOR>(
-                                ins_address, hw_thr, options, rd, rs1, rs2));
+                                ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
                     }
@@ -1573,8 +1573,8 @@ protected:
                 {
                     output->verbose(
                         CALL_INFO, 16, 0, "---> FDIV.D %" PRIu16 " <- %" PRIu16 " / %" PRIu16 "\n", rd, rs1, rs2);
-                    bundle->addInstruction(new VanadisFPDivideInstruction<VanadisRegisterFormat::VANADIS_FORMAT_FP64>(
-                        ins_address, hw_thr, options, rd, rs1, rs2));
+                    bundle->addInstruction(new VanadisFPDivideInstruction<double>(
+                        ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                     decode_fault = false;
                 } break;
                 case 105:
@@ -1591,7 +1591,7 @@ protected:
                     {
                         output->verbose(CALL_INFO, 16, 0, "-----> FCVT.D.W %" PRIu16 " <- %" PRIu16 "\n", rs1, rd);
                         bundle->addInstruction(
-                            new VanadisGPR2FPInstruction<int32_t, double>(ins_address, hw_thr, options, rd, rs1));
+                            new VanadisGPR2FPInstruction<int32_t, double>(ins_address, hw_thr, options, fpflags, rd, rs1));
                         decode_fault = false;
                     } break;
                     case 1:
@@ -1624,7 +1624,7 @@ protected:
                         output->verbose(
                             CALL_INFO, 16, 0, "-----> FLE.D %" PRIu16 " <- %" PRIu16 " <= %" PRIu16 "\n", rd, rs1, rs2);
                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LTE, double>(
-                            ins_address, hw_thr, options, rd, rs1, rs2));
+                            ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
                     case 0x1:
@@ -1633,7 +1633,7 @@ protected:
                         output->verbose(
                             CALL_INFO, 16, 0, "-----> FLT.D %" PRIu16 " <- %" PRIu16 " < %" PRIu16 "\n", rd, rs1, rs2);
                         bundle->addInstruction(new VanadisFPSetRegCompareInstruction<REG_COMPARE_LT, double>(
-                            ins_address, hw_thr, options, rd, rs1, rs2));
+                            ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                         decode_fault = false;
                     } break;
                     }
@@ -1646,7 +1646,7 @@ protected:
                         if ( 0 == func_code3 ) {
                             output->verbose(CALL_INFO, 16, 0, "-----> FMV.X.D %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
                             bundle->addInstruction(
-                                new VanadisFP2GPRInstruction<int64_t, int64_t>(ins_address, hw_thr, options, rd, rs1));
+                                new VanadisFP2GPRInstruction<int64_t, int64_t>(ins_address, hw_thr, options, fpflags, rd, rs1));
                             decode_fault = false;
                         }
                     }
@@ -1659,7 +1659,7 @@ protected:
                         if ( 0 == func_code3 ) {
                             output->verbose(CALL_INFO, 16, 0, "-----> FMV.D.X %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
                             bundle->addInstruction(
-                                new VanadisGPR2FPInstruction<int64_t, int64_t>(ins_address, hw_thr, options, rd, rs1));
+                                new VanadisGPR2FPInstruction<int64_t, int64_t>(ins_address, hw_thr, options, fpflags, rd, rs1));
                             decode_fault = false;
                         }
                     }

--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_2_FP
 #define _H_VANADIS_FP_2_FP
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -24,14 +24,14 @@ namespace SST {
 namespace Vanadis {
 
 template <VanadisRegisterFormat register_format>
-class VanadisFP2FPInstruction : public VanadisInstruction
+class VanadisFP2FPInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFP2FPInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t fp_dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t fp_dest,
         const uint16_t fp_src) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64 ||
               register_format == VanadisRegisterFormat::VANADIS_FORMAT_INT64) &&
              (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_2_GPR
 #define _H_VANADIS_FP_2_GPR
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -24,14 +24,14 @@ namespace SST {
 namespace Vanadis {
 
 template <typename fp_format, typename gpr_format>
-class VanadisFP2GPRInstruction : public VanadisInstruction
+class VanadisFP2GPRInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFP2GPRInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t int_dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t int_dest,
         const uint16_t fp_src) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 1, 0, 1,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 1, 0, 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1, 0)
     {

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -29,8 +29,8 @@ class VanadisFPAddInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPAddInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
-        const uint16_t src_1, const uint16_t src_2) :
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+        VanadisFloatingPointFlags* fpflags, const uint16_t dest, const uint16_t src_1, const uint16_t src_2) :
         VanadisFloatingPointInstruction(
             addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
@@ -58,7 +58,9 @@ public:
 
     const char* getInstCode() const override
     {
-        if ( std::is_same<fp_format, double>::value ) { return "FP64ADD"; }
+        if ( std::is_same<fp_format, double>::value ) {
+			return "FP64ADD";
+		  }
         else if ( std::is_same<fp_format, float>::value ) {
             return "FP32ADD";
         }
@@ -71,7 +73,7 @@ public:
     {
         snprintf(
             buffer, buffer_size,
-            "%8s  %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 ")",
+            "%s  %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " + %5" PRIu16 ")",
             getInstCode(), isa_fp_regs_out[0], isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0],
             phys_fp_regs_in[0], phys_fp_regs_in[1]);
     }
@@ -79,44 +81,44 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
-		if(output->getVerboseLevel() >= 16) {
-        char* int_register_buffer = new char[256];
-        char* fp_register_buffer  = new char[256];
+        if ( output->getVerboseLevel() >= 16 ) {
+            char* int_register_buffer = new char[256];
+            char* fp_register_buffer  = new char[256];
 
-        writeIntRegs(int_register_buffer, 256);
-        writeFPRegs(fp_register_buffer, 256);
+            writeIntRegs(int_register_buffer, 256);
+            writeFPRegs(fp_register_buffer, 256);
 
-        output->verbose(
-            CALL_INFO, 16, 0, "Execute: 0x%llx %s int: %s / fp: %s\n", getInstructionAddress(), getInstCode(),
-            int_register_buffer, fp_register_buffer);
+            output->verbose(
+                CALL_INFO, 16, 0, "Execute: 0x%llx %s int: %s / fp: %s\n", getInstructionAddress(), getInstCode(),
+                int_register_buffer, fp_register_buffer);
 
-        delete[] int_register_buffer;
-        delete[] fp_register_buffer;
-		}
+            delete[] int_register_buffer;
+            delete[] fp_register_buffer;
+        }
 #endif
 
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
-            const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
-            const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
-				const fp_format result = src_1 + src_2;
+            const fp_format src_1  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+            const fp_format src_2  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+            const fp_format result = src_1 + src_2;
 
-				performFlagChecks<fp_format>(result);
+            performFlagChecks<fp_format>(result);
 
-		if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
-		}
+            if ( output->getVerboseLevel() >= 16 ) {
+                output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+            }
             fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
         }
         else {
-            const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
-            const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
-				const fp_format result = src_1 + src_2;
+            const fp_format src_1  = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
+            const fp_format src_2  = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+            const fp_format result = src_1 + src_2;
 
-				performFlagChecks<fp_format>(result);
+            performFlagChecks<fp_format>(result);
 
-		if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
-		}
+            if ( output->getVerboseLevel() >= 16 ) {
+                output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+            }
 
             regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -29,10 +29,10 @@ class VanadisFPAddInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPAddInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
         VanadisFloatingPointInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
@@ -79,6 +79,7 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
+		if(output->getVerboseLevel() >= 16) {
         char* int_register_buffer = new char[256];
         char* fp_register_buffer  = new char[256];
 
@@ -91,23 +92,33 @@ public:
 
         delete[] int_register_buffer;
         delete[] fp_register_buffer;
+		}
 #endif
 
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
             const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
             const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+				const fp_format result = src_1 + src_2;
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 + src_2));
+				performFlagChecks<fp_format>(result);
 
-            fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1 + src_2);
+		if(output->getVerboseLevel() >= 16) {
+            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+		}
+            fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
         }
         else {
             const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
             const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+				const fp_format result = src_1 + src_2;
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 + src_2));
+				performFlagChecks<fp_format>(result);
 
-            regFile->setFPReg<fp_format>(phys_fp_regs_out[0], ((src_1) + (src_2)));
+		if(output->getVerboseLevel() >= 16) {
+            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+		}
+
+            regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }
 
         markExecuted();

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_CONVERT
 #define _H_VANADIS_FP_CONVERT
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -24,14 +24,14 @@ namespace SST {
 namespace Vanadis {
 
 template <typename src_format, typename dest_format>
-class VanadisFPConvertInstruction : public VanadisInstruction
+class VanadisFPConvertInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPConvertInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t fp_dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t fp_dest,
         const uint16_t fp_src) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(src_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
             ((sizeof(dest_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
             ((sizeof(src_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -28,8 +28,8 @@ class VanadisFPDivideInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPDivideInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
-        const uint16_t src_1, const uint16_t src_2) :
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+        VanadisFloatingPointFlags* fpflags, const uint16_t dest, const uint16_t src_1, const uint16_t src_2) :
         VanadisFloatingPointInstruction(
             addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
@@ -54,7 +54,7 @@ public:
     }
 
     VanadisFPDivideInstruction* clone() override { return new VanadisFPDivideInstruction(*this); }
-    VanadisFunctionalUnitType     getInstFuncType() const override { return INST_FP_DIV; }
+    VanadisFunctionalUnitType   getInstFuncType() const override { return INST_FP_DIV; }
 
     const char* getInstCode() const override
     {
@@ -91,47 +91,47 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
-		  if(output->getVerboseLevel() >= 16) {
-        char* int_register_buffer = new char[256];
-        char* fp_register_buffer  = new char[256];
+        if ( output->getVerboseLevel() >= 16 ) {
+            char* int_register_buffer = new char[256];
+            char* fp_register_buffer  = new char[256];
 
-        writeIntRegs(int_register_buffer, 256);
-        writeFPRegs(fp_register_buffer, 256);
+            writeIntRegs(int_register_buffer, 256);
+            writeFPRegs(fp_register_buffer, 256);
 
-        output->verbose(
-            CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(), getInstCode(),
-            int_register_buffer, fp_register_buffer);
+            output->verbose(
+                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(),
+                getInstCode(), int_register_buffer, fp_register_buffer);
 
-        delete[] int_register_buffer;
-        delete[] fp_register_buffer;
-		  }
+            delete[] int_register_buffer;
+            delete[] fp_register_buffer;
+        }
 #endif
 
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
-            const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
-            const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
-			   const fp_format result = src_1 / src_2;
+            const fp_format src_1  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+            const fp_format src_2  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+            const fp_format result = src_1 / src_2;
 
-				performDivFlagChecks<fp_format>(src_2);
-				performFlagChecks<fp_format>(result);
+            performDivFlagChecks<fp_format>(src_2);
+            performFlagChecks<fp_format>(result);
 
-				if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
-				}
+            if ( output->getVerboseLevel() >= 16 ) {
+                output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
+            }
 
             fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
         }
         else {
-            const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
-            const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
-			   const fp_format result = src_1 / src_2;
+            const fp_format src_1  = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
+            const fp_format src_2  = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+            const fp_format result = src_1 / src_2;
 
-				performDivFlagChecks<fp_format>(src_2);
-				performFlagChecks<fp_format>(result);
+            performDivFlagChecks<fp_format>(src_2);
+            performFlagChecks<fp_format>(result);
 
-				if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
-				}
+            if ( output->getVerboseLevel() >= 16 ) {
+                output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
+            }
 
             regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }
@@ -139,15 +139,17 @@ public:
         markExecuted();
     }
 
-	 template<typename T>
-	 void performDivFlagChecks(const T value) {
-		if(std::fpclassify(value) == FP_ZERO) {
-			fpflags->setDivZero();
-			update_fp_flags = true;
-		} else {
-			fpflags->clearDivZero();
-		}
-	 }
+    template <typename T>
+    void performDivFlagChecks(const T value)
+    {
+        if ( std::fpclassify(value) == FP_ZERO ) {
+            fpflags->setDivZero();
+            update_fp_flags = true;
+        }
+        else {
+            fpflags->clearDivZero();
+        }
+    }
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -16,42 +16,29 @@
 #ifndef _H_VANADIS_FP_DIV
 #define _H_VANADIS_FP_DIV
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
 namespace SST {
 namespace Vanadis {
 
-template <VanadisRegisterFormat register_format>
-class VanadisFPDivideInstruction : public VanadisInstruction
+template <typename fp_format>
+class VanadisFPDivideInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPDivideInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
-            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
-             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
-                ? 4
-                : 2,
-            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
-             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
-                ? 2
-                : 1,
-            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
-             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
-                ? 4
-                : 2,
-            ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
-             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
-                ? 2
-                : 1)
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
+            ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
+            ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
+            ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1)
     {
 
-        if ( (register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
-             (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()) ) {
+        if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()) ) {
             isa_fp_regs_in[0]  = src_1;
             isa_fp_regs_in[1]  = src_1 + 1;
             isa_fp_regs_in[2]  = src_2;
@@ -67,36 +54,44 @@ public:
     }
 
     VanadisFPDivideInstruction* clone() override { return new VanadisFPDivideInstruction(*this); }
-    VanadisFunctionalUnitType   getInstFuncType() const override { return INST_FP_DIV; }
+    VanadisFunctionalUnitType     getInstFuncType() const override { return INST_FP_DIV; }
 
     const char* getInstCode() const override
     {
-        switch ( register_format ) {
-        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
-            return "FP64DIV";
-        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
+        if ( std::is_same<fp_format, double>::value ) { return "FP64DIV"; }
+        else if ( std::is_same<fp_format, float>::value ) {
             return "FP32DIV";
-        case VanadisRegisterFormat::VANADIS_FORMAT_INT64:
-            return "FPINT64DIV";
-        case VanadisRegisterFormat::VANADIS_FORMAT_INT32:
-            return "FPINT32DIV";
         }
-
-        return "FPUNK";
+        else if ( std::is_same<fp_format, int32_t>::value ) {
+            return "FPI32DIV";
+        }
+        else if ( std::is_same<fp_format, uint32_t>::value ) {
+            return "FPU32DIV";
+        }
+        else if ( std::is_same<fp_format, int64_t>::value ) {
+            return "FPI64DIV";
+        }
+        else if ( std::is_same<fp_format, uint64_t>::value ) {
+            return "FPU64DIV";
+        }
+        else {
+            return "FPDIVUNK";
+        }
     }
 
     void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,
-            "DIV     %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 ")",
-            isa_fp_regs_out[0], isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0], phys_fp_regs_in[0],
-            phys_fp_regs_in[1]);
+            "%6s  %5" PRIu16 " <- %5" PRIu16 " * %5" PRIu16 " (phys: %5" PRIu16 " <- %5" PRIu16 " / %5" PRIu16 ")",
+            getInstCode(), isa_fp_regs_out[0], isa_fp_regs_in[0], isa_fp_regs_in[1], phys_fp_regs_out[0],
+            phys_fp_regs_in[0], phys_fp_regs_in[1]);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
+		  if(output->getVerboseLevel() >= 16) {
         char* int_register_buffer = new char[256];
         char* fp_register_buffer  = new char[256];
 
@@ -109,45 +104,50 @@ public:
 
         delete[] int_register_buffer;
         delete[] fp_register_buffer;
+		  }
 #endif
-        switch ( register_format ) {
-        case VanadisRegisterFormat::VANADIS_FORMAT_FP32:
-        {
-            const float src_1 = regFile->getFPReg<float>(phys_fp_regs_in[0]);
-            const float src_2 = regFile->getFPReg<float>(phys_fp_regs_in[1]);
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 / src_2));
+        if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
+            const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+            const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+			   const fp_format result = src_1 / src_2;
 
-            regFile->setFPReg<float>(phys_fp_regs_out[0], src_1 / src_2);
-        } break;
-        case VanadisRegisterFormat::VANADIS_FORMAT_FP64:
-        {
-            if ( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() ) {
-                const double src_1 = combineFromRegisters<double>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
-                const double src_2 = combineFromRegisters<double>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+				performDivFlagChecks<fp_format>(src_2);
+				performFlagChecks<fp_format>(result);
 
-                output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 / src_2));
+				if(output->getVerboseLevel() >= 16) {
+            output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
+				}
 
-                fractureToRegisters<double>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1 / src_2);
-            }
-            else {
-                const double src_1 = regFile->getFPReg<double>(phys_fp_regs_in[0]);
-                const double src_2 = regFile->getFPReg<double>(phys_fp_regs_in[1]);
+            fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
+        }
+        else {
+            const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
+            const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+			   const fp_format result = src_1 / src_2;
 
-                output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 / src_2));
+				performDivFlagChecks<fp_format>(src_2);
+				performFlagChecks<fp_format>(result);
 
-                regFile->setFPReg<double>(phys_fp_regs_out[0], src_1 / src_2);
-            }
-        } break;
-        default:
-        {
-            output->verbose(CALL_INFO, 16, 0, "Unknown floating point type.\n");
-            flagError();
-        } break;
+				if(output->getVerboseLevel() >= 16) {
+            output->verbose(CALL_INFO, 16, 0, "---> %f / %f = %f\n", src_1, src_2, result);
+				}
+
+            regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }
 
         markExecuted();
     }
+
+	 template<typename T>
+	 void performDivFlagChecks(const T value) {
+		if(std::fpclassify(value) == FP_ZERO) {
+			fpflags->setDivZero();
+			update_fp_flags = true;
+		} else {
+			fpflags->clearDivZero();
+		}
+	 }
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpinst.h
+++ b/src/sst/elements/vanadis/inst/vfpinst.h
@@ -21,8 +21,11 @@
 #include "inst/vinst.h"
 #include "inst/vinsttype.h"
 #include "inst/vregfmt.h"
+#include "util/vfpreghandler.h"
+#include "vfpflags.h"
 
 #include <cstring>
+#include <cmath>
 #include <sst/core/output.h>
 
 namespace SST {
@@ -33,13 +36,38 @@ class VanadisFloatingPointInstruction : public VanadisInstruction
 public:
     VanadisFloatingPointInstruction(
         const uint64_t address, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
-        const uint16_t c_phys_int_reg_in, const uint16_t c_phys_int_reg_out, const uint16_t c_isa_int_reg_in,
-        const uint16_t c_isa_int_reg_out, const uint16_t c_phys_fp_reg_in, const uint16_t c_phys_fp_reg_out,
-        const uint16_t c_isa_fp_reg_in, const uint16_t c_isa_fp_reg_out) :
+        VanadisFloatingPointFlags* fp_flags, const uint16_t c_phys_int_reg_in, const uint16_t c_phys_int_reg_out,
+        const uint16_t c_isa_int_reg_in, const uint16_t c_isa_int_reg_out, const uint16_t c_phys_fp_reg_in,
+        const uint16_t c_phys_fp_reg_out, const uint16_t c_isa_fp_reg_in, const uint16_t c_isa_fp_reg_out) :
         VanadisInstruction(
             address, hw_thr, isa_opts, c_phys_int_reg_in, c_phys_int_reg_out, c_isa_int_reg_in, c_isa_int_reg_out,
-            c_phys_fp_reg_in, c_phys_fp_reg_out, c_isa_fp_reg_in, c_isa_fp_reg_out)
+            c_phys_fp_reg_in, c_phys_fp_reg_out, c_isa_fp_reg_in, c_isa_fp_reg_out),
+        fpflags(fp_flags),
+        update_fp_flags(false)
     {}
+
+    VanadisFloatingPointInstruction(const VanadisFloatingPointInstruction& copy_me) :
+        VanadisInstruction(copy_me),
+        update_fp_flags(copy_me.update_fp_flags),
+        fpflags(copy_me.fpflags)
+    {}
+
+    virtual bool updatesFPFlags() const { return update_fp_flags; }
+    virtual void performFPFlagsUpdate() const {}
+
+protected:
+    bool                       update_fp_flags;
+    VanadisFloatingPointFlags* fpflags;
+
+	 template<typename T>
+    void performFlagChecks(const T value) {
+		if(std::fpclassify(value) == FP_INFINITE) {
+			fpflags->setOverflow();
+			update_fp_flags = true;
+		} else {
+			fpflags->clearOverflow();
+		}
+	 }
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -28,8 +28,8 @@ class VanadisFPMultiplyInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPMultiplyInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
-        const uint16_t src_1, const uint16_t src_2) :
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+        VanadisFloatingPointFlags* fpflags, const uint16_t dest, const uint16_t src_1, const uint16_t src_2) :
         VanadisFloatingPointInstruction(
             addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
@@ -91,39 +91,41 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
-        char* int_register_buffer = new char[256];
-        char* fp_register_buffer  = new char[256];
+        if ( output->getVerboseLevel() >= 16 ) {
+            char* int_register_buffer = new char[256];
+            char* fp_register_buffer  = new char[256];
 
-        writeIntRegs(int_register_buffer, 256);
-        writeFPRegs(fp_register_buffer, 256);
+            writeIntRegs(int_register_buffer, 256);
+            writeFPRegs(fp_register_buffer, 256);
 
-        output->verbose(
-            CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(), getInstCode(),
-            int_register_buffer, fp_register_buffer);
+            output->verbose(
+                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(),
+                getInstCode(), int_register_buffer, fp_register_buffer);
 
-        delete[] int_register_buffer;
-        delete[] fp_register_buffer;
+            delete[] int_register_buffer;
+            delete[] fp_register_buffer;
+        }
 #endif
 
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
-            const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
-            const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
-				const fp_format result = src_1 * src_2;
+            const fp_format src_1  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
+            const fp_format src_2  = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+            const fp_format result = src_1 * src_2;
 
-				performFlagChecks<fp_format>(result);
+            performFlagChecks<fp_format>(result);
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+            output->verbose(CALL_INFO, 16, 0, "---> %f * %f = %f\n", src_1, src_2, result);
 
             fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
         }
         else {
-            const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
-            const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
-				const fp_format result = src_1 * src_2;
+            const fp_format src_1  = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
+            const fp_format src_2  = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+            const fp_format result = src_1 * src_2;
 
-				performFlagChecks<fp_format>(result);
+            performFlagChecks<fp_format>(result);
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+            output->verbose(CALL_INFO, 16, 0, "---> %f * %f = %f\n", src_1, src_2, result);
 
             regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_MUL
 #define _H_VANADIS_FP_MUL
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -24,14 +24,14 @@ namespace SST {
 namespace Vanadis {
 
 template <typename fp_format>
-class VanadisFPMultiplyInstruction : public VanadisInstruction
+class VanadisFPMultiplyInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPMultiplyInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
@@ -108,18 +108,24 @@ public:
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {
             const fp_format src_1 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[0], phys_fp_regs_in[1]);
             const fp_format src_2 = combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3]);
+				const fp_format result = src_1 * src_2;
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 * src_2));
+				performFlagChecks<fp_format>(result);
 
-            fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], src_1 * src_2);
+            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+
+            fractureToRegisters<fp_format>(regFile, phys_fp_regs_out[0], phys_fp_regs_out[1], result);
         }
         else {
             const fp_format src_1 = regFile->getFPReg<fp_format>(phys_fp_regs_in[0]);
             const fp_format src_2 = regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
+				const fp_format result = src_1 * src_2;
 
-            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, (src_1 * src_2));
+				performFlagChecks<fp_format>(result);
 
-            regFile->setFPReg<fp_format>(phys_fp_regs_out[0], (src_1) * (src_2));
+            output->verbose(CALL_INFO, 16, 0, "---> %f + %f = %f\n", src_1, src_2, result);
+
+            regFile->setFPReg<fp_format>(phys_fp_regs_out[0], result);
         }
 
         markExecuted();

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -29,8 +29,8 @@ class VanadisFPSetRegCompareInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPSetRegCompareInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
-        const uint16_t src_1, const uint16_t src_2) :
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts,
+        VanadisFloatingPointFlags* fpflags, const uint16_t dest, const uint16_t src_1, const uint16_t src_2) :
         VanadisFloatingPointInstruction(
             addr, hw_thr, isa_opts, fpflags, 0, 1, 0, 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2, 0,
@@ -152,18 +152,20 @@ public:
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 #ifdef VANADIS_BUILD_DEBUG
-        char* int_register_buffer = new char[256];
-        char* fp_register_buffer  = new char[256];
+        if ( output->getVerboseLevel() >= 16 ) {
+            char* int_register_buffer = new char[256];
+            char* fp_register_buffer  = new char[256];
 
-        writeIntRegs(int_register_buffer, 256);
-        writeFPRegs(fp_register_buffer, 256);
+            writeIntRegs(int_register_buffer, 256);
+            writeFPRegs(fp_register_buffer, 256);
 
-        output->verbose(
-            CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s (%s) int: %s / fp: %s\n", getInstructionAddress(),
-            getInstCode(), convertCompareTypeToString(compare_type), int_register_buffer, fp_register_buffer);
+            output->verbose(
+                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s (%s) int: %s / fp: %s\n", getInstructionAddress(),
+                getInstCode(), convertCompareTypeToString(compare_type), int_register_buffer, fp_register_buffer);
 
-        delete[] int_register_buffer;
-        delete[] fp_register_buffer;
+            delete[] int_register_buffer;
+            delete[] fp_register_buffer;
+        }
 #endif
         const bool compare_result = performCompare(output, regFile);
         regFile->setIntReg<uint64_t>(phys_int_regs_out[0], compare_result ? 1 : 0);

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -17,7 +17,7 @@
 #define _H_VANADIS_FP_SET_REG_COMPARE
 
 #include "inst/vcmptype.h"
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -25,14 +25,14 @@ namespace SST {
 namespace Vanadis {
 
 template <VanadisRegisterCompareType compare_type, typename fp_format>
-class VanadisFPSetRegCompareInstruction : public VanadisInstruction
+class VanadisFPSetRegCompareInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPSetRegCompareInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 1, 0, 1,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 1, 0, 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2, 0)
     {

--- a/src/sst/elements/vanadis/inst/vfpsignlogic.h
+++ b/src/sst/elements/vanadis/inst/vfpsignlogic.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_SIGN_LOGIC
 #define _H_VANADIS_FP_SIGN_LOGIC
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -28,14 +28,14 @@ namespace Vanadis {
 enum class VanadisFPSignLogicOperation { SIGN_COPY, SIGN_XOR, SIGN_NEG };
 
 template <VanadisRegisterFormat register_format, VanadisFPSignLogicOperation sign_op>
-class VanadisFPSignLogicInstruction : public VanadisInstruction
+class VanadisFPSignLogicInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPSignLogicInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((register_format == VanadisRegisterFormat::VANADIS_FORMAT_FP64) &&
              (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode()))
                 ? 4

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_FP_SUB
 #define _H_VANADIS_FP_SUB
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 #include "util/vfpreghandler.h"
 
@@ -24,14 +24,14 @@ namespace SST {
 namespace Vanadis {
 
 template <typename fp_format>
-class VanadisFPSubInstruction : public VanadisInstruction
+class VanadisFPSubInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisFPSubInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t dest,
         const uint16_t src_1, const uint16_t src_2) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 0, 0, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 0, 0, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 4 : 2,

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -16,7 +16,7 @@
 #ifndef _H_VANADIS_GPR_2_FP
 #define _H_VANADIS_GPR_2_FP
 
-#include "inst/vinst.h"
+#include "inst/vfpinst.h"
 #include "inst/vregfmt.h"
 //#include "util/vtypename.h"
 
@@ -27,14 +27,14 @@ namespace Vanadis {
 
 // template <VanadisRegisterFormat int_register_format, VanadisRegisterFormat fp_register_format>
 template <typename gpr_format, typename fp_format>
-class VanadisGPR2FPInstruction : public VanadisInstruction
+class VanadisGPR2FPInstruction : public VanadisFloatingPointInstruction
 {
 public:
     VanadisGPR2FPInstruction(
-        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, const uint16_t fp_dest,
+        const uint64_t addr, const uint32_t hw_thr, const VanadisDecoderOptions* isa_opts, VanadisFloatingPointFlags* fpflags, const uint16_t fp_dest,
         const uint16_t int_src) :
-        VanadisInstruction(
-            addr, hw_thr, isa_opts, 1, 0, 1, 0, 0,
+        VanadisFloatingPointInstruction(
+            addr, hw_thr, isa_opts, fpflags, 1, 0, 1, 0, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1, 0,
             ((sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_opts->getFPRegisterMode())) ? 2 : 1)
     {

--- a/src/sst/elements/vanadis/inst/vinst.h
+++ b/src/sst/elements/vanadis/inst/vinst.h
@@ -347,6 +347,9 @@ public:
 
     virtual bool performFPRegisterRecovery() const { return true; }
 
+	 virtual bool updatesFPFlags() const { return false; }
+    virtual void performFPFlagsUpdate() const {}
+
 protected:
     const uint64_t ins_address;
     const uint32_t hw_thread;

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -944,6 +944,11 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
                 rob_front, int_register_stacks[rob_front->getHWThread()], fp_register_stacks[rob_front->getHWThread()],
                 issue_isa_tables[rob_front->getHWThread()], retire_isa_tables[rob_front->getHWThread()]);
 
+				if(output->getVerboseLevel() >= 16) {
+					fp_flags.at(rob_front->getHWThread())->print(output);
+			   }
+
+
             ins_retired_this_cycle++;
 
             if ( perform_delay_cleanup ) {
@@ -967,6 +972,11 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
                     delay_ins, int_register_stacks[delay_ins->getHWThread()],
                     fp_register_stacks[delay_ins->getHWThread()], issue_isa_tables[delay_ins->getHWThread()],
                     retire_isa_tables[delay_ins->getHWThread()]);
+
+				if(output->getVerboseLevel() >= 16) {
+					fp_flags.at(rob_front->getHWThread())->print(output);
+			   }
+
 
                 //					if( delay_ins->endsMicroOpGroup() )
                 //{ 						stat_ins_retired->addData(1);

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -32,7 +32,6 @@ VANADIS_COMPONENT::VANADIS_COMPONENT(SST::ComponentId_t id, SST::Params& params)
 
     instPrintBuffer = new char[1024];
     pipelineTrace   = nullptr;
-    fpflags         = new VanadisFloatingPointFlags();
 
     max_cycle = params.find<uint64_t>("max_cycle", std::numeric_limits<uint64_t>::max());
 
@@ -108,6 +107,10 @@ VANADIS_COMPONENT::VANADIS_COMPONENT(SST::ComponentId_t id, SST::Params& params)
 
         sprintf(decoder_name, "decoder%" PRIu32 "", i);
         VanadisDecoder* thr_decoder = loadUserSubComponent<SST::Vanadis::VanadisDecoder>(decoder_name);
+
+		  fp_flags.push_back(new VanadisFloatingPointFlags());
+		  thr_decoder->setFPFlags(fp_flags[i]);
+
         //		thr_decoder->setHardwareThread( i );
 
         output->verbose(
@@ -488,7 +491,9 @@ VANADIS_COMPONENT::~VANADIS_COMPONENT()
 
     if ( pipelineTrace != nullptr ) { fclose(pipelineTrace); }
 
-    delete fpflags;
+	 for( VanadisFloatingPointFlags* next_fp_flags : fp_flags ) {
+		delete next_fp_flags;
+	 }
 }
 
 void
@@ -930,6 +935,11 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
             if ( pipelineTrace != nullptr ) {
                 fprintf(pipelineTrace, "0x%08llx %s\n", rob_front->getInstructionAddress(), rob_front->getInstCode());
             }
+
+				if(UNLIKELY(rob_front->updatesFPFlags())) {
+					rob_front->performFPFlagsUpdate();
+				}
+
             recoverRetiredRegisters(
                 rob_front, int_register_stacks[rob_front->getHWThread()], fp_register_stacks[rob_front->getHWThread()],
                 issue_isa_tables[rob_front->getHWThread()], retire_isa_tables[rob_front->getHWThread()]);
@@ -948,6 +958,10 @@ VANADIS_COMPONENT::performRetire(VanadisCircularQueue<VanadisInstruction*>* rob,
                     fprintf(
                         pipelineTrace, "0x%08llx %s\n", delay_ins->getInstructionAddress(), delay_ins->getInstCode());
                 }
+
+					if(UNLIKELY(rob_front->updatesFPFlags())) {
+						rob_front->performFPFlagsUpdate();
+					}
 
                 recoverRetiredRegisters(
                     delay_ins, int_register_stacks[delay_ins->getHWThread()],

--- a/src/sst/elements/vanadis/vanadis.h
+++ b/src/sst/elements/vanadis/vanadis.h
@@ -297,7 +297,7 @@ private:
 
     uint64_t pause_on_retire_address;
 
-    VanadisFloatingPointFlags* fpflags;
+    std::vector<VanadisFloatingPointFlags*> fp_flags;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/vfpflags.h
+++ b/src/sst/elements/vanadis/vfpflags.h
@@ -41,6 +41,15 @@ public:
     bool                  inexact() const { return f_inexact; }
     VanadisFPRoundingMode getRoundingMode() const { return round_mode; }
 
+	 void print(SST::Output* output) {
+		output->verbose(CALL_INFO, 16, 0, "-> FP Status: IVLD: %c / DIV0: %c / OF: %c / UF: %c / INXCT: %c\n",
+			f_invalidop ? 'y' : 'n',
+			f_divzero ? 'y' : 'n',
+			f_overflow ? 'y' : 'n',
+			f_underflow ? 'y' : 'n',
+			f_inexact ? 'y' : 'n');
+	 }
+
 protected:
     bool f_invalidop;
     bool f_divzero;

--- a/src/sst/elements/vanadis/vfpflags.h
+++ b/src/sst/elements/vanadis/vfpflags.h
@@ -5,54 +5,53 @@
 namespace SST {
 namespace Vanadis {
 
-enum class VanadisFPRoundingMode {
-	ROUND_NEAREST,
-	ROUND_TO_ZERO,
-	ROUND_DOWN,
-	ROUND_UP,
-	ROUND_NEAREST_TO_MAX
-};
+enum class VanadisFPRoundingMode { ROUND_NEAREST, ROUND_TO_ZERO, ROUND_DOWN, ROUND_UP, ROUND_NEAREST_TO_MAX };
 
-class VanadisFloatingPointFlags {
+class VanadisFloatingPointFlags
+{
 
 public:
-	VanadisFloatingPointFlags() :
-		f_invalidop(false), f_divzero(false), f_overflow(false), f_underflow(false),
-		f_inexact(false), round_mode(VanadisFPRoundingMode::ROUND_NEAREST) {}
+    VanadisFloatingPointFlags() :
+        f_invalidop(false),
+        f_divzero(false),
+        f_overflow(false),
+        f_underflow(false),
+        f_inexact(false),
+        round_mode(VanadisFPRoundingMode::ROUND_NEAREST)
+    {}
 
-	void setInvalidOp() { f_invalidop = true; }
-	void setDivZero() { f_divzero = true; }
-	void setOverflow() { f_overflow = true; }
-	void setUnderflow() { f_underflow = true; }
-	void setInexact() { f_inexact = true; }
-	void setRoundingMode(VanadisFPRoundingMode newMode) { round_mode = newMode; }
+    void setInvalidOp() { f_invalidop = true; }
+    void setDivZero() { f_divzero = true; }
+    void setOverflow() { f_overflow = true; }
+    void setUnderflow() { f_underflow = true; }
+    void setInexact() { f_inexact = true; }
+    void setRoundingMode(VanadisFPRoundingMode newMode) { round_mode = newMode; }
 
-	void clearInvalidOp() { f_invalidop = false; }
-	void clearDivZero() { f_divzero = false; }
-	void clearOverflow() { f_overflow = false; }
-	void clearUnderflow() { f_underflow = false; }
-	void clearInexact() { f_inexact = false; }
-	void clearRoundingMode() { round_mode = VanadisFPRoundingMode::ROUND_NEAREST; }
+    void clearInvalidOp() { f_invalidop = false; }
+    void clearDivZero() { f_divzero = false; }
+    void clearOverflow() { f_overflow = false; }
+    void clearUnderflow() { f_underflow = false; }
+    void clearInexact() { f_inexact = false; }
+    void clearRoundingMode() { round_mode = VanadisFPRoundingMode::ROUND_NEAREST; }
 
-	bool invalidOp() const { return f_invalidop; }
-	bool divZero() const { return f_divzero; }
-	bool overflow() const { return f_overflow; }
-	bool underflow() const { return f_underflow; }
-	bool inexact() const { return f_inexact; }
-	VanadisFPRoundingMode getRoundingMode() const { return round_mode; }
+    bool                  invalidOp() const { return f_invalidop; }
+    bool                  divZero() const { return f_divzero; }
+    bool                  overflow() const { return f_overflow; }
+    bool                  underflow() const { return f_underflow; }
+    bool                  inexact() const { return f_inexact; }
+    VanadisFPRoundingMode getRoundingMode() const { return round_mode; }
 
 protected:
-	bool f_invalidop;
-	bool f_divzero;
-	bool f_overflow;
-	bool f_underflow;
-	bool f_inexact;
+    bool f_invalidop;
+    bool f_divzero;
+    bool f_overflow;
+    bool f_underflow;
+    bool f_inexact;
 
-	VanadisFPRoundingMode round_mode;
-
+    VanadisFPRoundingMode round_mode;
 };
 
-}
-}
+} // namespace Vanadis
+} // namespace SST
 
 #endif


### PR DESCRIPTION
Provides support for floating-point flags/exceptions in the Vanadis pipeline:

- Enables overflow, underflow, zero flags to be set
- Enable div-by-zero flags for divide operations
- Flag update on instruction retire is default operation
- Supports rounding mode set/read but this does not affect calculation operations in current design
