### PR TITLE
Fix mercury c++ standard compliance/warnings

### DIFF
--- a/src/sst/elements/mercury/common/component.h
+++ b/src/sst/elements/mercury/common/component.h
@@ -44,7 +44,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #pragma once
 
-#include <sst/core/sst_config.h>
+#include <sst_element_config.h>
 #include <sst/core/component.h>
 #include <sst/core/subcomponent.h>
 #include <sst/core/link.h>

--- a/src/sst/elements/mercury/common/util.cc
+++ b/src/sst/elements/mercury/common/util.cc
@@ -49,6 +49,9 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #include <cstring>
 
+extern template class  SST::Hg::HgBase<SST::Component>;
+extern template class  SST::Hg::HgBase<SST::SubComponent>;
+
 typedef int (*main_fxn)(int,char**);
 typedef int (*empty_main_fxn)();
 

--- a/src/sst/elements/mercury/components/node.cc
+++ b/src/sst/elements/mercury/components/node.cc
@@ -21,6 +21,7 @@
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
 extern template SST::TimeConverter* HgBase<SST::Component>::time_converter_;
 
 Node::Node(ComponentId_t id, Params &params)
@@ -28,7 +29,7 @@ Node::Node(ComponentId_t id, Params &params)
 
   my_addr_ = getId();
   unsigned int verbose = params.find<unsigned int>("verbose",0);
