### PR TITLE
Split tricount graph generation and counting.

### DIFF
--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -568,8 +568,11 @@ libvanadis_la_LDFLAGS = -module -avoid-version
 
 #libvanadisdbg_la_LDFLAGS = -module -avoid-version
 
-bin_PROGRAMS = sst-vanadis-tracediff
+bin_PROGRAMS = sst-vanadis-tracediff tricount_clean tricount_clean_gen_only tricount_clean_with_gen
 
+tricount_clean_SOURCES = tests/small/misc/tricount/tricount_clean.cc
+tricount_clean_gen_only_SOURCES = tests/small/misc/tricount/tricount_clean_gen_only.cc
+tricount_clean_with_gen_SOURCES = tests/small/misc/tricount/tricount_clean_with_gen.cc
 sst_vanadis_tracediff_SOURCES = tools/tracediff/tracediff.cc
 
 #vanadisdbg.cc: vanadis.cc $(VANADIS_SRC_FILES)

--- a/src/sst/elements/vanadis/tests/small/misc/tricount/run_tricount.sh
+++ b/src/sst/elements/vanadis/tests/small/misc/tricount/run_tricount.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+make tricount_clean
+
+ARGS="configs/input_$1_$2_$3_$4_$5_$6.txt"
+
+if [ ! -f $ARGS ]; then
+  echo "File $ARGS does not exist"
+  exit
+fi
+
+export VANADIS_EXE=$PWD/tricount_clean.riscv64
+export VANADIS_EXE_ARGS=$ARGS
+time sst tc_vanadis.py

--- a/src/sst/elements/vanadis/tests/small/misc/tricount/run_tricount_with_gen.sh
+++ b/src/sst/elements/vanadis/tests/small/misc/tricount/run_tricount_with_gen.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+make tricount_clean_with_gen
+
+export VANADIS_EXE=$PWD/tricount_clean_with_gen.riscv64
+export VANADIS_EXE_ARGS=$*
+time sst tc_vanadis.py

--- a/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean.cc
+++ b/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean.cc
@@ -1,0 +1,75 @@
+// Written by Courtenay T. Vaughan - cleaned of extras - version 7/8/23
+#include <iostream>
+#include <random>
+#include <algorithm>
+#include <fstream>
+
+int main(int argc, char *argv[]) {
+  uint64_t i, j;
+  uint64_t tmp, src, dst, tct;
+  int k, l, a, at, al, b, bt, bl;
+
+  if (argc != 2) {printf("Usage: <fname>\n"); return 1;}
+
+  std::string filename(argv[1]);
+  std::ifstream ifile(filename, std::ios::in | std::ios::binary);
+  uint64_t num_indices;
+  ifile >> num_indices;
+
+  uint64_t *index = new uint64_t[num_indices];
+  for (i = 0; i < num_indices; i++) {
+    ifile >> index[i];
+  }
+
+  uint64_t edge;
+  ifile >> edge;
+
+  uint64_t *edges = new uint64_t[edge];
+  for (i = 0; i < edge; i++) {
+    ifile >> edges[i];
+  }
+  ifile.close();
+
+  uint64_t num_vertices = num_indices - 1;
+  printf("num_verticies %d\n", num_vertices);
+  printf("num_edges %d\n",  edge);
+
+  // Count number of triangles
+  tct = 0;
+  for (i = 0; i < num_vertices; i++) {
+    // going over all of the vertices: i is the vertex number
+    at = index[i];
+    al = index[i+1];
+
+    if (al > edge) {
+      printf("WARNING: Detected malformed input: Index out of edge range\n");
+      printf("         Vertex: %u, Edges: %u Index range: [%u,%u)\n",
+              i, edge, at, al);
+    }
+
+    // at is the pointer into the edges array for i
+    for (j = at; j < al && j < edge; j++) {
+      // Begin TASK
+      // j is the pointer in the edges array for b, which is second vertex
+      bt = index[edges[j]]; bl = index[edges[j]+1];
+
+      // now search through a edges for match with b edges, a triangle
+      a = j + 1; // Start search at next possible third vertex
+      b = bt;
+      while(a < al && b < bl) {
+        if (edges[a] < edges[b]) {
+          a++;
+        } else if (edges[a] > edges[b]) {
+          b++;
+        } else {
+          // printf("triangle at: (i, j, k)=(%d,%d,%d)\n", i, edges[j], edges[a]);
+          a++; b++; tct++;
+        }
+      }
+      // End TASK
+    }
+  }
+  printf("total triangles %ld\n", tct);
+  delete[] index;
+  delete[] edges;
+}

