### PR TITLE
add rdcycle assembly instruction support

### DIFF
--- a/src/sst/elements/vanadis/decoder/vdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vdecoder.h
@@ -213,6 +213,7 @@ public:
     void setThreadLocalStoragePointer(uint64_t new_tls) { tls_ptr = new_tls; }
 
     uint64_t getThreadLocalStoragePointer() const { return tls_ptr; }
+    uint64_t getCycleCount() const { return cycle_count; }
 
     // VanadisCircularQueue<VanadisInstruction*>* getDecodedQueue() { return
     // decoded_q; }
@@ -235,6 +236,7 @@ protected:
     uint32_t hw_thr;
 
     uint64_t tls_ptr;
+    uint64_t cycle_count;
 
     bool                                       wantDelegatedLoad;
     VanadisCircularQueue<VanadisInstruction*>* thread_rob;

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -434,6 +434,8 @@ public:
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Decode step for thr: %" PRIu32 "\n", hw_thr);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> Max decodes per cycle: %" PRIu16 "\n", max_decodes_per_cycle);
 
+        cycle_count = cycle;
+
         ins_loader->printStatus(output);
 
         uint16_t decodes_performed = 0;

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -136,6 +136,8 @@ public:
             output->verbose(CALL_INFO, 16, 0, "---> Max decodes per cycle: %" PRIu16 "\n", max_decodes_per_cycle);
         }
 
+        cycle_count = cycle;
+
         for ( uint16_t i = 0; i < max_decodes_per_cycle; ++i ) {
             if ( ! thread_rob->full() ) {
                 if ( ins_loader->hasBundleAt(ip) ) {
@@ -1088,6 +1090,18 @@ protected:
 
 										bundle->addInstruction(new VanadisFPFlagsReadInstruction<true, false, false>(ins_address, hw_thr, options, fpflags, rd));
                               decode_fault = false;
+                        } break;
+                        case 0xfffffffffffffc00:
+                        {
+                            auto thread_call = std::bind(&VanadisRISCV64Decoder::getCycleCount, this);
+
+                            // Read the cycle count
+                            output->verbose( CALL_INFO, 16, 0, "-------> RDCYCLE, read the cycle count\n");
+
+                            bundle->addInstruction(
+                                new VanadisSetRegisterByCallInstruction<int64_t>(
+                                    ins_address, hw_thr, options, rd, thread_call));
+                            decode_fault = false;
                         } break;
                         }
                     } break;


### PR DESCRIPTION
Add support to the RISCV decoder for RDCYCLE instruction.