### PR TITLE
Fix automake for Mercury

### DIFF
--- a/src/sst/elements/mercury/Makefile.am
+++ b/src/sst/elements/mercury/Makefile.am
@@ -5,6 +5,9 @@
 AM_CPPFLAGS += \
 	$(MPI_CPPFLAGS)
 
+# unpleasant hack to make vintage automake (e.g. 1.13.4) work
+AM_LIBTOOLFLAGS = --tag=CXX
+
 compdir = $(pkglibdir)
 comp_LTLIBRARIES = libhg.la libsystemapi.la
 libhg_la_SOURCES = \


### PR DESCRIPTION
Older automake (e.g. 1.13.4) don't include a libtool tag for assembly files (.S) and, due to some other libtool oddities, libtool can't infer that it should use either c or c++ mode (both work actually).

This fix is a hack that happens to work -- just stick --tag=CXX in front of every call to libtool by adding it to AM_LIBTOOLFLAGS. Since we're always compiling c++ files we get lucky and this works without breaking anything else.

I don't like it, but it works.