### PR TITLE
Tweak Data Structures to Improve Performance in Vanadis

### DIFF
--- a/src/sst/elements/vanadis/datastruct/cqueue.h
+++ b/src/sst/elements/vanadis/datastruct/cqueue.h
@@ -41,8 +41,8 @@ public:
         delete[] data;
     }
 
-    bool empty() { return 0 == count; }
-    bool full() { return max_capacity == count; }
+    bool empty() const { return 0 == count; }
+    bool full() const { return max_capacity == count; }
 
     void push(T item) {
         assert(count < max_capacity);

--- a/src/sst/elements/vanadis/datastruct/cqueue.h
+++ b/src/sst/elements/vanadis/datastruct/cqueue.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstddef>
 #include <deque>
+#include <bitset>
 
 namespace SST {
 namespace Vanadis {
@@ -27,45 +28,80 @@ template <typename T>
 class VanadisCircularQueue
 {
 public:
-    VanadisCircularQueue(const size_t size) : max_capacity(size) {}
+    VanadisCircularQueue(const int size) : max_capacity(size) {
+        data = new T[size];
+        clear();
 
-    ~VanadisCircularQueue() {}
+        std::bitset<32> size_bits(size);
+        max_power_two = (size_bits.count() == 1);
+        bit_mask = max_power_two ? size - 1 : 0;
+    }
 
-    bool empty() { return 0 == data.size(); }
+    ~VanadisCircularQueue() {
+        delete[] data;
+    }
 
-    bool full() { return max_capacity == data.size(); }
+    bool empty() { return 0 == count; }
+    bool full() { return max_capacity == count; }
 
-    void push(T item) { data.push_back(item); }
+    void push(T item) {
+        assert(count < max_capacity);
 
-    T peek() { return data.front(); }
+        data[tail] = item;
+        tail = incrementIndex(tail);
+        count++;
+    }
 
-    T peekAt(const size_t index) { return data.at(index); }
+    T peek() {
+        assert(count > 0);
+
+        T peek_me = data[head];
+        return peek_me;
+    }
+
+    T peekAt(const size_t index) { 
+        assert(index < count);
+        return data[calculateIndex(index)];
+    }
 
     T pop()
     {
-        T tmp = data.front();
-        data.pop_front();
-        return tmp;
+        assert(count > 0);
+
+        T pop_me = data[head];
+        head = incrementIndex(head);
+        count--;
+
+        return pop_me;
     }
 
-    size_t size() const { return data.size(); }
-
+    size_t size() const { return count; }
     size_t capacity() const { return max_capacity; }
 
-    void clear() { data.clear(); }
-
-    void removeAt(const size_t index)
-    {
-        auto remove_itr = data.begin();
-
-        for ( size_t i = 0; i < index; ++i, remove_itr++ ) {}
-
-        data.erase(remove_itr);
+    void clear() {
+        head = 0;
+        tail = 0;
+        count = 0;
     }
 
 private:
+    int calculateIndex(const int index) const {
+        return max_power_two ? (head + index) & bit_mask : (head + index) % max_capacity;
+    }
+
+    int incrementIndex(const int index) const {
+        return max_power_two ? (index + 1) & bit_mask : (index + 1) % max_capacity;
+    }
+
     const size_t  max_capacity;
-    std::deque<T> data;
+    int head;
+    int tail;
+    int count;
+
+    T* data;
+
+    bool max_power_two;
+    int bit_mask;
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/datastruct/vcache.h
+++ b/src/sst/elements/vanadis/datastruct/vcache.h
@@ -57,9 +57,9 @@ public:
     }
 
     void store(const I& key, T value) {
-        if (contains(key)) {
+        if (LIKELY(contains(key))) {
             send_key_to_front(key);
-	    data_values[key] = value;
+	        data_values[key] = value;
         } else {
             kill_lru_key();
             data_values.insert(std::pair<I, T>(key, value));
@@ -68,7 +68,7 @@ public:
     }
 
     void touch(const I& key) {
-        if (contains(key)) {
+        if (LIKELY(contains(key))) {
             send_key_to_front(key);
         }
     }
@@ -84,7 +84,7 @@ private:
             return;
         }
 
-        I remove_key = ordering_q.back();
+        const I remove_key = ordering_q.back();
         ordering_q.pop_back();
 
         auto find_key = data_values.find(remove_key);
@@ -95,7 +95,7 @@ private:
     void send_key_to_front(const I& key) {
         bool found_key = false;
 
-        for (auto order_itr = ordering_q.begin(); order_itr != ordering_q.end();) {
+        for (auto order_itr = ordering_q.cbegin(); order_itr != ordering_q.cend();) {
             if (key == (*order_itr)) {
                 ordering_q.erase(order_itr);
                 found_key = true;
@@ -105,7 +105,7 @@ private:
             }
         }
 
-        if (found_key) {
+        if (LIKELY(found_key)) {
             ordering_q.push_front(key);
         }
     }


### PR DESCRIPTION
Tweak circular queue and standard cache data structures to improve performance by a small amount in long running Vanadis simulations.