--- a/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean_gen_only.cc
+++ b/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean_gen_only.cc
@@ -1,0 +1,99 @@
+// Written by Courtenay T. Vaughan - cleaned of extras - version 7/8/23
+#include <iostream>
+#include <random>
+#include <algorithm>
+#include <fstream>
+
+int main(int argc, char *argv[]) {
+  uint64_t i, j;
+  uint64_t tmp, src, dst, edge = 0, tct;
+  int k, l, a, at, al, b, bt, bl;
+
+  if (argc != 8) {printf("Usage: <seed> <scale> <edge ratio> <A> <B> <C> <fname>\n"); return 1;}
+
+  uint64_t seed = std::stoll(argv[1]);
+  uint64_t scale = std::stoll(argv[2]);
+  uint64_t num_vertices = 1 << std::stoll(argv[2]);
+  uint64_t num_edges = num_vertices * std::stoll(argv[3]);
+
+  double A = std::stod(argv[4]) / 100.0;
+  double B = std::stod(argv[5]) / 100.0;
+  double C = std::stod(argv[6]) / 100.0;
+  double D = 1.0 - A - B - C;
+
+  std::string filename(argv[7]);
+
+  std::mt19937_64 gen64(seed + num_edges);
+  uint64_t max_rand = gen64.max();
+
+  uint64_t *index = new uint64_t[num_vertices+1];
+  std::fill(index, index + num_vertices + 1, 0);
+
+  uint64_t *edges = new uint64_t[num_edges];
+  for (i = 0; i < num_edges; i++) {
+
+    // Generate new edge src and dst ids
+    src = dst = 0;
+    for (j = 0; j < scale; j++) {
+      double rand = (double) gen64() / (double) max_rand;
+
+      src <<= 1;
+      if (rand > A + B) { src += 1; }
+
+      dst <<= 1;
+      if (rand > A && rand <= A + B || rand > A + B + C) { dst += 1; }
+    }
+
+    if (src == dst) continue;  // do not include self edges
+
+    // Edge inclusion
+    // Order edge definition
+    if (src > dst) {
+      tmp = dst; dst = src; src = tmp;
+    }
+
+    // Determine whether edge list update is needed
+    // index[src] - index[src+1] is the edge index range for the src vertex
+    tmp = 1;
+    for (k = index[src]; k < index[src+1]; k++) {
+      if (edges[k] >= dst) {
+        if (edges[k] == dst) {
+          tmp = 0;
+        }
+        break;
+      }
+    }
+
+    // Insert the new edge into the list and update structures
+    // Find location for insertion (dsts are ordered by vertex id)
+    if (tmp) {
+      if (index[num_vertices] > 0)
+        for (l = index[num_vertices]; l >= k; l--)
+          edges[l+1] = edges[l];
+      edges[k] = dst;
+      for (k = num_vertices; k > src; k--)
+        index[k]++;
+      edge++;
+    }
+  }
+
+  printf("num_verticies %d\n", num_vertices);
+  printf("num_edges %d\n",  edge);
+
+  std::ofstream ofile(filename, std::ios::out | std::ios::binary);
+  ofile << num_vertices + 1 << std::endl;
+  for (i = 0; i < num_vertices + 1; i++) {
+    ofile << index[i] << " ";
+  }
+  ofile << std::endl;
+
+  ofile << edge << std::endl;
+  for (i = 0; i < edge; i++) {
+    ofile << edges[i] << " ";
+  }
+  ofile << std::endl;
+  ofile.close();
+
+  delete[] index;
+  delete[] edges;
+}

