### PR TITLE
Fixed issue with calling OTF2 functions from Ember getting unresolved names

### DIFF
--- a/src/sst/elements/ember/Makefile.am
+++ b/src/sst/elements/ember/Makefile.am
@@ -326,7 +326,7 @@ libember_la_SOURCES += \
 libember_la_LIBADD = \
 	$(OTF2_LDFLAGS) \
 	$(OTF2_LIBS)
-
+	-lotf2
 endif
 
 install-exec-hook:


### PR DESCRIPTION
OTF2 was not linked to when compiling the OTF2 Trace motif. 

This fixes it, not the best solution as it should be handled with the auto tools but this will work. 