### PR TITLE
Vanadis: fix mprotect bug

### DIFF
--- a/src/sst/elements/vanadis/os/include/virtMemMap.h
+++ b/src/sst/elements/vanadis/os/include/virtMemMap.h
@@ -207,7 +207,7 @@ public:
             }
         } else if ( ( addr < region->addr + region->length ) && ( addr + length == region->end() ) ) {
             region->length -= length; 
-            m_regionMap[addr] = new MemoryRegion( "", addr, length, prot ); 
+            m_regionMap[addr] = new MemoryRegion( region->name, addr, length, prot ); 
         } else {
                 // we currently are only supporting splitting a region
                 assert(0);

--- a/src/sst/elements/vanadis/os/syscall/mprotect.cc
+++ b/src/sst/elements/vanadis/os/syscall/mprotect.cc
@@ -33,6 +33,11 @@ VanadisMprotectSyscall::VanadisMprotectSyscall( VanadisNodeOSComponent* os, SST:
     if ( event->getProt() & PROT_WRITE ) {
         perms |= 0x2;
     }
+
+    // ***************
+    // Note that we are not flushing the TLBs
+    // to this point in development calls to mprotect have been limited and we can get away with not flushing TLBs
+    // ***************
     process->mprotect( event->getAddr(), event->getLen(), perms );
 
     setReturnSuccess(0);


### PR DESCRIPTION
mprotect was not properly splitting a memory region