--- a/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean_with_gen.cc
+++ b/src/sst/elements/vanadis/tests/small/misc/tricount/tricount_clean_with_gen.cc
@@ -1,0 +1,121 @@
+// Written by Courtenay T. Vaughan - cleaned of extras - version 7/8/23
+#include <iostream>
+#include <random>
+#include <algorithm>
+
+int main(int argc, char *argv[]) {
+  uint64_t i, j;
+  uint64_t tmp, src, dst, edge = 0, tct;
+  int k, l, a, at, al, b, bt, bl;
+
+  if (argc != 7) {printf("Usage: <seed> <scale> <edge ratio> <A> <B> <C>\n"); return 1;}
+
+  uint64_t seed = std::stoll(argv[1]);
+  uint64_t scale = std::stoll(argv[2]);
+  uint64_t num_vertices = 1 << std::stoll(argv[2]);
+  uint64_t num_edges = num_vertices * std::stoll(argv[3]);
+
+  double A = std::stod(argv[4]) / 100.0;
+  double B = std::stod(argv[5]) / 100.0;
+  double C = std::stod(argv[6]) / 100.0;
+  double D = 1.0 - A - B - C;
+
+  std::mt19937_64 gen64(seed + num_edges);
+  uint64_t max_rand = gen64.max();
+
+  uint64_t *index = new uint64_t[num_vertices+1];
+  std::fill(index, index + num_vertices + 1, 0);
+
+  uint64_t *edges = new uint64_t[num_edges];
+  for (i = 0; i < num_edges; i++) {
+
+    // Generate new edge src and dst ids
+    src = dst = 0;
+    for (j = 0; j < scale; j++) {
+      double rand = (double) gen64() / (double) max_rand;
+
+      src <<= 1;
+      if (rand > A + B) { src += 1; }
+
+      dst <<= 1;
+      if (rand > A && rand <= A + B || rand > A + B + C) { dst += 1; }
+    }
+
+    if (src == dst) continue;  // do not include self edges
+
+    // Edge inclusion
+    // Order edge definition
+    if (src > dst) {
+      tmp = dst; dst = src; src = tmp;
+    }
+
+    // Determine whether edge list update is needed
+    // index[src] - index[src+1] is the edge index range for the src vertex
+    tmp = 1;
+    for (k = index[src]; k < index[src+1]; k++) {
+      if (edges[k] >= dst) {
+        if (edges[k] == dst) {
+          tmp = 0;
+        }
+        break;
+      }
+    }
+
+    // Insert the new edge into the list and update structures
+    // Find location for insertion (dsts are ordered by vertex id)
+    if (tmp) {
+      if (index[num_vertices] > 0)
+        for (l = index[num_vertices]; l >= k; l--)
+          edges[l+1] = edges[l];
+      edges[k] = dst;
+      for (k = num_vertices; k > src; k--)
+        index[k]++;
+      edge++;
+    }
+  }
+
+  printf("num_verticies %d\n", num_vertices);
+  printf("num_edges %d\n",  edge);
+
+  // Graph generation is above - below is the counting and depends on having
+  // the list of edges (edges), the index into the edges (index), and the
+  // number of vertices in the graph
+
+  tct = 0;
+  for (i = 0; i < num_vertices; i++) {
+    // going over all of the vertices: i is the vertex number
+    at = index[i];
+    al = index[i+1];
+
+    if (al > edge) {
+      printf("WARNING: Detected malformed input: Index out of edge range\n");
+      printf("         Vertex: %u, Edges: %u Index range: [%u,%u)\n",
+              i, edge, at, al);
+    }
+
+    // at is the pointer into the edges array for i
+    for (j = at; j < al && j < edge; j++) {
+      // Begin TASK
+      // j is the pointer in the edges array for b, which is second vertex
+      bt = index[edges[j]]; bl = index[edges[j]+1];
+
+      // now search through a edges for match with b edges, a triangle
+      a = j + 1; // Start search at next possible third vertex
+      b = bt;
+      while(a < al && b < bl) {
+        if (edges[a] < edges[b]) {
+          a++;
+        } else if (edges[a] > edges[b]) {
+          b++;
+        } else {
+         //  printf("triangle at: (i, j, k)=(%d,%d,%d)\n", i, edges[j], edges[a]);
+          a++; b++; tct++;
+        }
+      }
+      // End TASK
+    }
+  }
+  printf("total triangles %ld\n", tct);
+  delete[] index;
+  delete[] edges;
+}


### PR DESCRIPTION
Both use intermediate binary file for passing index and edge arrays. Added convenience scripts to run different tricount versions (w and w/o gen). Expand vertex id to uint64_t.
Fix edge cases with neighborless final vertex and index count.
