### PR TITLE
fixing merlin linkcontrol parameters for memHierarchy.memNIC

### DIFF
--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -47,7 +47,7 @@ MemNIC::MemNIC(ComponentId_t id, Params &params, TimeConverter* tc) : MemNICBase
         std::string link_control_class = params.find<std::string>("network_link_control", "merlin.linkcontrol");
 
         if (link_control_class != "merlin.linkcontrol")
-            dbg.output("%s, Warning: use of the 'network_link_control' parameter is deprecated in favor of specifying a named 'linkcontrol' subcomponent in the input configuration.\n",
+          dbg.fatal(CALL_INFO, -1, "%s, Error: use of the 'network_link_control' parameter is no longer supported. Please specify a named 'linkcontrol' subcomponent in the input configuration.\n",
                     getName().c_str());
 
         link_control = loadAnonymousSubComponent<SimpleNetwork>(link_control_class, "linkcontrol", 0, ComponentInfo::SHARE_PORTS | ComponentInfo::INSERT_STATS, netparams, 1);

--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -41,8 +41,8 @@ MemNIC::MemNIC(ComponentId_t id, Params &params, TimeConverter* tc) : MemNICBase
     if (!link_control) {
         Params netparams;
         netparams.insert("port_name", params.find<std::string>("port", "port"));
-        netparams.insert("in_buf_size", params.find<std::string>("network_input_buffer_size", "1KiB"));
-        netparams.insert("out_buf_size", params.find<std::string>("network_output_buffer_size", "1KiB"));
+        netparams.insert("input_buf_size", params.find<std::string>("network_input_buffer_size", "1KiB"));
+        netparams.insert("output_buf_size", params.find<std::string>("network_output_buffer_size", "1KiB"));
         netparams.insert("link_bw", params.find<std::string>("network_bw", "80GiB/s"));
         std::string link_control_class = params.find<std::string>("network_link_control", "merlin.linkcontrol");
 


### PR DESCRIPTION
@tomhaber submitted a bug (Issue #1916) regarding the `memHierarchy.memNIC` coupling to `merlin.linkcontrol`.  The bug is associated with the correct naming conventions for the `merlin.linkcontrol` `input_buf_size` and `output_buf_size`.  This is a very simple fix to inject the correct names in the subcomponent parameter setup for this particular subcomponent.  

Version tested: sst-elements-devel (2022.12.16); sst-core-devel (2022.12.16)