-  out_ = std::make_unique<Output>(sprintf("Node%d:",my_addr_), verbose, 0, Output::STDOUT);
+  out_ = std::unique_ptr<SST::Output>(new SST::Output(sprintf("Node%d:",my_addr_), verbose, 0, Output::STDOUT));
 
   out_->debug(CALL_INFO, 1, 0, "loading hg.operatingsystem\n");
   os_ =  loadAnonymousSubComponent<OperatingSystem>("hg.operating_system", "os_slot", OS_SLOT,

--- a/src/sst/elements/mercury/components/operating_system.cc
+++ b/src/sst/elements/mercury/components/operating_system.cc
@@ -35,6 +35,8 @@ static uintptr_t sst_hg_nullptr_range = 0;
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
 extern template SST::TimeConverter* HgBase<SST::SubComponent>::time_converter_;
 
 OperatingSystem* OperatingSystem::active_os_ = nullptr;
@@ -69,7 +71,7 @@ OperatingSystem::OperatingSystem(SST::ComponentId_t id, SST::Params& params, Nod
   auto os_params = params.get_scoped_params("OperatingSystem");
   os_params.print_all_params(std::cerr);
   unsigned int verbose = os_params.find<unsigned int>("verbose",0);
-  out_ = std::make_unique<SST::Output>(sprintf("Node%d:OperatingSystem:", my_addr_), verbose, 0, Output::STDOUT);
+  out_ = std::unique_ptr<SST::Output>(new SST::Output(sprintf("Node%d:OperatingSystem:", my_addr_), verbose, 0, Output::STDOUT));
   out_->debug(CALL_INFO, 1, 0, "constructing\n");
 
   if (sst_hg_nullptr == nullptr){
@@ -285,17 +287,17 @@ OperatingSystem::completeActiveThread()
   Thread* thr_todelete = active_thread_;
 
   //if any threads waiting on the join, unblock them
-  out_->debug(CALL_INFO, 1, 0, "completing thread %ld\n", thr_todelete->threadId());
+  out_->debug(CALL_INFO, 1, 0, "completing thread %d\n", thr_todelete->threadId());
   while (!thr_todelete->joiners_.empty()) {
       Thread* blocker = thr_todelete->joiners_.front();
-      out_->debug(CALL_INFO, 1, 0, "thread %ld is unblocking joiner %p\n",
+      out_->debug(CALL_INFO, 1, 0, "thread %d is unblocking joiner %p\n",
                   thr_todelete->threadId(), blocker);
       unblock(blocker);
       //to_awake_.push(thr_todelete->joiners_.front());
       thr_todelete->joiners_.pop();
     }
   active_thread_ = nullptr;  
-  out_->debug(CALL_INFO, 1, 0, "completing context for %ld\n", thr_todelete->threadId());
+  out_->debug(CALL_INFO, 1, 0, "completing context for %d\n", thr_todelete->threadId());
   thr_todelete->context()->completeContext(des_context_);
 }
 

--- a/src/sst/elements/mercury/libraries/system/system_api.cc
+++ b/src/sst/elements/mercury/libraries/system/system_api.cc
@@ -54,6 +54,7 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
 extern template SST::TimeConverter* HgBase<SST::SubComponent>::time_converter_;
 
 using os = OperatingSystem;

--- a/src/sst/elements/mercury/operating_system/launch/app_launcher.cc
+++ b/src/sst/elements/mercury/operating_system/launch/app_launcher.cc
@@ -50,6 +50,9 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
+
 AppLauncher::AppLauncher(OperatingSystem* os) :
   os_(os)
 {

--- a/src/sst/elements/mercury/operating_system/libraries/api.cc
+++ b/src/sst/elements/mercury/operating_system/libraries/api.cc
@@ -56,6 +56,8 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
 extern template SST::TimeConverter* HgBase<SST::SubComponent>::time_converter_;
 
 static thread_lock the_api_lock;

--- a/src/sst/elements/mercury/operating_system/libraries/library.cc
+++ b/src/sst/elements/mercury/operating_system/libraries/library.cc
@@ -48,6 +48,9 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
+
 Library::Library(const std::string& libname, SoftwareId sid, OperatingSystem* os) :
   os_(os),
   sid_(sid), 

--- a/src/sst/elements/mercury/operating_system/libraries/unblock_event.cc
+++ b/src/sst/elements/mercury/operating_system/libraries/unblock_event.cc
@@ -49,6 +49,9 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
+
 UnblockEvent::UnblockEvent(OperatingSystem *os, Thread *thr)
   :  os_(os), thr_(thr)
 {

--- a/src/sst/elements/mercury/operating_system/process/app.cc
+++ b/src/sst/elements/mercury/operating_system/process/app.cc
@@ -306,7 +306,7 @@ App::App(SST::Params& params, SoftwareId sid,
   notify_(true),
   rc_(0)
 {
-  out_ = std::make_unique<Output>(sprintf("application%d:", sid.app_), 1, 0, Output::STDOUT);
+  out_ = std::unique_ptr<SST::Output>(new SST::Output(sprintf("application%d:", sid.app_), 1, 0, Output::STDOUT));
   out_->debug(CALL_INFO, 1, 0, "constructing");
 
   //globals_storage_ = allocateDataSegment(false); //not tls

--- a/src/sst/elements/mercury/operating_system/process/loadlib.h
+++ b/src/sst/elements/mercury/operating_system/process/loadlib.h
@@ -44,7 +44,7 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #pragma once
 
-#include <sst/core/sst_config.h>
+#include <sst_element_config.h>
 #include <sst/core/output.h>
 #include <string>
 

--- a/src/sst/elements/mercury/operating_system/process/simple_compute_scheduler.cc
+++ b/src/sst/elements/mercury/operating_system/process/simple_compute_scheduler.cc
@@ -50,6 +50,9 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
+
 void
 SimpleComputeScheduler::reserveCores(int ncores, Thread* thr)
 {

--- a/src/sst/elements/mercury/operating_system/process/thread.cc
+++ b/src/sst/elements/mercury/operating_system/process/thread.cc
@@ -74,6 +74,8 @@ using namespace std;
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
 extern template SST::TimeConverter* HgBase<SST::SubComponent>::time_converter_;
 
 static thread_safe_u32 THREAD_ID_CNT(0);

--- a/src/sst/elements/mercury/operating_system/process/thread_info.cc
+++ b/src/sst/elements/mercury/operating_system/process/thread_info.cc
@@ -61,6 +61,9 @@ Questions? Contact sst-macro-help@sandia.gov
 namespace SST {
 namespace Hg {
 
+extern template class  HgBase<SST::Component>;
+extern template class  HgBase<SST::SubComponent>;
+
 //#if (SST_HG_TLS_OFFSET != SPKT_TLS_OFFSET)
 //#error sprockit and sstmac do not agree on stack TLS offset
 //#endif


### PR DESCRIPTION
Make mercury build with -std=c++11 and fix a bunch of warnings