### PR TITLE
Use proper asm for linux/osx

### DIFF
--- a/src/sst/elements/mercury/Makefile.am
+++ b/src/sst/elements/mercury/Makefile.am
@@ -39,6 +39,7 @@ libhg_la_SOURCES = \
 #  threading/threading_pth.cc \
 #  threading/threading_ucontext.cc
 
+if SST_COMPILE_OSX
 if SST_HG_X86
   libhg_la_SOURCES += \
     operating_system/threading/asm/make_x86_64_sysv_macho_gas.S \
@@ -50,6 +51,20 @@ if SST_HG_A64
     operating_system/threading/asm/make_arm64_aapcs_macho_gas.S \
     operating_system/threading/asm/jump_arm64_aapcs_macho_gas.S \
     operating_system/threading/asm/ontop_arm64_aapcs_macho_gas.S
+endif
+else
+if SST_HG_X86
+  libhg_la_SOURCES += \
+    operating_system/threading/asm/make_x86_64_sysv_elf_gas.S \
+    operating_system/threading/asm/jump_x86_64_sysv_elf_gas.S \
+    operating_system/threading/asm/ontop_x86_64_sysv_elf_gas.S
+endif
+if SST_HG_A64
+  libhg_la_SOURCES += \
+    operating_system/threading/asm/make_arm64_aapcs_elf_gas.S \
+    operating_system/threading/asm/jump_arm64_aapcs_elf_gas.S \
+    operating_system/threading/asm/ontop_arm64_aapcs_elf_gas.S
+endif
 endif
 
 libsystemapi_la_SOURCES = \


### PR DESCRIPTION
Mercury bug fix: Use proper asm for linux/osx