### PR TITLE
Vanadis: Fix syscall to dead process

### DIFF
--- a/src/sst/elements/vanadis/os/vnodeos.cc
+++ b/src/sst/elements/vanadis/os/vnodeos.cc
@@ -334,10 +334,15 @@ VanadisNodeOSComponent::handleIncomingSyscall(SST::Event* ev) {
                       "a system-call event.\n");
         }
     } else {
-        auto process = m_coreInfoMap.at(sys_ev->getCoreID()).getProcess( sys_ev->getThreadID() );
-        auto syscall = handleIncomingSyscall( process, sys_ev, core_links[ sys_ev->getCoreID() ] );
+	auto process = m_coreInfoMap.at(sys_ev->getCoreID()).getProcess( sys_ev->getThreadID() );
+	if ( process ) {
+		auto syscall = handleIncomingSyscall( process, sys_ev, core_links[ sys_ev->getCoreID() ] );
 
-        processSyscallPost( syscall );
+		processSyscallPost( syscall );
+	} else {
+		printf("no active process for core %d, hwthread %d\n", sys_ev->getCoreID(), sys_ev->getThreadID() );
+		delete ev;
+	}
     } 
 }
 


### PR DESCRIPTION
When an exitgroup happens there is a race condition where a syscall from an hardware thread could be processed by the OS after it terminated the process.