### PR TITLE
RDMA NIC fix for RISCV

### DIFF
--- a/src/sst/elements/rdmaNic/rdmaNic.h
+++ b/src/sst/elements/rdmaNic/rdmaNic.h
@@ -26,6 +26,8 @@
 #include <sst/core/interfaces/stdMem.h>
 #include <sst/core/interfaces/simpleNetwork.h>
 
+typedef uint64_t Addr_t;
+
 #include "rdmaNicHostInterface.h"
 
 #define DBG_X_FLAG (1<<0)

--- a/src/sst/elements/rdmaNic/rdmaNicHostInterface.h
+++ b/src/sst/elements/rdmaNic/rdmaNicHostInterface.h
@@ -13,8 +13,6 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-typedef uint32_t Addr_t;
-
 typedef Addr_t Context;
 typedef int QueueIndex;
 typedef enum { RdmaDone=0, RdmaSend=1, RdmaRecv, RdmaFini, RdmaCreateCQ, RdmaDestroyCQ, RdmaCreateRQ, 
@@ -100,9 +98,9 @@ typedef struct __attribute__((aligned(64))) {
 
 typedef struct __attribute__((aligned(64))) {
 	uint32_t numThreads;
-	uint32_t reqQueueAddress;
+	Addr_t reqQueueAddress;
 	uint32_t reqQueueSize;
-	uint32_t compQueuesAddress;
+	Addr_t compQueuesAddress;
 
 	uint32_t nodeId;
 	uint32_t numNodes;
@@ -110,8 +108,8 @@ typedef struct __attribute__((aligned(64))) {
 } NicQueueInfo;
 
 typedef struct __attribute__((aligned(64))) {
-	uint32_t respAddress;
-	uint32_t reqQueueTailIndexAddress;
+	Addr_t respAddress;
+	Addr_t reqQueueTailIndexAddress;
 
 } HostQueueInfo;
 

--- a/src/sst/elements/rdmaNic/tests/app/rdma/Makefile
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/Makefile
@@ -1,10 +1,15 @@
-AR=mipsel-linux-musl-ar
-CC=mipsel-linux-musl-gcc
+ARCH ?= riscv64
+ADDR_TYPE ?= uint64_t
+PRIxBITS ?= PRIx64
+PRIuBITS ?= PRIu64
 
-CFLAGS=-Iinclude -I../../.. -Wattributes -Wall 
+AR=$(ARCH)-linux-musl-ar
+CC=$(ARCH)-linux-musl-gcc
+
+CFLAGS=-Iinclude -I../../.. -Wattributes -Wall -DADDR_TYPE=$(ADDR_TYPE)  -DPRIxBITS=$(PRIxBITS) -DPRIuBITS=$(PRIuBITS)
 LIBS=-lrdma -L.
 
-OBJS=rdma.o base.o
+OBJS=base.o rdma.o
 
 all: librdma.a write msg incast incast-v2 barrier
 librdma.a: ${OBJS}

--- a/src/sst/elements/rdmaNic/tests/app/rdma/incast-v2.c
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/incast-v2.c
@@ -18,6 +18,7 @@
 #include <rdma.h>
 #include <unistd.h>
 #include <strings.h>
+#include <inttypes.h>
 
 #define BUF_SIZE 100000
 
@@ -48,7 +49,7 @@ int main( int argc, char* argv[] ) {
 		for ( int i = 0; i < numNodes -1; i++ ) {
 			RdmaCompletion comp;
 			rdma_read_comp( cq, &comp, 1 );
-			printf("got a message in buffer %#x\n",comp.context);
+			printf("got a message in buffer %#" PRIxBITS "\n",comp.context);
 #if VALIDATE
 			uint32_t* buf = (uint32_t*) comp.context;
 			for ( int i = 0; i < BUF_SIZE; i++ ) {

--- a/src/sst/elements/rdmaNic/tests/app/rdma/incast.c
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/incast.c
@@ -18,6 +18,7 @@
 #include <rdma.h>
 #include <unistd.h>
 #include <strings.h>
+#include <inttypes.h>
 
 //#define BUF_SIZE 250000
 #define BUF_SIZE 10
@@ -60,7 +61,7 @@ int main( int argc, char* argv[] ) {
 		for ( int i = 0; i < numNodes -1; i++ ) {
 			RdmaCompletion comp;
 			rdma_read_comp( msgCq, &comp, 1 );
-			printf("got a message in buffer %#x\n",comp.context);
+			printf("got a message in buffer %#" PRIxBITS "\n",comp.context);
 #if VALIDATE
 			uint32_t* buf = (uint32_t*) comp.context;
 			for ( int i = 0; i < BUF_SIZE; i++ ) {

--- a/src/sst/elements/rdmaNic/tests/app/rdma/include/base.h
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/include/base.h
@@ -16,6 +16,10 @@
 #ifndef _BASE_H
 #define _BASE_H
 
+#include <stdint.h>
+
+typedef ADDR_TYPE Addr_t;
+
 #include <rdmaNicHostInterface.h>
 void writeCmd( NicCmd* cmd );
 void base_init();

--- a/src/sst/elements/rdmaNic/tests/app/rdma/msg.out.gold
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/msg.out.gold
@@ -2,4 +2,4 @@ node=0 pid=100 tid=100 has exited
 all process have exited
 node=1 pid=100 tid=100 has exited
 all process have exited
-Simulation is complete, simulated time: 69.8103 us
+Simulation is complete, simulated time: 55.4932 us

--- a/src/sst/elements/rdmaNic/tests/app/rdma/msg.stdout-node0.cpu0.os.gold
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/msg.stdout-node0.cpu0.os.gold
@@ -1,3 +1,3 @@
 myNode=0 numNodes=2
-buffer=0x101040
+buffer=0x1040
 returning

--- a/src/sst/elements/rdmaNic/tests/app/rdma/msg.stdout-node1.cpu0.os.gold
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/msg.stdout-node1.cpu0.os.gold
@@ -1,5 +1,5 @@
 myNode=1 numNodes=2
-buffer=0x101040
+buffer=0x1040
 validate
 validate complete
 returning

--- a/src/sst/elements/rdmaNic/tests/app/rdma/src/rdma.c
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/src/rdma.c
@@ -27,7 +27,7 @@
 #define dbgPrint(fmt, ARGS...) \
         do { if (DEBUG) fprintf(stdout, "%s():%d: " fmt, __func__,__LINE__, ##ARGS); } while (0) 
 
-typedef uint32_t* IndexPtr;
+typedef Addr_t* IndexPtr;
 
 typedef struct {
 	RdmaCompletion data[RDMA_COMP_Q_SIZE];
@@ -168,7 +168,7 @@ int rdma_create_cq( ) {
 	resp->data.createCQ.tailIndexAddr = getCompQueueInfoAddress();
 
 	int retval = resp->retval; 
-	dbgPrint("retval=%d tailIndexPtr=%#x\n",retval,resp->data.createCQ.tailIndexAddr);
+	dbgPrint("retval=%d tailIndexPtr=%#" PRIxBITS "\n",retval,resp->data.createCQ.tailIndexAddr);
 	assert( retval < NUM_COMP_Q ); 
 	assert( s_compQ[retval].tailIndexAddr == (IndexPtr) NULL );
 	s_compQ[retval].tailIndexAddr = (IndexPtr) resp->data.createCQ.tailIndexAddr; 
@@ -245,7 +245,7 @@ int rdma_send_post( void* buf, size_t len, Node destNode, Pid destPid, RecvQueue
 
 	NicCmd* cmd = allocCmd();
 	
-	dbgPrint("ptr=%p len=%zu destNode=%d destPid=%d cmdbuf=%p context=%#x\n", buf,len,destNode,destPid,cmd,context);
+	dbgPrint("ptr=%p len=%zu destNode=%d destPid=%d cmdbuf=%p context=%#" PRIxBITS "\n", buf,len,destNode,destPid,cmd,context);
 
 	cmd->type = RdmaSend;
 	cmd->data.send.pe = destPid;
@@ -272,7 +272,7 @@ int rdma_recv_post( void* buf, size_t len, RecvQueueId rqId, Context context )
 {
 	NicCmd* cmd = allocCmd();
 	
-	dbgPrint("buf=%p len=%zu rqId=%d context=%#x\n", buf,len,rqId,context);
+	dbgPrint("buf=%p len=%zu rqId=%d context=%#" PRIxBITS "\n", buf,len,rqId,context);
 
 	cmd->type = RdmaRecv;
 	cmd->data.recv.addr = (Addr_t)buf;
@@ -302,7 +302,7 @@ int rdma_read_comp( CompQueueId cqId, RdmaCompletion* buf, int blocking ) {
 	dbgPrint("got completion cqId=%d head=%d tail=%d \n",cqId, s_compQ[cqId].headIndex,s_compQ[cqId].tailIndex );
 	//RdmaCompletion* comp = &s_compQ[cqId].data[s_compQ[cqId].tailIndex];
 	memcpy( buf , &s_compQ[cqId].data[s_compQ[cqId].tailIndex], sizeof(*buf) );
-	dbgPrint("context=%x\n",buf->context);
+	dbgPrint("context=%#" PRIxBITS "\n",buf->context);
 
 	++s_compQ[cqId].tailIndex;
 	s_compQ[cqId].tailIndex %= s_compQ[cqId].num;
@@ -361,7 +361,7 @@ int rdma_memory_write( MemRgnKey key, Node node, Pid pid, size_t offset, void* s
 {
 	NicCmd* cmd = allocCmd();
 	
-	dbgPrint("key=%#x offset=%d length=%zu cqId=%d\n", key, offset, length, id );
+	dbgPrint("key=%#x offset=%" PRIuBITS " length=%zu cqId=%d\n", key, offset, length, id );
 
 	cmd->type = RdmaMemWrite;
 	cmd->data.write.key = key;
@@ -389,7 +389,7 @@ int rdma_memory_read( MemRgnKey key, Node node, Pid pid, size_t offset, void* de
 {
 	NicCmd* cmd = allocCmd();
 	
-	dbgPrint("key=%#x destBuffer=%p offset=%d length=%zu cqId=%d\n",key, destBuffer, offset, length, id );
+	dbgPrint("key=%#x destBuffer=%p offset=%" PRIuBITS " length=%zu cqId=%d\n",key, destBuffer, offset, length, id );
 
 	cmd->type = RdmaMemRead;
 	cmd->data.read.key = key;

--- a/src/sst/elements/rdmaNic/tests/app/rdma/write.c
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/write.c
@@ -47,7 +47,7 @@ int main( int argc, char* argv[] ) {
 		Pid pid = 0;
 	if ( myNode == 0 ) {
 		addr[0] = 0;
-		printf("%s() 0, read local mem, addr=%x\n",__func__,(int)addr);
+		printf("%s() 0, read local mem, addr=%p\n",__func__,addr);
 		while ( addr[0] == 0 );
 		printf("%s() 0, read local mem, value %x\n",__func__,addr[0]);
 
@@ -55,7 +55,7 @@ int main( int argc, char* argv[] ) {
 		volatile int tmp = 0;
 		
 		printf("%s() 0, addr of tmp  %p\n",__func__,&tmp);
-		rdma_memory_read( key, node, pid, 0, (void*) &tmp, sizeof(tmp), cq, (int)NULL ); 	
+		rdma_memory_read( key, node, pid, 0, (void*) &tmp, sizeof(tmp), cq, 0 ); 	
 	
 		while ( tmp == 0 );
 		printf("%s() 0, read far mem value %x\n",__func__,tmp);
@@ -68,7 +68,7 @@ int main( int argc, char* argv[] ) {
 		int tmp=0x1234abcd;
 			
 		Node node = 0; 
-		rdma_memory_write( key, node, pid, 0, &tmp, sizeof(tmp), cq, (int)NULL ); 	
+		rdma_memory_write( key, node, pid, 0, &tmp, sizeof(tmp), cq, 0 ); 	
 		while ( addr[0] == 0 );
 		printf("%s() 1, read local mem, value %x\n",__func__,addr[0]);
 	}

--- a/src/sst/elements/rdmaNic/tests/vanadisBlock.py
+++ b/src/sst/elements/rdmaNic/tests/vanadisBlock.py
@@ -1,9 +1,12 @@
 import os
 import sst
 
-#map = "0x0:0x80000000:0x80000000"
-
 coherence_protocol="MESI"
+
+vanadis_isa = os.getenv("VANADIS_ISA", "MIPS")
+isa="mipsel"
+vanadis_isa = os.getenv("VANADIS_ISA", "RISCV64")
+isa="riscv64"
 
 #physMemSize = "4GiB"
 
@@ -105,14 +108,14 @@ class Vanadis_Builder:
             if (verbosity > 0):
                 print( "No application arguments found, continuing with argc=0" )
 
-        decode = cpu.setSubComponent( "decoder0", "vanadis.VanadisMIPSDecoder" )
+        decode = cpu.setSubComponent( "decoder0", "vanadis.Vanadis" + vanadis_isa + "Decoder" )
 
         decode.addParams({
             "uop_cache_entries" : 1536,
             "predecode_cache_entries" : 4
         })
 
-        os_hdlr = decode.setSubComponent( "os_handler", "vanadis.VanadisMIPSOSHandler" )
+        os_hdlr = decode.setSubComponent( "os_handler", "vanadis.Vanadis" + vanadis_isa + "OSHandler" )
         os_hdlr.addParams({
             "verbose" : os_verbosity,
             "brk_zero_memory" : "yes"


### PR DESCRIPTION
Make the RDMA NIC work with both MIPS and RISCV. Make RISCV the default.
