### PR TITLE
memH: Avoid duplicate entries in retryBuffer_

### DIFF
--- a/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
+++ b/src/sst/elements/memHierarchy/coherencemgr/coherenceController.cc
@@ -487,6 +487,7 @@ std::vector<MemEventBase*>* CoherenceController::getRetryBuffer() {
 
 void CoherenceController::clearRetryBuffer() {
     retryBuffer_.clear();
+    retryBufferAddrSet_.clear();
 }
 
 

--- a/src/sst/elements/memHierarchy/coherencemgr/coherenceController.h
+++ b/src/sst/elements/memHierarchy/coherencemgr/coherenceController.h
@@ -17,6 +17,7 @@
 #define MEMHIERARCHY_COHERENCECONTROLLER_H
 
 #include <array>
+#include <set>
 
 #include <sst/core/sst_config.h>
 #include <sst/core/subcomponent.h>
@@ -286,6 +287,7 @@ protected:
 
     /* Retry buffer - filled by coherence manangers and drained by parent */
     std::vector<MemEventBase*> retryBuffer_;
+    std::set<Addr> retryBufferAddrSet_;
 
     /* Statistics - some variables used by all are declared here, but they are maintained by coherence protocols */
     Statistic<uint64_t>* stat_eventSent[(int)Command::LAST_CMD];    // Count events sent


### PR DESCRIPTION
This pull request avoids duplicate entries in `retryBuffer_`. The retry buffer in caches is used for queueing events to retry. The retry buffer is designed under the assumption that all events in the buffer are unique. When there are duplicate events in the retry buffer, SST may fail to find an address in MSHR ("Error: MSHR::removePendingRetry. Address does not exist in MSHR."). Duplicate events in the retry buffer may appear when a cache is shared and multiple requests for the same address arrive in the same cycle. This patch tracks the address set in the retry buffer, and when an address is found in the address set, the corresponding event is not added to the retry buffer. This logic is only applied to shared caches because private caches will not experience the case where the same address is accessed by multiple requests at the same time.