### PR TITLE
Minor Vanadis I/O Fixes

### DIFF
--- a/src/sst/elements/rdmaNic/tests/app/rdma/msg.out.gold
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/msg.out.gold
@@ -14,20 +14,4 @@ node0.l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapola
 RdmaNic() sizeof(NicCmd) 64
 node1.l2cache: No MSHR lookup latency provided (mshr_latency_cycles)...intrapolated to 3 cycles.
 RdmaNic() sizeof(NicCmd) 64
-[os-memgmr] requested allocation size: 4096
-[os-memgmr] -> page-size:            4096
-[os-memgmr] -> requested page count: 1
-[os-memgmr] -> free-pages:           393215
-[os-memgmr] -> used-pages:           0
-[os-memgmr] alloc matched: size: 4096 / page-count: 1 / alloc-start: 536870912
-[os-memgmr] requested allocation size: 4096
-[os-memgmr] -> page-size:            4096
-[os-memgmr] -> requested page count: 1
-[os-memgmr] -> free-pages:           393215
-[os-memgmr] -> used-pages:           0
-[os-memgmr] alloc matched: size: 4096 / page-count: 1 / alloc-start: 536870912
-[os-memgmr] requested deallocation from address 0x20000000 for 4096 bytes.
-[os-memgmr] aligned allocation-address (0x20000000) to page boundary at 0x20000000
-[os-memgmr] requested deallocation from address 0x20000000 for 4096 bytes.
-[os-memgmr] aligned allocation-address (0x20000000) to page boundary at 0x20000000
 Simulation is complete, simulated time: 40.2788 us

--- a/src/sst/elements/vanadis/os/memmgr/vmemmgr.h
+++ b/src/sst/elements/vanadis/os/memmgr/vmemmgr.h
@@ -34,7 +34,7 @@ public:
         assert((region_end % region_page_size) == 0);
         assert(region_start < region_end);
 
-        output = new SST::Output("[os-memgmr] ", 16, 0, Output::STDOUT);
+        output = new SST::Output("[os-memgmr] ", verbosity, 0, Output::STDOUT);
 
         for (uint64_t page_start = region_start; page_start < region_end; page_start += region_page_size) {
             free_pages.insert(page_start);

--- a/src/sst/elements/vanadis/os/vnodeoshandler.h
+++ b/src/sst/elements/vanadis/os/vnodeoshandler.h
@@ -231,8 +231,7 @@ public:
                 output->getVerboseLevel(), openat_ev->getDirectoryFileDescriptor(), openat_ev->getPathPointer(),
                 openat_ev->getFlags(), &file_descriptors, handlerSendMemCallback);
 
-            const uint64_t start_read_len
-                = (openat_ev->getPathPointer() % 64) == 0 ? 64 : openat_ev->getPathPointer() % 64;
+            const uint64_t start_read_len = vanadis_line_remainder( openat_ev->getPathPointer(), 64 );
 
             StandardMem::Read* openat_start_req
                 = new StandardMem::Read(openat_ev->getPathPointer(), start_read_len);
@@ -290,7 +289,7 @@ public:
                 = new VanadisOpenHandlerState(output->getVerboseLevel(), open_ev->getPathPointer(), open_ev->getFlags(),
                                               open_ev->getMode(), &file_descriptors, handlerSendMemCallback);
 
-            const uint64_t start_read_len = (open_ev->getPathPointer() % 64) == 0 ? 64 : open_ev->getPathPointer() % 64;
+            const uint64_t start_read_len = vanadis_line_remainder( open_ev->getPathPointer(), 64 );
 
             StandardMem::Read* open_start_req
                 = new StandardMem::Read(open_ev->getPathPointer(), start_read_len);


### PR DESCRIPTION
Fix OPEN and OPENAT syscall handler so that the first memory access of file path is cache aligned.
Enable runtime configuration of debug verbosity of VanadisMemoryManager.