### PR TITLE
Fix for gcc 4.2 std::list

### DIFF
--- a/src/sst/elements/vanadis/datastruct/vcache.h
+++ b/src/sst/elements/vanadis/datastruct/vcache.h
@@ -95,7 +95,7 @@ private:
     void send_key_to_front(const I& key) {
         bool found_key = false;
 
-        for (auto order_itr = ordering_q.cbegin(); order_itr != ordering_q.cend();) {
+        for (auto order_itr = ordering_q.begin(); order_itr != ordering_q.end();) {
             if (UNLIKELY(key == (*order_itr))) {
                 ordering_q.erase(order_itr);
                 found_key = true;


### PR DESCRIPTION
std::list will not work with const iters in c++98...and it looks like this isn't completely implemented in c++11 in gcc-4.8.2