### PR TITLE
Vanadis 

### DIFF
--- a/src/sst/elements/vanadis/os/node/vnodeosopenath.h
+++ b/src/sst/elements/vanadis/os/node/vnodeosopenath.h
@@ -58,6 +58,12 @@ public:
                 output->verbose(CALL_INFO, 16, 0, "[syscall-openat] new Vanadis file descriptor %" PRIu32 ", SST file descriptor %d\n",
                         opened_fd_handle, desp->getFileDescriptor() );
             } catch ( int error ) {
+
+#ifdef SST_COMPILE_MACOSX
+                if ( errno == 30 ) {
+                    errno = 13;
+                }
+#endif
                 opened_fd_handle = -errno;
                 char buf[100];
                 strerror_r(errno,buf,100);

--- a/src/sst/elements/vanadis/os/vmipscpuos.h
+++ b/src/sst/elements/vanadis/os/vmipscpuos.h
@@ -232,6 +232,12 @@ public:
             int32_t path_addr = getRegister( 5 );
             int32_t flags = getRegister( 6 );
 
+#ifdef SST_COMPILE_MACOSX
+            if ( dirFd == -100 ) {
+                dirFd = -2;
+            }
+#endif
+
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to unlinkat( %d, %" PRId32 ", %#" PRIx32" )\n",dirFd,path_addr,flags);
 
             call_ev = new VanadisSyscallUnlinkatEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_32B, dirFd,path_addr,flags);

--- a/src/sst/elements/vanadis/os/vriscvcpuos.h
+++ b/src/sst/elements/vanadis/os/vriscvcpuos.h
@@ -227,6 +227,11 @@ public:
             int64_t path_addr = getRegister<int64_t>( 11 );
             int64_t flags = getRegister<int64_t>( 12 );
 
+#ifdef SST_COMPILE_MACOSX
+            if ( dirFd == -100 ) {
+                dirFd = -2;
+            }
+#endif
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to unlinkat( %d, %" PRIu64 ", %#" PRIx64" )\n",dirFd,path_addr,flags);
 
             call_ev = new VanadisSyscallUnlinkatEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, dirFd,path_addr,flags);
@@ -247,13 +252,11 @@ public:
             uint64_t openat_flags = getRegister<uint64_t>( 12 );
             uint64_t openat_mode = getRegister<uint64_t>(13);
 
-
 #ifdef SST_COMPILE_MACOSX
             if ( openat_dirfd == -100 ) {
                 openat_dirfd = -2;
             }
 #endif
-
             output->verbose(CALL_INFO, 8, 0, "[syscall-handler] found a call to openat( %d, %#llx, %#" PRIx64 ", %#" PRIx64 ")\n",
                     openat_dirfd, openat_path_ptr, openat_flags, openat_mode);
 

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -9,6 +9,8 @@ module_init = 0
 module_sema = threading.Semaphore()
 vanadis_test_matrix = []
 
+MakeTests = False
+#MakeTests = True
 updateFiles = False
 #updateFiles = True
 
@@ -126,7 +128,8 @@ class testcase_vanadis(SSTTestCase):
     def test_vanadis_short_tests(self, testnum, testname, sdlfile, elftestdir, elffile, isa, timeout_sec):
         self._checkSkipConditions( isa )
 
-        self.makeTest( testname, isa, elftestdir, elffile )
+        if MakeTests:
+            self.makeTest( testname, isa, elftestdir, elffile )
         log_debug("Running Vanadis test #{0} ({1}): elffile={4} in dir {3}, isa {5}; using sdl={2}".format(testnum, testname, sdlfile, elftestdir, elffile, isa, timeout_sec))
         self.vanadis_test_template(testnum, testname, sdlfile, elftestdir, elffile, isa, timeout_sec)
 
@@ -222,8 +225,9 @@ class testcase_vanadis(SSTTestCase):
 
     def _checkSkipConditions(self,isa):
         # Check to see if the musl compiler is missing
-        if self._is_musl_compiler_available(isa) == False:
-            self.skipTest("Vanadis Skipping Test - musl compiler not available")
+        if MakeTests:
+            if self._is_musl_compiler_available(isa) == False:
+                self.skipTest("Vanadis Skipping Test - musl compiler not available")
 
         if testing_check_get_num_ranks() > 1:
             self.skipTest("Vanadis Skipping Test - ranks > 1 not supported")


### PR DESCRIPTION

- change testing so it uses the executables that are in the repository, this allows testing on machines that don't have compilers installed
- fix the openat and unlinkat system calls so the produced the same result on OSX and Linux