### PR TITLE
Fix MemH MemRtrEvent memory leak

### DIFF
--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -83,7 +83,7 @@ bool MemNIC::clock(SimTime_t cycle) {
 bool MemNIC::recvNotify(int) {
     MemRtrEvent * mre = doRecv(link_control);
     if (mre) {
-        MemEventBase* ev = mre->event;
+        MemEventBase* ev = mre->takeEvent();
         delete mre;
         if (ev) {
             if (is_debug_event(ev)) {
@@ -136,7 +136,7 @@ void MemNIC::printStatus(Output &out) {
     // Since this is just debug/fatal we're just going to read out the queue & re-populate it
     std::queue<SST::Interfaces::SimpleNetwork::Request*> tmpQ;
     while (!sendQueue.empty()) {
-        MemEventBase * ev = static_cast<MemRtrEvent*>(sendQueue.front()->inspectPayload())->event;
+        MemEventBase * ev = static_cast<MemRtrEvent*>(sendQueue.front()->inspectPayload())->inspectEvent();
         out.output("      %s\n", ev->getVerboseString(out.getVerboseLevel()).c_str());
         tmpQ.push(sendQueue.front());
         sendQueue.pop();
@@ -151,7 +151,7 @@ void MemNIC::emergencyShutdownDebug(Output &out) {
     out.output(" Draining link control...\n");
     MemRtrEvent * mre = doRecv(link_control);
     while (mre != nullptr) {
-        MemEventBase * ev = mre->event;
+        MemEventBase * ev = mre->takeEvent();
         delete mre;
         if (ev) {
             out.output("      Undelivered message: %s\n", ev->getVerboseString(out.getVerboseLevel()).c_str());

--- a/src/sst/elements/memHierarchy/memNICFour.cc
+++ b/src/sst/elements/memHierarchy/memNICFour.cc
@@ -238,7 +238,7 @@ void MemNICFour::doRecv(SimpleNetwork::Request * req, NetType net) {
 }
 
 void MemNICFour::recvNotify(OrderedMemRtrEvent* mre) {
-    MemEventBase * me = static_cast<MemEventBase*>(mre->event);
+    MemEventBase * me = static_cast<MemEventBase*>(mre->takeEvent());
     delete mre;
 
     if (!me) return;

--- a/src/sst/elements/memHierarchy/memNetBridge.cc
+++ b/src/sst/elements/memHierarchy/memNetBridge.cc
@@ -86,7 +86,7 @@ SimpleNetwork::Request* MemNetBridge::translate(SimpleNetwork::Request *req, uin
 
     SimpleNetwork::nid_t tgt;
     if ( mre->hasClientData() ) {
-        tgt = getAddrFor(outNet, mre->event->getDst());
+        tgt = getAddrFor(outNet, mre->inspectEvent()->getDst());
     } else {
         MemNIC::InitMemRtrEvent *imre = static_cast<MemNIC::InitMemRtrEvent*>(mre);
         imre->info.addr = getAddrForNetwork(fromNet^1);

--- a/src/sst/elements/memHierarchy/networkMemInspector.cc
+++ b/src/sst/elements/memHierarchy/networkMemInspector.cc
@@ -36,7 +36,7 @@ networkMemInspector::networkMemInspector(ComponentId_t id, Params &params, const
 void networkMemInspector::inspectNetworkData(SimpleNetwork::Request* req) {
     MemNIC::MemRtrEvent *mre = dynamic_cast<MemNIC::MemRtrEvent*>(req->inspectPayload());
     if (mre) {
-        memCmdStat[(int)mre->event->getCmd()]->addData(1);
+        memCmdStat[(int)mre->inspectEvent()->getCmd()]->addData(1);
     } else {
         dbg.output(CALL_INFO,"Unexpected payload encountered. Ignoring.\n");
     }

--- a/src/sst/elements/opal/opalMemNIC.cc
+++ b/src/sst/elements/opal/opalMemNIC.cc
@@ -57,7 +57,7 @@ bool OpalMemNIC::clock() {
 bool OpalMemNIC::recvNotify(int) {
     MemRtrEvent * mre = doRecv(link_control);
     if (mre) {
-        MemHierarchy::MemEventBase * me = mre->event;
+        MemHierarchy::MemEventBase * me = mre->takeEvent();
         delete mre;
         if (me) {
             (*recvHandler)(me);


### PR DESCRIPTION
This PR fixes a memory leak in MemH. When MemRtrEvent wraps an event and gets deleted, it does not delete the wrapped event. This PR adds a destructor to ensure the wrapped event gets deleted and changes the wrapped object to be protected instead of public. It also includes functions for interacting with the event.
- `takeEvent()` returns the pointer to the event and sets the pointer to `nullptr`. 
- `inspectEvent()` returns the pointer but does not set the pointer to `nullptr`
- `putEvent()` is used to set the value of the Event