### PR TITLE
Fixed incorrect parameter name for routing algorithm

### DIFF
--- a/src/sst/elements/merlin/topology/fattree.cc
+++ b/src/sst/elements/merlin/topology/fattree.cc
@@ -76,7 +76,7 @@ topo_fattree::topo_fattree(ComponentId_t cid, Params& params, int num_ports, int
         }
     }
     else {
-        std::string route_algo = params.find<std::string>("algorithm", "deterministic");
+        std::string route_algo = params.find<std::string>("routing_alg", "deterministic");
         for ( int i = 0; i < num_vns; ++i ) vn_route_algos.push_back(route_algo);
     }
 


### PR DESCRIPTION
Setting the routing algorithm for a Fat Tree uses the parameter "routing_alg" but this is only checked for a list of algorithms, it was checking for the parameter name "algorithm" when one routing algorithm was set but this is not valid. 

It may be worth swapping the name of this parameter to match the Dragonfly parameters which use the parameter name "algorithm".  