### PR TITLE
Add clang-format infrastructure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,200 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveMacros: AcrossComments
+AlignConsecutiveAssignments: AcrossComments
+AlignConsecutiveBitFields: AcrossComments
+AlignConsecutiveDeclarations: AcrossComments
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline #All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse  
+AllowShortLoopsOnASingleLine: false
+#AlwaysBreakAfterDefinitionReturnType: None #depricated
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+#AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true   #modified
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: AfterColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: AfterColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+#updated to force the re-sort as specified below in IncludeCategories 
+IncludeBlocks: Regroup
+#sst_config.h always first, so set to negative priority to be above 'main' include (priority 0)
+#main header included after - main include assumed to have no suffix
+#prioritize all headers in "sst/core" next
+#next include other external headers - characterized by headers wrappped with ' " " ' that do NOT have "sst" in the name 
+#finally include all system headers - characterized as headers wrapped with '< >'
+IncludeCategories:
+  - Regex:           '(<.*>)'
+    Priority:        4
+    SortPriority:    4
+  - Regex:           '("[^\(sst\)].*")'
+    Priority:        3
+    SortPriority:    3
+  - Regex:           '("sst/core/testElements/.*")'
+    Priority:        1
+    SortPriority:    1
+  - Regex:           '("sst/core/.*")'
+    Priority:        2
+    SortPriority:    2
+  - Regex:            'sst_config.h'
+    Priority:        -1
+IncludeIsMainRegex: ''
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:   true    #updated to enable Include files to be Re-sorted
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: true 
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - ImplementSerializable
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+# Can't get the ELI macros to format properly,
+# so we'll just leave them untouched
+WhitespaceSensitiveMacros:
+  - DIAG_DISABLE
+  - SST_ELI_DECLARE_BASE
+  - SST_ELI_DECLARE_CTOR_EXTERN
+  - SST_ELI_DECLARE_DEFAULT_INFO
+  - SST_ELI_DECLARE_INFO
+  - SST_ELI_DECLARE_INFO_COMMON
+  - SST_ELI_DECLARE_INFO_EXTERN
+  - SST_ELI_DECLARE_NEW_BASE
+  - SST_ELI_DECLARE_STATISTIC_TEMPLATE
+  - SST_ELI_DOCUMENT_MODEL_SUPPORTED_EXTENSIONS
+  - SST_ELI_DOCUMENT_PARAMS
+  - SST_ELI_DOCUMENT_PORTS
+  - SST_ELI_DOCUMENT_SIMPLE_INFO
+  - SST_ELI_DOCUMENT_STATISTICS
+  - SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS
+  - SST_ELI_INTERFACE_INFO
+  - SST_ELI_NEW_BASE_CTOR
+  - SST_ELI_REGISTER_COMPONENT
+  - SST_ELI_REGISTER_DERIVED
+  - SST_ELI_REGISTER_MODEL_DESCRIPTION
+  - SST_ELI_REGISTER_MODULE
+  - SST_ELI_REGISTER_PARTITIONER
+  - SST_ELI_REGISTER_PROFILETOOL_API
+  - SST_ELI_REGISTER_PROFILETOOL_DERIVED_API
+  - SST_ELI_REGISTER_PROFILETOOL
+  - SST_ELI_REGISTER_SUBCOMPONENT_API
+  - SST_ELI_REGISTER_SUBCOMPONENT_DERIVED
+  - SST_ELI_REGISTER_SUBCOMPONENT_DERIVED_API
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/scripts/clang-format-test.sh
+++ b/scripts/clang-format-test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# This script will run clang-format on directories in sst-elements to test/verify format
+
+# Check for running in the root dir of SST-Elements
+if [ ! -f ./scripts/clang-format-test.sh  ]; then
+    echo "ERROR: This script must be run from the top level root directory of SST-Elements..."
+    exit 1
+fi
+
+CLANG_FORMAT_EXE="clang-format"
+CLANG_FORMAT_ARG="--dry-run"
+
+while :; do
+  case $1 in 
+    -h | --help)
+      echo "Run as scripts/clang-format-test.sh [--format-exe <path_to_clang-format>]"
+      exit
+      ;;
+    --format-exe)
+      if [ "$2" ]; then
+        CLANG_FORMAT_EXE=$2
+        shift 2
+      else
+        echo 'Error, --format-exe requires a path to a clang-format.'
+        exit
+      fi
+      ;;
+    -i)
+      CLANG_FORMAT_ARG="-i"
+      shift
+      ;;
+    * )
+      break
+  esac
+done
+
+echo "Using clang-format ${CLANG_FORMAT_EXE} with arguments ${CLANG_FORMAT_ARG}."
+
+clang_format_version="$(${CLANG_FORMAT_EXE} --version)"
+currentver="$(${CLANG_FORMAT_EXE} --version | cut -d' ' -f3 | tr -dc '0-9')"
+if [ $currentver -lt 1200 ]; then
+  echo "clang-format version is $clang_format_version. We require version 12."
+  exit 1
+fi
+
+if [ $currentver -ge 1300 ]; then
+  echo "clang-format version is $clang_format_version. We require version 12."
+  exit 1
+fi
+
+
+# Setup SST-Elements Directories to be skipped for clang-format checks
+DIRS_TO_SKIP="-path ./build "
+# Add additional directories to skip here...
+
+echo "======================================="
+echo "=== PERFORMING CLANG-FORMAT TESTING ==="
+echo "======================================="
+
+# Run clang-format on all specific .h files
+echo
+find . -type d \( $DIRS_TO_SKIP \) -prune -false -o -name '*.h' -exec ${CLANG_FORMAT_EXE} ${CLANG_FORMAT_ARG} {} \;  > clang_format_results_h.txt 2>&1
+rtncode=$?
+echo "=== CLANG-FORMAT FINISHED *.h CHECKS WITH RTN CODE $rtncode"
+
+# Run clang-format on all specific .cc files
+echo
+find . -type d \( $DIRS_TO_SKIP \) -prune -false -o -name '*.cc' -exec ${CLANG_FORMAT_EXE} ${CLANG_FORMAT_ARG} {} \; > clang_format_results_cc.txt 2>&1
+rtncode=$?
+echo "=== CLANG-FORMAT FINISHED *.cc CHECKS WITH RTN CODE $rtncode"
+
+# Set a test result return to a default rtn
+export FINAL_TEST_RESULT=0
+
+# Evaluate the Results
+echo
+if [ -s ./clang_format_results_h.txt ]; then
+  echo "=== CLANG FORMAT RESULT FILE FOR .h FILES IS IS NOT EMPTY - FAILURE"
+  cat ./clang_format_results_h.txt
+  export FINAL_TEST_RESULT=1
+else
+  echo "=== CLANG FORMAT RESULT FILE FOR .h FILES IS EMPTY - SUCCESS"
+fi
+
+echo
+if [ -s ./clang_format_results_cc.txt ]; then
+  echo "=== CLANG FORMAT RESULT FILE FOR .cc FILES IS IS NOT EMPTY - FAILURE"
+  cat ./clang_format_results_cc.txt
+  export FINAL_TEST_RESULT=1
+else
+  echo "=== CLANG FORMAT RESULT FILE FOR .cc FILES IS EMPTY - SUCCESS"
+fi
+
+# Display the final results
+echo
+echo "========================================"
+if [ $FINAL_TEST_RESULT == 0 ]; then
+echo "=== FINAL TEST RESULT = ($FINAL_TEST_RESULT) - PASSED ==="
+else
+echo "=== FINAL TEST RESULT = ($FINAL_TEST_RESULT) - FAILED ==="
+fi
+echo "========================================"
+echo
+
+exit $FINAL_TEST_RESULT


### PR DESCRIPTION
Adding clang format configuration file and clang format script.  The `.clang-format` script was copied directly from the sst-core master branch on 07/22/2022.  The `clang-format-test.sh` script was also pulled from sst-core, but modified slightly for the sst-elements directory structure.  This PR is in prep to begin reformatting the sst-elements code (which contains a rather diverse set of code styles) in the same manner as sst-core.  We hope to move to a centrally formatted set of sst-elements in the future and add the clang-format-test script to the standard PR checks.  
