### PR TITLE
Kill child process in finish phase if it is still running

### DIFF
--- a/src/sst/elements/ariel/frontend/pin3/pin3frontend.cc
+++ b/src/sst/elements/ariel/frontend/pin3/pin3frontend.cc
@@ -285,7 +285,14 @@ void Pin3Frontend::init(unsigned int phase)
     }
 }
 
-void Pin3Frontend::finish() { }
+void Pin3Frontend::finish() {
+    // If the simulation ended early, e.g. by using --stop-at, the child
+    // may still be executing. It will become a zombie if we do not
+    // kill it.
+    if (child_pid != 0) {
+        kill(child_pid, SIGKILL);
+    }
+}
 
 ArielTunnel* Pin3Frontend::getTunnel() {
     return tunnel;


### PR DESCRIPTION
Fixes #2070. 

This PR adds code to kill the child process in the `Pin3Frontend::finish()` method, so that the child process does not keep running after the simulation has ended.