### PR TITLE
Fix use of uint instead of uint32_t in several components

### DIFF
--- a/src/sst/elements/CramSim/c_AddressHasher.cpp
+++ b/src/sst/elements/CramSim/c_AddressHasher.cpp
@@ -66,9 +66,9 @@ void c_AddressHasher::build(Params &params) {
 
   // this is replacement code for the above, which is generally safer than my implemention
   // of parsePattern below
-  uint l_curPos = 0;
+  uint32_t l_curPos = 0;
   vector<string> l_simpleOrder;
-  pair<string,uint> l_parsedData;
+  pair<string,uint32_t> l_parsedData;
 
   while(!l_mapCopy.empty()) {
     parsePattern(&l_mapCopy, &l_parsedData);
@@ -102,15 +102,15 @@ void c_AddressHasher::build(Params &params) {
     }
 
     l_curPos = 0;
-    map<string, uint> l_cfgBits;
-    l_cfgBits["C"] = (uint)log2(k_pNumChannels);
-    l_cfgBits["c"] = (uint)log2(k_pNumPseudoChannels);   // set the number of address bits assigned to pseudo channel.
-    l_cfgBits["R"] = (uint)log2(k_pNumRanks);
-    l_cfgBits["B"] = (uint)log2(k_pNumBankGroups);
-    l_cfgBits["b"] = (uint)log2(k_pNumBanks);
-    l_cfgBits["r"] = (uint)log2(k_pNumRows);
-    l_cfgBits["l"] = (uint)log2(k_pNumCols);
-    l_cfgBits["h"] = (uint)log2(k_pBurstSize);
+    map<string, uint32_t> l_cfgBits;
+    l_cfgBits["C"] = (uint32_t)log2(k_pNumChannels);
+    l_cfgBits["c"] = (uint32_t)log2(k_pNumPseudoChannels);   // set the number of address bits assigned to pseudo channel.
+    l_cfgBits["R"] = (uint32_t)log2(k_pNumRanks);
+    l_cfgBits["B"] = (uint32_t)log2(k_pNumBankGroups);
+    l_cfgBits["b"] = (uint32_t)log2(k_pNumBanks);
+    l_cfgBits["r"] = (uint32_t)log2(k_pNumRows);
+    l_cfgBits["l"] = (uint32_t)log2(k_pNumCols);
+    l_cfgBits["h"] = (uint32_t)log2(k_pBurstSize);
 
     for(auto l_iter : l_simpleOrder) {
       m_structureSizes[l_iter] = l_cfgBits[l_iter];
@@ -526,7 +526,7 @@ ulong c_AddressHasher::getAddressForBankId(const unsigned x_bankId) {
 // also removes the matched portion of the pattern from l_inStr
 //
 // everything is parsed from the end of the string backwards
-void c_AddressHasher::parsePattern(string *x_inStr, std::pair<string,uint> *x_outPair) {
+void c_AddressHasher::parsePattern(string *x_inStr, std::pair<string,uint32_t> *x_outPair) {
   assert(x_inStr != nullptr);
   assert(x_outPair != nullptr);
 
@@ -575,4 +575,4 @@ void c_AddressHasher::parsePattern(string *x_inStr, std::pair<string,uint> *x_ou
       break;
     }
   } // while(!l_matched)
-} // parsePattern(string, pair<string,uint>)
+} // parsePattern(string, pair<string,uint32_t>)

--- a/src/sst/elements/GNA/GNA.cc
+++ b/src/sst/elements/GNA/GNA.cc
@@ -130,7 +130,7 @@ void GNA::init(unsigned int phase) {
         using namespace Interfaces;
         // most neurons connect to 1-4, 1% connect to 15
         uint16_t roll = rng.generateNextUInt32() % 100;
-        uint numCon = 1;
+        uint32_t numCon = 1;
         bool local = 1;
         if (roll == 0) {
             numCon = 15;
@@ -214,7 +214,8 @@ void GNA::init(unsigned int phase) {
     }
 #endif
     for (int i = 0; i < bwpl_len; ++i) {
-        BWPs.insert(std::pair<uint,Ctrl_And_Stat_Types::T_BwpFl>(bwpl[i].TmpSft, bwpl[i]));
+        BWPs.insert(std::pair<uint32_t,Ctrl_And_Stat_Types::T_BwpFl>(bwpl[i].TmpSft, 
+bwpl[i]));
     }
 }
 

--- a/src/sst/elements/GNA/GNA.cc
+++ b/src/sst/elements/GNA/GNA.cc
@@ -315,7 +315,7 @@ void GNA::processFire() {
 
 // run LIF on all neurons
 void GNA::lifAll() {
-    for (uint n = 0; n < numNeurons; ++n) {
+    for (uint32_t n = 0; n < numNeurons; ++n) {
         bool fired = neurons[n].lif(now);
         if (fired) {
             //printf(" %d fired\n", n);

--- a/src/sst/elements/GNA/GNA.h
+++ b/src/sst/elements/GNA/GNA.h
@@ -93,24 +93,24 @@ private:
 
     Output out;
     Interfaces::StandardMem * memory;
-    uint numNeurons;
-    uint BWPpTic;
-    uint STSDispatch;
-    uint STSParallelism;
-    uint maxOutMem;
-    uint now;
-    uint numFirings;
-    uint numDeliveries;
+    uint32_t numNeurons;
+    uint32_t BWPpTic;
+    uint32_t STSDispatch;
+    uint32_t STSParallelism;
+    uint32_t maxOutMem;
+    uint32_t now;
+    uint32_t numFirings;
+    uint32_t numDeliveries;
     queue<SST::Interfaces::StandardMem::Request *> outgoingReqs;
 
     neuron *neurons;
     vector<STS> STSUnits;
 
-    typedef multimap<const uint, Ctrl_And_Stat_Types::T_BwpFl> BWPBuf_t;
+    typedef multimap<const uint32_t, Ctrl_And_Stat_Types::T_BwpFl> BWPBuf_t;
     // brain wave pulse buffer
     BWPBuf_t BWPs;
 
-    std::deque<uint> firedNeurons;
+    std::deque<uint32_t> firedNeurons;
     std::map<uint64_t, STS*> requests;
 
     TimeConverter *clockTC;

--- a/src/sst/elements/GNA/neuron.h
+++ b/src/sst/elements/GNA/neuron.h
@@ -29,12 +29,12 @@ public:
     void configure(const Neuron_Loader_Types::T_NctFl &in) {
         config = in;
     }
-    void deliverSpike(float str, uint when) {
+    void deliverSpike(float str, uint32_t when) {
         temporalBuffer[when] += str;
         //printf(" got %f @ %d\n", str, when);
     }
     // performs Leaky Integrate and Fire. Returns true if fired.
-    bool lif(const uint now) {
+    bool lif(const uint32_t now) {
         // Leak
         value -= config.NrnLkg;
 
@@ -65,7 +65,7 @@ private:
     Neuron_Loader_Types::T_NctFl config;
     float value;
     // temporal buffer
-    typedef map<const uint, float> tBuf_t;
+    typedef map<const uint32_t, float> tBuf_t;
     tBuf_t temporalBuffer;
     // Neuron's white matter list
     uint64_t WMLAddr; // start

--- a/src/sst/elements/GNA/sts.cc
+++ b/src/sst/elements/GNA/sts.cc
@@ -41,7 +41,7 @@ bool STS::isFree() {
     return (numSpikes == 0);
 }
 
-void STS::advance(uint now) {
+void STS::advance(uint32_t now) {
     // AFR: should throttle
     while (incomingReqs.empty() == false) {
         // get the request

--- a/src/sst/elements/GNA/sts.h
+++ b/src/sst/elements/GNA/sts.h
@@ -44,7 +44,7 @@ public:
     STS(GNA *parent, int n) : myGNA(parent), stsID(n), numSpikes(0) {;}
     bool isFree();
     void assign(int);
-    void advance(uint);
+    void advance(uint32_t);
     void returnRequest(SST::Interfaces::StandardMem::Request *req) {
         incomingReqs.push(req);
     }

--- a/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.cc
+++ b/src/sst/elements/memHierarchy/membackend/HBMpagedMultiBackend.cc
@@ -539,7 +539,7 @@ void HBMpagedMultiMemory::moveToFast(HBMpageInfo &page) {
     assert(page.swapDir == HBMpageInfo::NONE);
 
     uint64_t addr = page.pageAddr << pageShift;
-    const uint numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
+    const uint32_t numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
 
     // mark page as swapping
     page.swapDir = HBMpageInfo::StoF;
@@ -563,7 +563,7 @@ void HBMpagedMultiMemory::moveToSlow(HBMpageInfo *page) {
     assert(page->swapDir == HBMpageInfo::NONE);
 
     uint64_t addr = page->pageAddr << pageShift;
-    const uint numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
+    const uint32_t numTransfers = 1 << (pageShift - 6); // assume 2^6 byte cache liens
 
     dbg.debug(_L10_, "moveToSlow(%p addr:%p)\n", page, (void*)(addr));
 

--- a/src/sst/elements/memHierarchy/membackend/pagedMultiBackend.h
+++ b/src/sst/elements/memHierarchy/membackend/pagedMultiBackend.h
@@ -41,12 +41,12 @@ struct pageInfo {
     typedef pageList_t::iterator pageListIter;
 
     uint64_t pageAddr;
-    uint touched; // how many times it is touched in quanta (used in LFU)
+    uint32_t touched; // how many times it is touched in quanta (used in LFU)
     pageListIter listEntry;
     bool inFast;
     SimTime_t lastTouch; // used in mrpuLRU
     uint64_t lastRef; // used in scan detection
-    uint scanLeng; // number of consecutive unit-1-stride accesses
+    uint32_t scanLeng; // number of consecutive unit-1-stride accesses
     SimTime_t pageDelay; // time when page will be in fast mem
 
     typedef enum {NONE, FtoS, StoF} swapDir_t;
@@ -283,12 +283,12 @@ public:
 
     typedef map<uint64_t, pageInfo> pageMap_t;
     pageMap_t pageMap;
-    uint maxFastPages;
-    uint pageShift;
-    uint pagesInFast;
-    uint lastMin;
-    uint threshold;
-    uint scanThreshold;
+    uint32_t maxFastPages;
+    uint32_t pageShift;
+    uint32_t pagesInFast;
+    uint32_t lastMin;
+    uint32_t threshold;
+    uint32_t scanThreshold;
     SimTime_t transferDelay;
     SimTime_t minAccTime;
     bool collectStats;


### PR DESCRIPTION
- Changes several uses of `uint` over to `uint32_t` to fix issues identified in bug #1929.