### PR TITLE
Fix print format specifier warnings

### DIFF
--- a/src/sst/elements/CramSim/c_BankCommand.cpp
+++ b/src/sst/elements/CramSim/c_BankCommand.cpp
@@ -129,7 +129,7 @@ void c_BankCommand::print(SimTime_t x_cycle) const {
 }
 
 void c_BankCommand::print(SST::Output *x_debugOutput, SimTime_t x_cycle) const {
-	x_debugOutput->verbose(CALL_INFO, 1, 0, "[BankCommand] Cycle:%llu," , x_cycle);
+	x_debugOutput->verbose(CALL_INFO, 1, 0, "[BankCommand] Cycle:%lu," , x_cycle);
 	x_debugOutput->verbose(CALL_INFO, 1, 0, "CMD:%s,",this->getCommandString().c_str());
 	x_debugOutput->verbose(CALL_INFO, 1, 0,	"SEQNUM:%d,",this->getSeqNum());
 	x_debugOutput->verbose(CALL_INFO, 1, 0,	"ADDR:%lx,",this->getAddress());
@@ -147,7 +147,7 @@ void c_BankCommand::print(SST::Output *x_debugOutput, SimTime_t x_cycle) const {
 }
 
 void c_BankCommand::print(SST::Output *x_debugOutput,const std::string x_prefix, SimTime_t x_cycle) const {
-	x_debugOutput->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %llu CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
+	x_debugOutput->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %lu CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
 							x_cycle,
 							getCommandString().c_str(),
 							m_seqNum,

--- a/src/sst/elements/CramSim/c_BankCommand.cpp
+++ b/src/sst/elements/CramSim/c_BankCommand.cpp
@@ -129,7 +129,7 @@ void c_BankCommand::print(SimTime_t x_cycle) const {
 }
 
 void c_BankCommand::print(SST::Output *x_debugOutput, SimTime_t x_cycle) const {
-	x_debugOutput->verbose(CALL_INFO, 1, 0, "[BankCommand] Cycle:%lu," , x_cycle);
+	x_debugOutput->verbose(CALL_INFO, 1, 0, "[BankCommand] Cycle:%" PRI_SIMTIME ",", x_cycle);
 	x_debugOutput->verbose(CALL_INFO, 1, 0, "CMD:%s,",this->getCommandString().c_str());
 	x_debugOutput->verbose(CALL_INFO, 1, 0,	"SEQNUM:%d,",this->getSeqNum());
 	x_debugOutput->verbose(CALL_INFO, 1, 0,	"ADDR:%lx,",this->getAddress());
@@ -147,7 +147,7 @@ void c_BankCommand::print(SST::Output *x_debugOutput, SimTime_t x_cycle) const {
 }
 
 void c_BankCommand::print(SST::Output *x_debugOutput,const std::string x_prefix, SimTime_t x_cycle) const {
-	x_debugOutput->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %lu CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
+	x_debugOutput->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%" PRI_SIMTIME " Cmd:%s seqNum: %" PRIu64 " CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
 							x_cycle,
 							getCommandString().c_str(),
 							m_seqNum,

--- a/src/sst/elements/CramSim/c_Transaction.cpp
+++ b/src/sst/elements/CramSim/c_Transaction.cpp
@@ -125,7 +125,7 @@ void c_Transaction::print() const {
 
 
 void c_Transaction::print(SST::Output *x_output, const std::string x_prefix, SimTime_t x_cycle) const {
-	x_output->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %lu addr:0x%lx CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
+	x_output->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%" PRI_SIMTIME " Cmd:%s seqNum: %" PRIu64 " addr:0x%lx CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
 				  x_cycle,
 				  getTransactionString().c_str(),
 					m_seqNum,

--- a/src/sst/elements/CramSim/c_Transaction.cpp
+++ b/src/sst/elements/CramSim/c_Transaction.cpp
@@ -125,7 +125,7 @@ void c_Transaction::print() const {
 
 
 void c_Transaction::print(SST::Output *x_output, const std::string x_prefix, SimTime_t x_cycle) const {
-	x_output->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %llu addr:0x%lx CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
+	x_output->verbosePrefix(x_prefix.c_str(),CALL_INFO,1,0,"Cycle:%lld Cmd:%s seqNum: %lu addr:0x%lx CH:%d PCH:%d Rank:%d BG:%d B:%d Row:%d Col:%d BankId:%d\n",
 				  x_cycle,
 				  getTransactionString().c_str(),
 					m_seqNum,

--- a/src/sst/elements/CramSim/c_TxnGen.cpp
+++ b/src/sst/elements/CramSim/c_TxnGen.cpp
@@ -117,13 +117,13 @@ c_TxnGenBase::c_TxnGenBase() :
 void c_TxnGenBase::finish()
 {
     output->output("\n======= CramSim Simulation Report [Transaction Generator] ============================\n");
-    output->output("Total Read-Txns Requests sent: %lu\n", m_resReadCount);
-    output->output("Total Write-Txns Requests sent: %lu\n", m_resWriteCount);
-    output->output("Total Txns Sents: %lu\n", m_resReadCount + m_resWriteCount);
+    output->output("Total Read-Txns Requests sent: %" PRIu64 "\n", m_resReadCount);
+    output->output("Total Write-Txns Requests sent: %" PRIu64 "\n", m_resWriteCount);
+    output->output("Total Txns Sents: %" PRIu64 "\n", m_resReadCount + m_resWriteCount);
 
-    output->output("Total Read-Txns Responses received: %lu\n", m_resReadCount);
-    output->output("Total Write-Txns Responses received: %lu\n", m_resWriteCount);
-    output->output("Total Txns Received: %lu\n", m_resReadCount + m_resWriteCount);
+    output->output("Total Read-Txns Responses received: %" PRIu64 "\n", m_resReadCount);
+    output->output("Total Write-Txns Responses received: %" PRIu64 "\n", m_resWriteCount);
+    output->output("Total Txns Received: %" PRIu64 "\n", m_resReadCount + m_resWriteCount);
     output->output("Cycles Per Transaction (CPT) = %.2f\n",
         static_cast<double>(m_simCycle) / static_cast<double>(m_resReadCount + m_resWriteCount));
     output->output("Component Finished.\n");

--- a/src/sst/elements/CramSim/c_TxnGen.cpp
+++ b/src/sst/elements/CramSim/c_TxnGen.cpp
@@ -117,13 +117,13 @@ c_TxnGenBase::c_TxnGenBase() :
 void c_TxnGenBase::finish()
 {
     output->output("\n======= CramSim Simulation Report [Transaction Generator] ============================\n");
-    output->output("Total Read-Txns Requests sent: %llu\n", m_resReadCount);
-    output->output("Total Write-Txns Requests sent: %llu\n", m_resWriteCount);
-    output->output("Total Txns Sents: %llu\n", m_resReadCount + m_resWriteCount);
+    output->output("Total Read-Txns Requests sent: %lu\n", m_resReadCount);
+    output->output("Total Write-Txns Requests sent: %lu\n", m_resWriteCount);
+    output->output("Total Txns Sents: %lu\n", m_resReadCount + m_resWriteCount);
 
-    output->output("Total Read-Txns Responses received: %llu\n", m_resReadCount);
-    output->output("Total Write-Txns Responses received: %llu\n", m_resWriteCount);
-    output->output("Total Txns Received: %llu\n", m_resReadCount + m_resWriteCount);
+    output->output("Total Read-Txns Responses received: %lu\n", m_resReadCount);
+    output->output("Total Write-Txns Responses received: %lu\n", m_resWriteCount);
+    output->output("Total Txns Received: %lu\n", m_resReadCount + m_resWriteCount);
     output->output("Cycles Per Transaction (CPT) = %.2f\n",
         static_cast<double>(m_simCycle) / static_cast<double>(m_resReadCount + m_resWriteCount));
     output->output("Component Finished.\n");

--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -114,45 +114,6 @@ nobase_sst_HEADERS = \
 
 libexec_PROGRAMS =
 
-
-#if SST_COMPILE_OSX
-
-#all-local: frontend/simple/fesimple.cc
-#	$(CXX) -O3 -shared \
-#	$(CXXFLAGS) \
-#	$(CPPFLAGS) \
-#	$(LIBZ_CPPFLAGS) \
-#	-DBIGARRAY_MULTIPLIER=1 \
-#	-DTARGET_IA32E -DHOST_IA32E -fPIC -DTARGET_MAC \
-#	$(CUDA_CPPFLAGS) \
-#	-I./ \
-#	-I$(PINTOOL_DIR)/source/include/pin \
-#	-I$(PINTOOL_DIR)/ \
-#	-I$(PINTOOL_DIR)/extras/components/include \
-#	-I$(PINTOOL_DIR)/source/include/pin/gen/ \
-#	-I$(PINTOOL_DIR)/extras/xed-intel64/include \
-#	-I$(top_srcdir)/src/sst \
-#	-I$(top_srcdir)/src/sst/elements/ariel \
-#	-fomit-frame-pointer -fno-stack-protector \
-#	-Wl,-exported_symbols_list \
-#	-Wl,$(PINTOOL_DIR)/source/include/pin/pintool.exp \
-#	$(CUDA_LIBS) \
-#	-L$(PINTOOL_DIR)/intel64/lib \
-#	-L$(PINTOOL_DIR)/intel64/lib-ext \
-#	-L$(PINTOOL_DIR)/extras/xed-intel64/lib \
-#	-o fesimple.dylib $(top_srcdir)/src/sst/elements/ariel/frontend/simple/fesimple.cc \
-#	-stdlib=libstdc++ \
-#	-lpin -lxed -lpindwarf -lpthread $(LIBZ_LDFLAGS) $(LIBZ_LIB) $(CUDA_LDFLAGS)
-
-#install-exec-hook:
-#	$(MKDIR_P) $(libexecdir)
-#	$(INSTALL) fesimple.dylib $(libexecdir)/fesimple.dylib
-#	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     ariel=$(abs_srcdir)
-#	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      ariel=$(abs_srcdir)/tests
-
-#else
-
-
 if !SST_COMPILE_OSX
 
 if HAVE_PINTOOL

--- a/src/sst/elements/ember/mpi/motifs/emberBFS.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberBFS.cc
@@ -1119,7 +1119,7 @@ bool EmberBFSGenerator::generate( std::queue<EmberEvent*>& evQ) {
                 idx_50 = 0;
                 break;
             default:
-                printf("idx_50 incorrect (%llu)\n", idx_50);
+                printf("idx_50 incorrect (%lu)\n", idx_50);
                 break;
             }
 
@@ -1277,7 +1277,7 @@ bool EmberBFSGenerator::generate( std::queue<EmberEvent*>& evQ) {
         }
         break;
     default:
-        printf("error\n Bad State %llu in rank %d\n", state, rank());
+        printf("error\n Bad State %lu in rank %d\n", state, rank());
         break;
     }
 

--- a/src/sst/elements/ember/mpi/motifs/emberBFS.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberBFS.cc
@@ -1119,7 +1119,7 @@ bool EmberBFSGenerator::generate( std::queue<EmberEvent*>& evQ) {
                 idx_50 = 0;
                 break;
             default:
-                printf("idx_50 incorrect (%lu)\n", idx_50);
+                printf("idx_50 incorrect (%" PRIu64 ")\n", idx_50);
                 break;
             }
 
@@ -1277,7 +1277,7 @@ bool EmberBFSGenerator::generate( std::queue<EmberEvent*>& evQ) {
         }
         break;
     default:
-        printf("error\n Bad State %lu in rank %d\n", state, rank());
+        printf("error\n Bad State %" PRIu64 " in rank %d\n", state, rank());
         break;
     }
 

--- a/src/sst/elements/firefly/nic.cc
+++ b/src/sst/elements/firefly/nic.cc
@@ -590,7 +590,7 @@ void Nic::feedTheNetwork( int vn )
                     m_linkSendWidget->setNotify( [=]() {
 						SimTime_t curTime = getCurrentSimCycle();
 						if ( curTime > m_predNetIdleTime ) {
-							m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"network stalled latency=%lu\n",
+							m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"network stalled latency=%" PRI_SIMTIME "\n",
 								curTime -  m_predNetIdleTime);
 							m_networkStall->addData( curTime - m_predNetIdleTime );
 						}
@@ -609,8 +609,8 @@ void Nic::feedTheNetwork( int vn )
 			}
 			m_predNetIdleTime += latPS;
 
-			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"predNetIdleTime=%lu\n",m_predNetIdleTime );
-			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"p1=%" PRIu64 " p2=%d\n", entry->p1(), entry->p2() );
+			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"predNetIdleTime=%" PRI_SIMTIME "\n",m_predNetIdleTime );
+			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"p1=%" PRI_SIMTIME " p2=%d\n", entry->p1(), entry->p2() );
 
 			sendPkt( x.pkt, x.dest, vn );
 

--- a/src/sst/elements/firefly/nic.cc
+++ b/src/sst/elements/firefly/nic.cc
@@ -590,7 +590,7 @@ void Nic::feedTheNetwork( int vn )
                     m_linkSendWidget->setNotify( [=]() {
 						SimTime_t curTime = getCurrentSimCycle();
 						if ( curTime > m_predNetIdleTime ) {
-							m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"network stalled latency=%lld\n",
+							m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"network stalled latency=%lu\n",
 								curTime -  m_predNetIdleTime);
 							m_networkStall->addData( curTime - m_predNetIdleTime );
 						}
@@ -609,7 +609,7 @@ void Nic::feedTheNetwork( int vn )
 			}
 			m_predNetIdleTime += latPS;
 
-			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"predNetIdleTime=%lld\n",m_predNetIdleTime );
+			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"predNetIdleTime=%lu\n",m_predNetIdleTime );
 			m_dbg.debug(CALL_INFO,1,NIC_DBG_SEND_NETWORK,"p1=%" PRIu64 " p2=%d\n", entry->p1(), entry->p2() );
 
 			sendPkt( x.pkt, x.dest, vn );

--- a/src/sst/elements/kingsley/linkControl.cc
+++ b/src/sst/elements/kingsley/linkControl.cc
@@ -556,7 +556,7 @@ LinkControl::printStatus(Output& out)
     }
     else {
         NocPacket* event = output_buf[0].front();
-        out.output("      src = %ld, dest = %ld, flits = %d\n",
+        out.output("      src = %" PRI_NID ", dest = %" PRI_NID ", flits = %d\n",
                    event->request->src, event->request->dest,
                    event->getSizeInFlits());
     }

--- a/src/sst/elements/kingsley/linkControl.cc
+++ b/src/sst/elements/kingsley/linkControl.cc
@@ -556,7 +556,7 @@ LinkControl::printStatus(Output& out)
     }
     else {
         NocPacket* event = output_buf[0].front();
-        out.output("      src = %lld, dest = %lld, flits = %d\n",
+        out.output("      src = %ld, dest = %ld, flits = %d\n",
                    event->request->src, event->request->dest,
                    event->getSizeInFlits());
     }

--- a/src/sst/elements/kingsley/nocEvents.h
+++ b/src/sst/elements/kingsley/nocEvents.h
@@ -96,7 +96,7 @@ public:
     inline int getSizeInFlits() { return size_in_flits; }
 
     virtual void print(const std::string& header, Output &out) const  override {
-        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %ld, dest = %ld\n",
+        out.output("%s RtrEvent to be delivered at %" PRI_SIMTIME " with priority %d. src = %" PRI_NID ", dest = %" PRI_NID "\n",
                    header.c_str(), getDeliveryTime(), getPriority(), request->src, request->dest);
         if ( request->inspectPayload() != NULL) request->inspectPayload()->print("  -> ", out);
     }

--- a/src/sst/elements/kingsley/nocEvents.h
+++ b/src/sst/elements/kingsley/nocEvents.h
@@ -96,7 +96,7 @@ public:
     inline int getSizeInFlits() { return size_in_flits; }
 
     virtual void print(const std::string& header, Output &out) const  override {
-        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %lld, dest = %lld\n",
+        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %ld, dest = %ld\n",
                    header.c_str(), getDeliveryTime(), getPriority(), request->src, request->dest);
         if ( request->inspectPayload() != NULL) request->inspectPayload()->print("  -> ", out);
     }

--- a/src/sst/elements/kingsley/noc_mesh.cc
+++ b/src/sst/elements/kingsley/noc_mesh.cc
@@ -1355,7 +1355,7 @@ noc_mesh::printStatus(Output& out)
             }
             else {
                 noc_mesh_event* event = port_queues[pinfo.second].front();
-                out.output("      src = %lld, dest = %lld, next_port = %d, flits = %d\n",
+                out.output("      src = %ld, dest = %ld, next_port = %d, flits = %d\n",
                            event->encap_ev->request->src, event->encap_ev->request->dest,
                            event->next_port, event->encap_ev->getSizeInFlits());
             }

--- a/src/sst/elements/kingsley/noc_mesh.cc
+++ b/src/sst/elements/kingsley/noc_mesh.cc
@@ -1355,7 +1355,7 @@ noc_mesh::printStatus(Output& out)
             }
             else {
                 noc_mesh_event* event = port_queues[pinfo.second].front();
-                out.output("      src = %ld, dest = %ld, next_port = %d, flits = %d\n",
+                out.output("      src = %" PRI_NID ", dest = %" PRI_NID ", next_port = %d, flits = %d\n",
                            event->encap_ev->request->src, event->encap_ev->request->dest,
                            event->next_port, event->encap_ev->getSizeInFlits());
             }

--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -107,7 +107,7 @@ void MemNIC::send(MemEventBase *ev) {
     req->vn = 0;
 
     if (is_debug_event(ev)) {
-        dbg.debug(_L5_, "N: %-40" PRIu64 "  %-20s Enqueue       Dst: %lld, bits: %zu, (%s)\n", 
+        dbg.debug(_L5_, "N: %-40" PRIu64 "  %-20s Enqueue       Dst: %ld, bits: %zu, (%s)\n",
             getCurrentSimCycle(), getName().c_str(), req->dest, req->size_in_bits, ev->getBriefString().c_str());
     }
 

--- a/src/sst/elements/memHierarchy/memNIC.cc
+++ b/src/sst/elements/memHierarchy/memNIC.cc
@@ -107,7 +107,7 @@ void MemNIC::send(MemEventBase *ev) {
     req->vn = 0;
 
     if (is_debug_event(ev)) {
-        dbg.debug(_L5_, "N: %-40" PRIu64 "  %-20s Enqueue       Dst: %ld, bits: %zu, (%s)\n",
+        dbg.debug(_L5_, "N: %-40" PRI_NID "  %-20s Enqueue       Dst: %" PRI_NID ", bits: %zu, (%s)\n",
             getCurrentSimCycle(), getName().c_str(), req->dest, req->size_in_bits, ev->getBriefString().c_str());
     }
 

--- a/src/sst/elements/memHierarchy/util.h
+++ b/src/sst/elements/memHierarchy/util.h
@@ -58,6 +58,9 @@ const unsigned int pebi = tebi * 1024;
 const unsigned int exbi = pebi * 1024;
 
 typedef uint64_t Addr;
+#ifndef PRI_ADDR
+#define PRI_ADDR PRIx64
+#endif
 
 // Event attributes
 /*

--- a/src/sst/elements/merlin/inspectors/circuitCounter.cc
+++ b/src/sst/elements/merlin/inspectors/circuitCounter.cc
@@ -81,7 +81,7 @@ void CircNetworkInspector::finish() {
             for(setMap_t::iterator i = setMap.begin();
                 i != setMap.end(); ++i) {
                 // print
-                output_file->output(CALL_INFO, "%s %" PRIu64 "\n",
+                output_file->output(CALL_INFO, "%s %zu\n",
                                     i->first.c_str(),
                                     i->second->size());
                 // clean up

--- a/src/sst/elements/merlin/inspectors/circuitCounter.cc
+++ b/src/sst/elements/merlin/inspectors/circuitCounter.cc
@@ -83,7 +83,7 @@ void CircNetworkInspector::finish() {
                 // print
                 output_file->output(CALL_INFO, "%s %" PRIu64 "\n",
                                     i->first.c_str(),
-                                    (unsigned long long)i->second->size());
+                                    i->second->size());
                 // clean up
                 delete(i->second);
             }

--- a/src/sst/elements/merlin/offeredload/offered_load.cc
+++ b/src/sst/elements/merlin/offeredload/offered_load.cc
@@ -249,7 +249,7 @@ OfferedLoad::handle_receives(int vn)
 {
     SimpleNetwork::Request* req = link_if->recv(vn);
     if ( req->dest != id ) {
-        out.fatal(CALL_INFO,-1,"Endpoint %d received a packet intended for %lld\n",id,req->dest);
+        out.fatal(CALL_INFO,-1,"Endpoint %d received a packet intended for %ld\n",id,req->dest);
     }
     if ( req != NULL ) {
         SimTime_t current_time = getCurrentSimTime(base_tc);

--- a/src/sst/elements/merlin/offeredload/offered_load.cc
+++ b/src/sst/elements/merlin/offeredload/offered_load.cc
@@ -249,7 +249,7 @@ OfferedLoad::handle_receives(int vn)
 {
     SimpleNetwork::Request* req = link_if->recv(vn);
     if ( req->dest != id ) {
-        out.fatal(CALL_INFO,-1,"Endpoint %d received a packet intended for %ld\n",id,req->dest);
+        out.fatal(CALL_INFO,-1,"Endpoint %d received a packet intended for %" PRI_NID "\n",id,req->dest);
     }
     if ( req != NULL ) {
         SimTime_t current_time = getCurrentSimTime(base_tc);

--- a/src/sst/elements/merlin/router.h
+++ b/src/sst/elements/merlin/router.h
@@ -163,7 +163,7 @@ public:
     }
 
     virtual void print(const std::string& header, Output &out) const  override {
-        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %ld (logical: %ld), dest = %ld\n",
+        out.output("%s RtrEvent to be delivered at %" PRI_SIMTIME " with priority %d. src = %" PRI_NID " (logical: %" PRI_NID "), dest = %" PRI_NID "\n",
                    header.c_str(), getDeliveryTime(), getPriority(), trusted_src, request->src, request->dest);
         if ( request->inspectPayload() != NULL) request->inspectPayload()->print("  -> ", out);
     }

--- a/src/sst/elements/merlin/router.h
+++ b/src/sst/elements/merlin/router.h
@@ -163,7 +163,7 @@ public:
     }
 
     virtual void print(const std::string& header, Output &out) const  override {
-        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %lld (logical: %lld), dest = %lld\n",
+        out.output("%s RtrEvent to be delivered at %" PRIu64 " with priority %d. src = %ld (logical: %ld), dest = %ld\n",
                    header.c_str(), getDeliveryTime(), getPriority(), trusted_src, request->src, request->dest);
         if ( request->inspectPayload() != NULL) request->inspectPayload()->print("  -> ", out);
     }

--- a/src/sst/elements/merlin/test/nic.cc
+++ b/src/sst/elements/merlin/test/nic.cc
@@ -222,7 +222,7 @@ nic::init_complete(unsigned int phase) {
                 init_broadcast_count++;
             }
             else {
-                if ( req->dest != net_id ) output.output("%d: received event with dest %lld and src %lld\n",net_id,req->dest,req->src);
+                if ( req->dest != net_id ) output.output("%d: received event with dest %ld and src %ld\n",net_id,req->dest,req->src);
                 init_count++;
             }
             delete req;

--- a/src/sst/elements/merlin/test/nic.cc
+++ b/src/sst/elements/merlin/test/nic.cc
@@ -222,7 +222,7 @@ nic::init_complete(unsigned int phase) {
                 init_broadcast_count++;
             }
             else {
-                if ( req->dest != net_id ) output.output("%d: received event with dest %ld and src %ld\n",net_id,req->dest,req->src);
+                if ( req->dest != net_id ) output.output("%d: received event with dest %" PRI_NID " and src %" PRI_NID "\n",net_id,req->dest,req->src);
                 init_count++;
             }
             delete req;

--- a/src/sst/elements/rdmaNic/rdmaNic.cc
+++ b/src/sst/elements/rdmaNic/rdmaNic.cc
@@ -150,7 +150,7 @@ void RdmaNic::mmioWriteSetup( StandardMem::Write* req) {
     auto& hostInfo = m_hostInfo[thread].hostInfo;
     auto& offset = m_hostInfo[thread].offset;
 
-    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"Write size=%zu addr=%" PRIx64 " offset=%llu thread=%d data %s\n",
+    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"Write size=%zu addr=%" PRIx64 " offset=%lu thread=%d data %s\n",
                     req->data.size(), req->pAddr, req->pAddr - m_ioBaseAddr, thread, getDataStr(req->data).c_str() );
 
 	memcpy( (uint8_t*) (&hostInfo) + offset, req->data.data(), req->data.size() );
@@ -207,11 +207,11 @@ void RdmaNic::mmioWrite(StandardMem::Write* req) {
 	int thread = calcThread( req->pAddr );
 	uint64_t offset = calcOffset( req->pAddr );
 
-    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"thread=%d Write size=%zu addr=%" PRIx64 " offset=%llu data %s\n",
+    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"thread=%d Write size=%zu addr=%" PRIx64 " offset=%lu data %s\n",
                     thread,req->data.size(), req->pAddr, offset, getDataStr(req->data).c_str() );
 
     if ( ! m_backing->write( offset, req->data.data(), req->data.size() ) ) {
-        out.fatal(CALL_INFO_LONG, -1, "Failed to write: thread=%d Write size=%zu addr=%" PRIx64 " offset=%llu data %s\n",
+        out.fatal(CALL_INFO_LONG, -1, "Failed to write: thread=%d Write size=%zu addr=%" PRIx64 " offset=%lu data %s\n",
                     thread,req->data.size(), req->pAddr, offset, getDataStr(req->data).c_str() );
     }
 

--- a/src/sst/elements/rdmaNic/rdmaNic.cc
+++ b/src/sst/elements/rdmaNic/rdmaNic.cc
@@ -150,7 +150,7 @@ void RdmaNic::mmioWriteSetup( StandardMem::Write* req) {
     auto& hostInfo = m_hostInfo[thread].hostInfo;
     auto& offset = m_hostInfo[thread].offset;
 
-    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"Write size=%zu addr=%" PRIx64 " offset=%lu thread=%d data %s\n",
+    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"Write size=%zu addr=%" PRI_ADDR " offset=%" PRIu64 " thread=%d data %s\n",
                     req->data.size(), req->pAddr, req->pAddr - m_ioBaseAddr, thread, getDataStr(req->data).c_str() );
 
 	memcpy( (uint8_t*) (&hostInfo) + offset, req->data.data(), req->data.size() );
@@ -207,11 +207,11 @@ void RdmaNic::mmioWrite(StandardMem::Write* req) {
 	int thread = calcThread( req->pAddr );
 	uint64_t offset = calcOffset( req->pAddr );
 
-    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"thread=%d Write size=%zu addr=%" PRIx64 " offset=%lu data %s\n",
+    dbg.debug( CALL_INFO_LONG,2,DBG_X_FLAG,"thread=%d Write size=%zu addr=%" PRI_ADDR " offset=%" PRIu64 " data %s\n",
                     thread,req->data.size(), req->pAddr, offset, getDataStr(req->data).c_str() );
 
     if ( ! m_backing->write( offset, req->data.data(), req->data.size() ) ) {
-        out.fatal(CALL_INFO_LONG, -1, "Failed to write: thread=%d Write size=%zu addr=%" PRIx64 " offset=%lu data %s\n",
+        out.fatal(CALL_INFO_LONG, -1, "Failed to write: thread=%d Write size=%zu addr=%" PRI_ADDR " offset=%" PRIu64 " data %s\n",
                     thread,req->data.size(), req->pAddr, offset, getDataStr(req->data).c_str() );
     }
 

--- a/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
+++ b/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
@@ -73,7 +73,7 @@
               case MemRequest::Write:
 
                 if ( req->buf.empty() ) {
-                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%lu dataSize=%d\n",
+                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRI_ADDR " data=%lu dataSize=%d\n",
                                     req->addr,req->data,req->dataSize);
                     for ( int i = 0; i < req->dataSize; i++ ) {
                         payload.push_back( (req->data >> i*8) & 0xff );

--- a/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
+++ b/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
@@ -73,7 +73,7 @@
               case MemRequest::Write:
 
                 if ( req->buf.empty() ) {
-                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRI_ADDR " data=%lu dataSize=%d\n",
+                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%lu dataSize=%d\n",
                                     req->addr,req->data,req->dataSize);
                     for ( int i = 0; i < req->dataSize; i++ ) {
                         payload.push_back( (req->data >> i*8) & 0xff );

--- a/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
+++ b/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
@@ -73,7 +73,7 @@
               case MemRequest::Write:
 
                 if ( req->buf.empty() ) {
-                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%lu dataSize=%d\n",
+                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%" PRIu64 " dataSize=%d\n",
                                     req->addr,req->data,req->dataSize);
                     for ( int i = 0; i < req->dataSize; i++ ) {
                         payload.push_back( (req->data >> i*8) & 0xff );
@@ -132,7 +132,7 @@
 
         void write( int srcNum, uint64_t addr, int dataSize, uint64_t data, MemRequest::Callback* callback = NULL ) {
 			assert( ! full(srcNum) );
-            Nic().dbg.debug(CALL_INFO,1,DBG_X_FLAG,"srcNum=%d addr=%#" PRIx64 " data=%lu dataSize=%d\n",srcNum,addr,data,dataSize);
+            Nic().dbg.debug(CALL_INFO,1,DBG_X_FLAG,"srcNum=%d addr=%#" PRIx64 " data=%" PRIu64 " dataSize=%d\n",srcNum,addr,data,dataSize);
             m_reqSrcQs[srcNum].queue.push( new MemRequest( srcNum, addr, dataSize, data, callback ) );
         }
 

--- a/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
+++ b/src/sst/elements/rdmaNic/rdmaNicMemRequestQ.h
@@ -73,7 +73,7 @@
               case MemRequest::Write:
 
                 if ( req->buf.empty() ) {
-                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%llu dataSize=%d\n",
+                    Nic().dbg.debug(CALL_INFO,1,DBG_MEMEVENT_FLAG,"write addr=%#" PRIx64 " data=%lu dataSize=%d\n",
                                     req->addr,req->data,req->dataSize);
                     for ( int i = 0; i < req->dataSize; i++ ) {
                         payload.push_back( (req->data >> i*8) & 0xff );
@@ -132,7 +132,7 @@
 
         void write( int srcNum, uint64_t addr, int dataSize, uint64_t data, MemRequest::Callback* callback = NULL ) {
 			assert( ! full(srcNum) );
-            Nic().dbg.debug(CALL_INFO,1,DBG_X_FLAG,"srcNum=%d addr=%#" PRIx64 " data=%llu dataSize=%d\n",srcNum,addr,data,dataSize);
+            Nic().dbg.debug(CALL_INFO,1,DBG_X_FLAG,"srcNum=%d addr=%#" PRIx64 " data=%lu dataSize=%d\n",srcNum,addr,data,dataSize);
             m_reqSrcQs[srcNum].queue.push( new MemRequest( srcNum, addr, dataSize, data, callback ) );
         }
 

--- a/src/sst/elements/vanadis/decoder/vdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vdecoder.h
@@ -204,7 +204,7 @@ public:
     {
         ip = newIP;
 
-        output->verbose(CALL_INFO, 16, 0, "[decoder] -> clear decode-q and set new ip: 0x%llx\n", newIP);
+        output->verbose(CALL_INFO, 16, 0, "[decoder] -> clear decode-q and set new ip: 0x%" PRI_ADDR "\n", newIP);
 
         // Clear out the decode queue, need to restart
         // decoded_q->clear();

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -299,7 +299,7 @@ public:
 
     void setStackPointer( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t start_stack_address ) {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting SP to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", start_stack_address,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting SP to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", start_stack_address,
             start_stack_address);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(29);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Stack Pointer (r29) maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -310,7 +310,7 @@ public:
 
     void setArg1Register( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting argument 1 register to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting argument 1 register to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(4);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> argument 1 (r4) maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -319,7 +319,7 @@ public:
 
     virtual void setFuncPointer( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 25 to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 25 to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(25);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> r25 maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -327,7 +327,7 @@ public:
     }
     virtual void setReturnRegister( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 2 to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 2 to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(2);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> r2 maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -336,7 +336,7 @@ public:
 
     virtual void setSuccessRegister( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 7 to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 7 to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(7);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> r7 maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -448,7 +448,7 @@ public:
             if ( !thread_rob->full() ) {
                 if ( ins_loader->hasBundleAt(ip) ) {
                     output->verbose(
-                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> Found uop bundle for ip=0x0%llx, loading from cache...\n", ip);
+                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> Found uop bundle for ip=0x0%" PRI_ADDR ", loading from cache...\n", ip);
                     VanadisInstructionBundle* bundle = ins_loader->getBundleAt(ip);
                     stat_uop_hit->addData(1);
 
@@ -457,7 +457,7 @@ public:
                         bundle->getInstructionCount());
 
                     if ( 0 == bundle->getInstructionCount() ) {
-                        output->fatal(CALL_INFO, -1, "------> STOP - bundle at 0x%0llx contains zero entries.\n", ip);
+                        output->fatal(CALL_INFO, -1, "------> STOP - bundle at 0x%0" PRI_ADDR " contains zero entries.\n", ip);
                     }
 
                     bool q_contains_store = false;
@@ -507,7 +507,7 @@ public:
                                     output->fatal(
                                         CALL_INFO, -1,
                                         "Error: instruction loader has bytes for delay slot at "
-                                        "%0llx, but they cannot be retrieved.\n",
+                                        "%0" PRI_ADDR ", but they cannot be retrieved.\n",
                                         (ip + 4));
                                 }
                             }
@@ -536,7 +536,7 @@ public:
                                     VanadisInstruction* next_ins = bundle->getInstructionByIndex(i)->clone();
 
                                     output->verbose(
-                                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%llx, %s...\n",
+                                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%" PRI_ADDR ", %s...\n",
                                         next_ins->getInstructionAddress(), next_ins->getInstCode());
 
                                     thread_rob->push(next_ins);
@@ -557,8 +557,8 @@ public:
                                             if ( predicted_address == (ip + 8) ) {
                                                 output->verbose(
                                                     CALL_INFO, 16, VANADIS_DBG_DECODER_FLG,
-                                                    "---> Branch 0x%llx predicted not "
-                                                    "taken, ip set to: 0x%0llx\n",
+                                                    "---> Branch 0x%" PRI_ADDR " predicted not "
+                                                    "taken, ip set to: 0x%0" PRI_ADDR "\n",
                                                     ip, predicted_address);
                                                 //												speculated_ins->setSpeculatedDirection(
                                                 // BRANCH_NOT_TAKEN );
@@ -566,8 +566,8 @@ public:
                                             else {
                                                 output->verbose(
                                                     CALL_INFO, 16, VANADIS_DBG_DECODER_FLG,
-                                                    "---> Branch 0x%llx predicted taken, "
-                                                    "jump to 0x%0llx\n",
+                                                    "---> Branch 0x%" PRI_ADDR " predicted taken, "
+                                                    "jump to 0x%0" PRI_ADDR "\n",
                                                     ip, predicted_address);
                                                 //												speculated_ins->setSpeculatedDirection(
                                                 // BRANCH_TAKEN );
@@ -577,15 +577,15 @@ public:
                                             output->verbose(
                                                 CALL_INFO, 16, VANADIS_DBG_DECODER_FLG,
                                                 "---> Forcing IP update according to branch "
-                                                "prediction table, new-ip: %0llx\n",
+                                                "prediction table, new-ip: %0" PRI_ADDR "\n",
                                                 ip);
                                         }
                                         else {
                                             output->verbose(
                                                 CALL_INFO, 16, VANADIS_DBG_DECODER_FLG,
                                                 "---> Branch table does not contain an "
-                                                "entry for ins: 0x%0llx, continue with "
-                                                "normal ip += 8 = 0x%0llx\n",
+                                                "entry for ins: 0x%0" PRI_ADDR ", continue with "
+                                                "normal ip += 8 = 0x%0" PRI_ADDR "\n",
                                                 ip, (ip + 8));
 
                                             //											speculated_ins->setSpeculatedDirection(
@@ -604,7 +604,7 @@ public:
                                     VanadisInstruction* next_ins = delay_bundle->getInstructionByIndex(i)->clone();
 
                                     output->verbose(
-                                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%llx, %s...\n",
+                                        CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%" PRI_ADDR ", %s...\n",
                                         next_ins->getInstructionAddress(), next_ins->getInstCode());
                                     thread_rob->push(next_ins);
                                 }
@@ -634,7 +634,7 @@ public:
                                 VanadisInstruction* next_ins = bundle->getInstructionByIndex(i);
 
                                 output->verbose(
-                                    CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%llx, %s...\n",
+                                    CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "---> --> issuing ins addr: 0x0%" PRI_ADDR ", %s...\n",
                                     next_ins->getInstructionAddress(), next_ins->getInstCode());
                                 thread_rob->push(next_ins->clone());
                             }
@@ -721,7 +721,7 @@ public:
 
         output->verbose(
             CALL_INFO, 16, VANADIS_DBG_DECODER_FLG,
-            "---> Performed %" PRIu16 " decodes this cycle, %" PRIu16 " uop-bundles used / updated-ip: 0x%llx.\n",
+            "---> Performed %" PRIu16 " decodes this cycle, %" PRIu16 " uop-bundles used / updated-ip: 0x%" PRI_ADDR ".\n",
             decodes_performed, uop_bundles_used, ip);
     }
 
@@ -745,7 +745,7 @@ protected:
 
     void decode(SST::Output* output, const uint64_t ins_addr, const uint32_t next_ins, VanadisInstructionBundle* bundle)
     {
-        output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "[decode] > addr: 0x%llx ins: 0x%08x\n", ins_addr, next_ins);
+        output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "[decode] > addr: 0x%" PRI_ADDR " ins: 0x%08x\n", ins_addr, next_ins);
 
         const uint32_t hw_thr    = getHardwareThread();
         const uint32_t ins_mask  = next_ins & MIPS_OP_MASK;
@@ -1519,7 +1519,7 @@ protected:
                 jump_to |= (uint64_t)upper_bits;
 
                 //				output->verbose(CALL_INFO, 16, 0,
-                //"[decoder/J]: -> jump-to: %" PRIu64 " / 0x%0llx\n", 					jump_to,
+                //"[decoder/J]: -> jump-to: %" PRIu64 " / 0x%0" PRI_ADDR "\n", 					jump_to,
                 // jump_to);
 
                 bundle->addInstruction(

--- a/src/sst/elements/vanadis/decoder/vmipsdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vmipsdecoder.h
@@ -753,7 +753,7 @@ protected:
 
         if ( 0 != (ins_addr & 0x3) ) {
             output->verbose(
-                CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "[decode] ---> fault address 0x%llu is not aligned at 4 bytes.\n", ins_addr);
+                CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "[decode] ---> fault address 0x%" PRIu64 " is not aligned at 4 bytes.\n", ins_addr);
             bundle->addInstruction(new VanadisInstructionDecodeFault(ins_addr, hw_thr, options));
             return;
         }

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -49,7 +49,7 @@ public:
       SST_ELI_ELEMENT_VERSION(1, 0, 0),
       "Implements a RISCV64-compatible decoder for Vanadis CPU processing.",
       SST::Vanadis::VanadisDecoder)
-      
+
     SST_ELI_DOCUMENT_PARAMS(
       {"decode_max_ins_per_cycle", "Maximum number of instructions that can be "
                                    "decoded and issued per cycle", "2"},
@@ -699,7 +699,7 @@ protected:
                     } break;
                     case 0x1:
                     {
-                        // MULHU mul und place in upper XLEN bits, unsigned 
+                        // MULHU mul und place in upper XLEN bits, unsigned
                         // need to check the register order
                         output->verbose(
                             CALL_INFO, 16, 0, "-------> MULHU %" PRIu16 " <- %" PRIu16 " + %" PRIu16 "\n", rd, rs1, rs2);
@@ -1039,12 +1039,12 @@ protected:
                         switch ( uimm64 ) {
                         case 0x1:
                         {
-                            // Pseudoinstructions FSFLAGS; csrrw x0, fflags rs  
+                            // Pseudoinstructions FSFLAGS; csrrw x0, fflags rs
                             output->verbose( CALL_INFO, 16, 0, "-----> FSFLAGS: %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", uimm64, rd, rs1);
 
                             // CSSRW x0, clear the flags
 							bundle->addInstruction(new VanadisFPFlagsSetInstruction(ins_address, hw_thr, options, fpflags, rd));
-                            // FFLAGS rs, write the flags 
+                            // FFLAGS rs, write the flags
 							bundle->addInstruction(new VanadisFPFlagsSetInstruction(ins_address, hw_thr, options, fpflags, rs1));
                             decode_fault = false;
                         } break;
@@ -1062,7 +1062,7 @@ protected:
                         switch ( uimm64 ) {
                         case 0x1:
                         {
-                            // Pseudoinstructions FRFLAGS; csrrs rd, fflags x0  
+                            // Pseudoinstructions FRFLAGS; csrrs rd, fflags x0
                             output->verbose( CALL_INFO, 16, 0, "-----> FRFLAGS: %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", uimm64, rd, rs1);
 
                             // CSRRS rd ; put fpflags in rd
@@ -1108,7 +1108,7 @@ protected:
 									   case 1: {
 											// CSR register 1 maps to floating point flags
 											bundle->addInstruction(new VanadisFPFlagsSetImmInstruction(ins_address, hw_thr, options, fpflags, static_cast<uint64_t>(rs1)));
-      	                        decode_fault = false;
+                                decode_fault = false;
 											} break;
 										}
                         }
@@ -1250,7 +1250,7 @@ protected:
 				   // could optimize this to be more efficient
 					output->verbose(CALL_INFO, 16, 0, "----> FENCE\n");
 					bundle->addInstruction(
-	                             	new VanadisFenceInstruction(ins_address, hw_thr, options, VANADIS_LOAD_STORE_FENCE));
+								    new VanadisFenceInstruction(ins_address, hw_thr, options, VANADIS_LOAD_STORE_FENCE));
                decode_fault = false;
 				} break;
             case 0x2F:
@@ -1281,8 +1281,8 @@ protected:
                 {
                     if(LIKELY(op_width != 0)) {
                         // AMO.ADD
-                        output->verbose(CALL_INFO, 16, 0, 
-                            "-----> AMOADD 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
+                        output->verbose(CALL_INFO, 16, 0,
+                            "-----> AMOADD 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16
                             " / width: %" PRIu32 " / aq: %s / rl: %s\n",
                             ins_address, hw_thr, rd, rs1, rs2, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
@@ -1337,8 +1337,8 @@ protected:
                 {
                     if(LIKELY(op_width != 0)) {
                         // AMO.SWAP
-                        output->verbose(CALL_INFO, 16, 0, 
-                            "-----> AMOSWAP 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
+                        output->verbose(CALL_INFO, 16, 0,
+                            "-----> AMOSWAP 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16
                             " / width: %" PRIu32 " / aq: %s / rl: %s\n",
                             ins_address, hw_thr, rd, rs1, rs2, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
@@ -1348,13 +1348,13 @@ protected:
 
                         // implement a micro-op sequence for AMOSWAP (yuck)
                         bundle->addInstruction(new VanadisLoadInstruction(
-                                    ins_address, hw_thr, options, rs1, 0, /* place in r32 */ 32, op_width, 
+                                    ins_address, hw_thr, options, rs1, 0, /* place in r32 */ 32, op_width,
                                     true, MEM_TRANSACTION_LLSC_LOAD,
                                     LOAD_INT_REGISTER));
 
-                        // 0 is a success, 1 is a failure 
+                        // 0 is a success, 1 is a failure
                         bundle->addInstruction(new VanadisStoreConditionalInstruction(
-                                ins_address, hw_thr, options, rs1, 0, rs2, /* place in r33 */ 33, op_width, 
+                                ins_address, hw_thr, options, rs1, 0, rs2, /* place in r33 */ 33, op_width,
                                 STORE_INT_REGISTER, 0, 1));
 
                         // conditionally copy the loaded value into rd IF the store-conditional was successful
@@ -1442,14 +1442,14 @@ protected:
 							output->verbose(CALL_INFO, 16, 0, "-------> FSW imm=%" PRId64 " / rs1: %" PRIu16 " / rs2: %" PRIu16 "\n", simm64, rs1, rs2);
 							bundle->addInstruction(new VanadisStoreInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rs2, 4, MEM_TRANSACTION_NONE, STORE_FP_REGISTER));
-                    	decode_fault = false;
+                        decode_fault = false;
 						} break;
 					case 0x3:
 						{
 							output->verbose(CALL_INFO, 16, 0, "-------> FSD imm=%" PRId64 " / rs1: %" PRIu16 " / rs2: %" PRIu16 "\n", simm64, rs1, rs2);
 							bundle->addInstruction(new VanadisStoreInstruction(
                         ins_address, hw_thr, options, rs1, simm64, rs2, 8, MEM_TRANSACTION_NONE, STORE_FP_REGISTER));
-                    	decode_fault = false;
+                        decode_fault = false;
 						} break;
 					}
             } break;
@@ -1623,7 +1623,7 @@ protected:
                         ins_address, hw_thr, options, fpflags, rd, rs1, rs2));
                     decode_fault = false;
                 } break;
-				    case 32:
+					case 32:
                     {
                       processR(ins, op_code, rd, rs1, rs2, func_code3, func_code7);
 
@@ -1632,7 +1632,7 @@ protected:
                       switch ( rs2 ) {
                         case 1:
                         {
-                            // double to float 
+                            // double to float
                             output->verbose(CALL_INFO, 16, 0, "-----> FCVT.S.D %" PRIu16 " <- %" PRIu16 "\n", rs1, rd);
                             bundle->addInstruction(
                                 new VanadisFPConvertInstruction<double,float>(ins_address, hw_thr, options, fpflags, rd, rs1));
@@ -1818,15 +1818,15 @@ protected:
                     {
 						switch(func_code3) {
 							case 0: {
-	                            output->verbose(CALL_INFO, 16, 0, "-----> FMV.X.W %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
+								output->verbose(CALL_INFO, 16, 0, "-----> FMV.X.W %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
                                 bundle->addInstruction(
                                 new VanadisFP2GPRInstruction<int32_t, int32_t>(ins_address, hw_thr, options, fpflags, rd, rs1));
-         	                    decode_fault = false;
+                                decode_fault = false;
 							} break;
 						}
                     } break;
                    }
-			    } break;
+				} break;
 				 case 120:
 				 {
                     processR(ins, op_code, rd, rs1, rs2, func_code3, func_code7);
@@ -1841,15 +1841,15 @@ protected:
                     {
 								switch(func_code3) {
 								case 0: {
-	                        output->verbose(CALL_INFO, 16, 0, "-----> FMV.W.X %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
-   	                     bundle->addInstruction(
-      	                      new VanadisGPR2FPInstruction<int32_t, int32_t>(ins_address, hw_thr, options, fpflags, rd, rs1));
-         	               decode_fault = false;
+							output->verbose(CALL_INFO, 16, 0, "-----> FMV.W.X %" PRIu16 " <- %" PRIu16 "\n", rd, rs1);
+                         bundle->addInstruction(
+                              new VanadisGPR2FPInstruction<int32_t, int32_t>(ins_address, hw_thr, options, fpflags, rd, rs1));
+                           decode_fault = false;
 								} break;
 								}
                     } break;
                    }
-			    } break;
+				} break;
                 case 0x50:
                 {
                     switch ( func_code3 ) {

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -85,7 +85,7 @@ public:
 	VanadisRegisterFile* regFile, const uint64_t start_stack_address ) override {
 
         output->verbose(
-            CALL_INFO, 16, 0, "-> Setting SP to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", start_stack_address,
+            CALL_INFO, 16, 0, "-> Setting SP to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", start_stack_address,
             start_stack_address);
 
         // Per RISCV Assembly Programemr's handbook, register x2 is for stack
@@ -100,7 +100,7 @@ public:
 
     void setArg1Register( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) override {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting argument 1 register to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting argument 1 register to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(10);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> argument 1 (r10) maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -110,7 +110,7 @@ public:
 
     virtual void setReturnRegister( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) override {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 10 to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting register 10 to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(10);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> r10 maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -120,7 +120,7 @@ public:
 
     virtual void setThreadPointer( SST::Output* output, VanadisISATable* isa_tbl, VanadisRegisterFile* regFile, const uint64_t value ) override {
         output->verbose(
-            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting thread pointer to (64B-aligned):          %" PRIu64 " / 0x%0llx\n", value,
+            CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Setting thread pointer to (64B-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", value,
             value);
         const int16_t sp_phys_reg = isa_tbl->getIntPhysReg(4);
         output->verbose(CALL_INFO, 16, VANADIS_DBG_DECODER_FLG, "-> Thread Pointer (r4) maps to phys-reg: %" PRIu16 "\n", sp_phys_reg);
@@ -143,7 +143,7 @@ public:
                     // We have the instruction in our micro-op cache
                     if(output->getVerboseLevel() >= 16) {
                         output->verbose(
-                            CALL_INFO, 16, 0, "---> Found uop bundle for ip=0x%llx, loading from cache...\n", ip);
+                            CALL_INFO, 16, 0, "---> Found uop bundle for ip=0x%" PRI_ADDR ", loading from cache...\n", ip);
                     }
                     stat_uop_hit->addData(1);
 
@@ -175,8 +175,8 @@ public:
                                     if(output->getVerboseLevel() >= 16) {
                                         output->verbose(
                                             CALL_INFO, 16, 0,
-                                            "----> contains a branch: 0x%llx / predicted "
-                                            "(found in predictor): 0x%llx\n",
+                                            "----> contains a branch: 0x%" PRI_ADDR " / predicted "
+                                            "(found in predictor): 0x%" PRI_ADDR "\n",
                                             ip, predicted_address);
                                     }
 
@@ -191,8 +191,8 @@ public:
                                     if(output->getVerboseLevel() >= 16) {
                                         output->verbose(
                                             CALL_INFO, 16, 0,
-                                            "----> contains a branch: 0x%llx / predicted "
-                                            "(not-found in predictor): 0x%llx, pc-increment: %" PRIu64 "\n",
+                                            "----> contains a branch: 0x%" PRI_ADDR " / predicted "
+                                            "(not-found in predictor): 0x%" PRI_ADDR ", pc-increment: %" PRIu64 "\n",
                                             ip, ip + 4, bundle->pcIncrement());
                                     }
 
@@ -209,7 +209,7 @@ public:
                         // already found a predicted target addeess to decode
                         if(output->getVerboseLevel() >= 16) {
                             output->verbose(
-                                CALL_INFO, 16, 0, "----> branch? %s, ip=0x%llx + inc=%" PRIu64 " = new-ip=0x%llx\n",
+                                CALL_INFO, 16, 0, "----> branch? %s, ip=0x%" PRI_ADDR " + inc=%" PRIu64 " = new-ip=0x%" PRI_ADDR "\n",
                                 bundle_has_branch ? "yes" : "no", ip, bundle_has_branch ? 0 : bundle->pcIncrement(),
                                 bundle_has_branch ? ip : ip + bundle->pcIncrement());
                         }
@@ -228,7 +228,7 @@ public:
                         output->verbose(
                             CALL_INFO, 16, 0,
                             "---> uop not found, but is located in the predecode "
-                            "i0-icache (ip=0x%llx)\n",
+                            "i0-icache (ip=0x%" PRI_ADDR ")\n",
                             ip);
                     }
 
@@ -241,7 +241,7 @@ public:
                         ins_loader->getPredecodeBytes(output, ip, (uint8_t*)&temp_ins, sizeof(temp_ins));
 
                     if ( predecode_bytes ) {
-                        output->verbose(CALL_INFO, 16, 0, "---> performing a decode for ip=0x%llx\n", ip);
+                        output->verbose(CALL_INFO, 16, 0, "---> performing a decode for ip=0x%" PRI_ADDR "\n", ip);
                         decode(output, ip, temp_ins, decoded_bundle);
 
                         if(output->getVerboseLevel() >= 16) {
@@ -253,7 +253,7 @@ public:
                         ins_loader->cacheDecodedBundle(decoded_bundle);
 
                         if ( 0 == decoded_bundle->getInstructionCount() ) {
-                            output->fatal(CALL_INFO, -1, "Error - bundle at: 0x%llx generates no micro-ops.\n", ip);
+                            output->fatal(CALL_INFO, -1, "Error - bundle at: 0x%" PRI_ADDR " generates no micro-ops.\n", ip);
                         }
 
                         // Exit this cycle because results saved to cache are available next
@@ -275,7 +275,7 @@ public:
                         output->verbose(
                             CALL_INFO, 16, 0,
                             "---> microop bundle and pre-decoded bytes are not found for "
-                            "0x%llx, requested read for cache line (line=%" PRIu64 ")\n",
+                            "0x%" PRI_ADDR ", requested read for cache line (line=%" PRIu64 ")\n",
                             ip, ins_loader->getCacheLineWidth());
                     }
                     ins_loader->requestLoadAt(output, ip, 4);
@@ -294,7 +294,7 @@ public:
         }
 
         if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> cycle is completed, ip=0x%llx\n", ip);
+            output->verbose(CALL_INFO, 16, 0, "---> cycle is completed, ip=0x%" PRI_ADDR "\n", ip);
         }
     }
 
@@ -307,7 +307,7 @@ protected:
 
     void decode(SST::Output* output, const uint64_t ins_address, const uint32_t ins, VanadisInstructionBundle* bundle)
     {
-        output->verbose(CALL_INFO, 16, 0, "[decode] -> addr: 0x%llx / ins: 0x%08x\n", ins_address, ins);
+        output->verbose(CALL_INFO, 16, 0, "[decode] -> addr: 0x%" PRI_ADDR " / ins: 0x%08x\n", ins_address, ins);
         output->verbose(CALL_INFO, 16, 0, "[decode] -> ins-bytes: 0x%08x\n", ins);
 
         // We are supposed to have 16b packets for RISCV instructions, if we don't then mark fault
@@ -467,7 +467,7 @@ protected:
                     output->verbose(
                         CALL_INFO, 16, 0,
                         "----> STORE width: %" PRIu32 " bytes == (1 << %" PRIu32 ") %" PRIu16 " -> memory[ %" PRIu16
-                        " + %" PRId64 " / (0x%llx)]\n",
+                        " + %" PRId64 " / (0x%" PRI_ADDR ")]\n",
                         store_bytes, func_code3, rs2, rs1, simm64, simm64);
 
                     bundle->addInstruction(new VanadisStoreInstruction(
@@ -922,7 +922,7 @@ protected:
 
                 output->verbose(
                     CALL_INFO, 16, 0,
-                    "-----> JAL link-reg: %" PRIu16 " / jump-address: 0x%llx + %" PRId64 " = 0x%llx\n", rd, ins_address,
+                    "-----> JAL link-reg: %" PRIu16 " / jump-address: 0x%" PRI_ADDR " + %" PRId64 " = 0x%" PRI_ADDR "\n", rd, ins_address,
                     simm64, jump_to);
 
                 bundle->addInstruction(new VanadisJumpLinkInstruction(
@@ -1033,7 +1033,7 @@ protected:
                     {
                         // CSRRW
                         output->verbose(
-                            CALL_INFO, 16, 0, "-----> CSRRW CSR: ins: 0x%llx / %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
+                            CALL_INFO, 16, 0, "-----> CSRRW CSR: ins: 0x%" PRI_ADDR " / %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
 
                         // Switch based on the CSR being read
                         switch ( uimm64 ) {
@@ -1055,7 +1055,7 @@ protected:
                     {
                         // CSRRS
                         output->verbose(
-                            CALL_INFO, 16, 0, "-----> CSRRS CSR: ins: 0x%llx / %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
+                            CALL_INFO, 16, 0, "-----> CSRRS CSR: ins: 0x%" PRI_ADDR " / %" PRIu64 " / rd: %" PRIu16 " / rs1: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
                         // ignore for now?
 
                         // Switch based on the CSR being read
@@ -1101,7 +1101,7 @@ protected:
                         // CSRRSI
                         output->verbose(
                             CALL_INFO, 16, 0,
-                            "-----> CSRRS CSRRSI: ins: 0x%llx / %" PRIu64 " / reg: %" PRIu16 " / UIMMM: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
+                            "-----> CSRRS CSRRSI: ins: 0x%" PRI_ADDR " / %" PRIu64 " / reg: %" PRIu16 " / UIMMM: %" PRIu16 "\n", ins_address, uimm64, rd, rs1);
 
                         if ( 0 == rd ) {
 										switch(uimm64) {
@@ -1282,7 +1282,7 @@ protected:
                     if(LIKELY(op_width != 0)) {
                         // AMO.ADD
                         output->verbose(CALL_INFO, 16, 0, 
-                            "-----> AMOADD 0x%llx / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
+                            "-----> AMOADD 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
                             " / width: %" PRIu32 " / aq: %s / rl: %s\n",
                             ins_address, hw_thr, rd, rs1, rs2, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
@@ -1338,7 +1338,7 @@ protected:
                     if(LIKELY(op_width != 0)) {
                         // AMO.SWAP
                         output->verbose(CALL_INFO, 16, 0, 
-                            "-----> AMOSWAP 0x%llx / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
+                            "-----> AMOSWAP 0x%" PRI_ADDR " / thr: %" PRIu32 " / %" PRIu16 " <- memory[ %" PRIu16 " ] <- %" PRIu16 
                             " / width: %" PRIu32 " / aq: %s / rl: %s\n",
                             ins_address, hw_thr, rd, rs1, rs2, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
@@ -1382,7 +1382,7 @@ protected:
                         // LR.?.AQ.RL
                         if(LIKELY(op_width != 0)) {
                             output->verbose(
-                                CALL_INFO, 16, 0, "-----> LR 0x%llx / thr: %" PRIu32 " / (LLSC_LOAD) %" PRIu16 " <- memory[ %" PRIu16 " ] / width: %" PRIu32 " / aq: %s / rl: %s\n",
+                                CALL_INFO, 16, 0, "-----> LR 0x%" PRI_ADDR " / thr: %" PRIu32 " / (LLSC_LOAD) %" PRIu16 " <- memory[ %" PRIu16 " ] / width: %" PRIu32 " / aq: %s / rl: %s\n",
                                     ins_address, hw_thr, rd, rs1, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
                             if(LIKELY(perform_aq)) {
@@ -1409,7 +1409,7 @@ protected:
                     if(LIKELY(op_width != 0)) {
                         output->verbose(
                             CALL_INFO, 16, 0,
-                            "-----> SC 0x%llx / thr: %" PRIu32 " / (LLSC_STORE) %" PRIu16 " -> memory[ %" PRIu16 " ] / result: %" PRIu16 " / width: %" PRIu32 " / aq: %s / rl: %s\n",
+                            "-----> SC 0x%" PRI_ADDR " / thr: %" PRIu32 " / (LLSC_STORE) %" PRIu16 " -> memory[ %" PRIu16 " ] / result: %" PRIu16 " / width: %" PRIu32 " / aq: %s / rl: %s\n",
                             ins_address, hw_thr, rs2, rs1, rd, op_width, perform_aq ?  "yes" : "no", perform_rl ? "yes" : "no");
 
                         if(LIKELY(perform_aq)) {
@@ -2315,7 +2315,7 @@ protected:
                         uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
 
                         output->verbose(
-                            CALL_INFO, 16, 0, "--------> RVC SRLI %" PRIu16 " = %" PRIu16 " >> %" PRIu64 " (0x%llx)\n",
+                            CALL_INFO, 16, 0, "--------> RVC SRLI %" PRIu16 " = %" PRIu16 " >> %" PRIu64 " (0x%" PRI_ADDR ")\n",
                             rvc_rs1, rvc_rs1, shift_by, shift_by);
                         bundle->addInstruction(
                             new VanadisShiftRightLogicalImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
@@ -2333,7 +2333,7 @@ protected:
                         uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
 
                         output->verbose(
-                            CALL_INFO, 16, 0, "--------> RVC SRAI %" PRIu16 " = %" PRIu16 " >> %" PRIu64 " (0x%llx)\n",
+                            CALL_INFO, 16, 0, "--------> RVC SRAI %" PRIu16 " = %" PRIu16 " >> %" PRIu64 " (0x%" PRI_ADDR ")\n",
                             rvc_rs1, rvc_rs1, shift_by, shift_by);
                         bundle->addInstruction(
                             new VanadisShiftRightArithmeticImmInstruction<VanadisRegisterFormat::VANADIS_FORMAT_INT64>(
@@ -2353,7 +2353,7 @@ protected:
                         uint16_t rvc_rs1 = expand_rvc_int_register(extract_rs1_rvc(ins));
 
                         output->verbose(
-                            CALL_INFO, 16, 0, "--------> RVC ANDI %" PRIu16 " = %" PRIu16 " & %" PRIu64 " (0x%llx)\n",
+                            CALL_INFO, 16, 0, "--------> RVC ANDI %" PRIu16 " = %" PRIu16 " & %" PRIu64 " (0x%" PRI_ADDR ")\n",
                             rvc_rs1, rvc_rs1, imm, imm);
 
                         bundle->addInstruction(
@@ -2488,7 +2488,7 @@ protected:
                     const uint64_t jump_target = static_cast<uint64_t>(pc_i64 + imm_final);
 
                     output->verbose(
-                        CALL_INFO, 16, 0, "----> decode RVC JUMP pc=0x%llx + imm=%" PRId64 " = 0x%llx\n", ins_address,
+                        CALL_INFO, 16, 0, "----> decode RVC JUMP pc=0x%" PRI_ADDR " + imm=%" PRId64 " = 0x%" PRI_ADDR "\n", ins_address,
                         imm_final, jump_target);
 
                     bundle->addInstruction(new VanadisJumpInstruction(
@@ -2511,7 +2511,7 @@ protected:
                     if ( imm_8 != 0 ) { imm_final |= 0xFFFFFFFFFFFFFE00; }
 
                     output->verbose(
-                        CALL_INFO, 16, 0, "----> decode RVC BEQZ %" PRIu16 " jump to: 0x%llx + 0x%llx = 0x%llx\n",
+                        CALL_INFO, 16, 0, "----> decode RVC BEQZ %" PRIu16 " jump to: 0x%" PRI_ADDR " + 0x%" PRI_ADDR " = 0x%" PRI_ADDR "\n",
                         rvc_rs1, ins_address, imm_final, ins_address + imm_final);
 
                     bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<
@@ -2535,7 +2535,7 @@ protected:
                     if ( imm_8 != 0 ) { imm_final |= 0xFFFFFFFFFFFFFE00; }
 
                     output->verbose(
-                        CALL_INFO, 16, 0, "----> decode RVC BNEZ %" PRIu16 " jump to: 0x%llx + 0x%llx = 0x%llx\n",
+                        CALL_INFO, 16, 0, "----> decode RVC BNEZ %" PRIu16 " jump to: 0x%" PRI_ADDR " + 0x%" PRI_ADDR " = 0x%" PRI_ADDR "\n",
                         rvc_rs1, ins_address, imm_final, ins_address + imm_final);
 
                     bundle->addInstruction(new VanadisBranchRegCompareImmInstruction<
@@ -2793,7 +2793,7 @@ protected:
             if ( fatal_decode_fault ) {
                 output->fatal(
                     CALL_INFO, -1,
-                    "[decode] -> decode fault detected at 0x%llx / thr: %" PRIu32 ", set to fatal on detect\n",
+                    "[decode] -> decode fault detected at 0x%" PRI_ADDR " / thr: %" PRIu32 ", set to fatal on detect\n",
                     ins_address, hw_thr);
             }
             bundle->addInstruction(new VanadisInstructionDecodeFault(ins_address, hw_thr, options));

--- a/src/sst/elements/vanadis/decoder/vriscv64decoder.h
+++ b/src/sst/elements/vanadis/decoder/vriscv64decoder.h
@@ -263,7 +263,7 @@ public:
                     else {
                         output->fatal(
                             CALL_INFO, -1,
-                            "Error - predecoded bytes for 0x%llu found, but "
+                            "Error - predecoded bytes for 0x%" PRIu64 " found, but "
                             "retrieval of bytes failed.\n",
                             ip);
                     }

--- a/src/sst/elements/vanadis/inst/isatable.h
+++ b/src/sst/elements/vanadis/inst/isatable.h
@@ -21,6 +21,10 @@
 
 #include <cstdint>
 
+#ifndef PRI_ADDR
+#define PRI_ADDR PRIx64
+#endif
+
 namespace SST {
 namespace Vanadis {
 
@@ -152,7 +156,7 @@ public:
                     output->verbose(
                         CALL_INFO, output_v, 0,
                         "[Thread: %d]: | isa:%5" PRIu16 " -> phys:%5" PRIu16 " | r:%5" PRIu32 " | w:%5" PRIu32
-                        " | v: 0x%016llx | v: %" PRIu64 " / %" PRId64 "\n",
+                        " | v: 0x%016" PRI_ADDR " | v: %" PRIu64 " / %" PRId64 "\n",
                         regFile-> getHWThread(), i, int_reg_ptr[i], int_reg_pending_read[i], int_reg_pending_write[i],
                         regFile->getIntReg<int64_t>(int_reg_ptr[i]), regFile->getIntReg<uint64_t>(int_reg_ptr[i]),
                         regFile->getIntReg<int64_t>(int_reg_ptr[i]));
@@ -183,7 +187,7 @@ public:
                         output->verbose(
                             CALL_INFO, output_v, 0,
                             "| isa:%5" PRIu16 " -> phys:%5" PRIu16 " | r:%5" PRIu32 " | w:%5" PRIu32
-                            " | v: 0x%016llx |\n",
+                            " | v: 0x%016" PRI_ADDR " |\n",
                             i, fp_reg_ptr[i], fp_reg_pending_read[i], fp_reg_pending_write[i],
                             regFile->getFPReg<uint64_t>(fp_reg_ptr[i]));
                     }

--- a/src/sst/elements/vanadis/inst/vadd.h
+++ b/src/sst/elements/vanadis/inst/vadd.h
@@ -63,7 +63,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
                 " / in=%" PRIu16 ", %" PRIu16 "\n",
                 getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0],
                 phys_int_regs_in[1], isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);

--- a/src/sst/elements/vanadis/inst/vbcmp.h
+++ b/src/sst/elements/vanadis/inst/vbcmp.h
@@ -63,7 +63,7 @@ public:
         snprintf(
             buffer, buffer_size,
             "BCMP (%s) isa-in: %" PRIu16 ", %" PRIu16 " / phys-in: %" PRIu16 ", %" PRIu16 " offset: %" PRId64
-            " = 0x%llx",
+            " = 0x%" PRI_ADDR "",
             convertCompareTypeToString(compare_type), isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_in[0],
             phys_int_regs_in[1], offset, getInstructionAddress() + offset);
     }
@@ -90,14 +90,14 @@ public:
             takenAddress = (uint64_t)(((int64_t)getInstructionAddress()) + offset);
 #ifdef VANADIS_BUILD_DEBUG
             output->verbose(
-                CALL_INFO, 16, 0, "-----> taken-address: 0x%llx + %" PRId64 " = 0x%llx\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "-----> taken-address: 0x%" PRI_ADDR " + %" PRId64 " = 0x%" PRI_ADDR "\n", getInstructionAddress(),
                 offset, takenAddress);
 #endif
         }
         else {
             takenAddress = calculateStandardNotTakenAddress();
 #ifdef VANADIS_BUILD_DEBUG
-            output->verbose(CALL_INFO, 16, 0, "-----> not-taken-address: 0x%llx\n", takenAddress);
+            output->verbose(CALL_INFO, 16, 0, "-----> not-taken-address: 0x%" PRI_ADDR "\n", takenAddress);
 #endif
         }
 

--- a/src/sst/elements/vanadis/inst/vbfp.h
+++ b/src/sst/elements/vanadis/inst/vbfp.h
@@ -58,7 +58,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: (addr=0x%llx) BFP%c isa-in: %" PRIu16 ", / phys-in: %" PRIu16 " / offset: %" PRId64 "\n",
+                "Execute: (addr=0x%" PRI_ADDR ") BFP%c isa-in: %" PRIu16 ", / phys-in: %" PRIu16 " / offset: %" PRId64 "\n",
                 getInstructionAddress(), branch_on_true ? 'T' : 'F', isa_fp_regs_in[0], phys_fp_regs_in[0], offset);
         }
 #endif
@@ -72,13 +72,13 @@ public:
             takenAddress = (uint64_t)(((int64_t)getInstructionAddress()) + offset);
 
             output->verbose(
-                CALL_INFO, 16, 0, "-----> taken-address: 0x%llx + %" PRId64 " = 0x%llx\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "-----> taken-address: 0x%" PRI_ADDR " + %" PRId64 " = 0x%" PRI_ADDR "\n", getInstructionAddress(),
                 offset, takenAddress);
         }
         else {
             takenAddress = calculateStandardNotTakenAddress();
 
-            output->verbose(CALL_INFO, 16, 0, "-----> not-taken-address: 0x%llx\n", takenAddress);
+            output->verbose(CALL_INFO, 16, 0, "-----> not-taken-address: 0x%" PRI_ADDR "\n", takenAddress);
         }
 
         markExecuted();

--- a/src/sst/elements/vanadis/inst/vcimov.h
+++ b/src/sst/elements/vanadis/inst/vcimov.h
@@ -59,7 +59,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: CMOVI    inst: 0x%llx / %5" PRIu16 " <- %" PRIu16 " if %" PRIu16 " == %" PRId64 " { %" PRIu16 " <- %" PRIu16 " if %" PRIu16 " == %" PRId64 " }\n",
+                "Execute: CMOVI    inst: 0x%" PRI_ADDR " / %5" PRIu16 " <- %" PRIu16 " if %" PRIu16 " == %" PRId64 " { %" PRIu16 " <- %" PRIu16 " if %" PRIu16 " == %" PRId64 " }\n",
                 getInstructionAddress(), isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1], imm,
                 phys_int_regs_out[0], phys_int_regs_in[0],
                 phys_int_regs_in[1], imm);

--- a/src/sst/elements/vanadis/inst/vdiv.h
+++ b/src/sst/elements/vanadis/inst/vdiv.h
@@ -71,7 +71,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
                 " / in=%" PRIu16 ", %" PRIu16 "\n",
                 getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0],
                 phys_int_regs_in[1], isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);

--- a/src/sst/elements/vanadis/inst/vdivmod.h
+++ b/src/sst/elements/vanadis/inst/vdivmod.h
@@ -71,7 +71,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s q: %" PRIu16 " r: %" PRIu16 " <- %" PRIu16 " \\ %" PRIu16 " (phys: q: %" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s q: %" PRIu16 " r: %" PRIu16 " <- %" PRIu16 " \\ %" PRIu16 " (phys: q: %" PRIu16
                 " r: %" PRIu16 " %" PRIu16 " %" PRIu16 ")\n",
                 getInstructionAddress(), getInstCode(), isa_int_regs_out[0], isa_int_regs_out[1],
                 isa_int_regs_in[0], isa_int_regs_in[1], phys_int_regs_out[0], phys_int_regs_out[1], phys_int_regs_in[0],

--- a/src/sst/elements/vanadis/inst/vfault.h
+++ b/src/sst/elements/vanadis/inst/vfault.h
@@ -50,7 +50,7 @@ public:
     void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
-            buffer, buffer_size, "%s (ins-addr: 0x%llx, %s)", getInstCode(), getInstructionAddress(),
+            buffer, buffer_size, "%s (ins-addr: 0x%" PRI_ADDR ", %s)", getInstCode(), getInstructionAddress(),
             fault_msg.c_str());
     }
 

--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -80,7 +80,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
                 "\n",
                 getInstructionAddress(), getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_fp_regs_in[0],
                 phys_fp_regs_in[0]);

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -80,7 +80,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s int-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s int-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
                 "\n",
                 getInstructionAddress(), getInstCode(), isa_int_regs_out[0], phys_int_regs_out[0], isa_fp_regs_in[0],
                 phys_fp_regs_in[0]);

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -83,7 +83,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: 0x%llx %s\n", getInstructionAddress(), getInstCode());
+                CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s\n", getInstructionAddress(), getInstCode());
         }
 #endif
 

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -133,7 +133,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- fp-src: isa: %" PRIu16 " phys: %" PRIu16
                 "\n",
                 getInstructionAddress(), getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_fp_regs_in[0],
                 phys_fp_regs_in[0]);

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -99,7 +99,7 @@ public:
             writeFPRegs(fp_register_buffer, 256);
 
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s int: %s / fp: %s\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s int: %s / fp: %s\n", getInstructionAddress(),
                 getInstCode(), int_register_buffer, fp_register_buffer);
 
             delete[] int_register_buffer;

--- a/src/sst/elements/vanadis/inst/vfpflagsread.h
+++ b/src/sst/elements/vanadis/inst/vfpflagsread.h
@@ -76,7 +76,7 @@ public:
 			}
 
 			if(output->getVerboseLevel() >= 16) {
-				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%llx %s out-reg: %" PRIu16 " / out-mask: 0x%llx / copy_round: %c / shift_round: %c / copy_fp: %c\n",
+				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s out-reg: %" PRIu16 " / out-mask: 0x%" PRI_ADDR " / copy_round: %c / shift_round: %c / copy_fp: %c\n",
 						getInstructionAddress(), getInstCode(), phys_int_regs_out[0], flags_out,
 						copy_round_mode ? 'y' : 'n', shift_round_mode ? 'y' : 'n', copy_fp_flags ? 'y' : 'n');
 			}

--- a/src/sst/elements/vanadis/inst/vfpflagsset.h
+++ b/src/sst/elements/vanadis/inst/vfpflagsset.h
@@ -57,7 +57,7 @@ public:
 			const uint64_t mask_in = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
 
 			if(output->getVerboseLevel() >= 16) {
-				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%llx %s in-reg: %" PRIu16 " / phys: %" PRIu16 " -> mask = %" PRIu64 " (0x%llx)\n",
+				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s in-reg: %" PRIu16 " / phys: %" PRIu16 " -> mask = %" PRIu64 " (0x%" PRI_ADDR ")\n",
 					getInstructionAddress(), getInstCode(), isa_int_regs_in[0], phys_int_regs_in[0], mask_in, mask_in);
 			}
 
@@ -85,7 +85,7 @@ public:
 
 			markExecuted();
 		} else {
-			output->verbose(CALL_INFO, 16, 0, "not front of ROB for ins: 0x%llx %s\n", getInstructionAddress(), getInstCode());
+			output->verbose(CALL_INFO, 16, 0, "not front of ROB for ins: 0x%" PRI_ADDR " %s\n", getInstructionAddress(), getInstCode());
 		}
     }
 };

--- a/src/sst/elements/vanadis/inst/vfpflagssetimm.h
+++ b/src/sst/elements/vanadis/inst/vfpflagssetimm.h
@@ -54,7 +54,7 @@ public:
     {
 		if(checkFrontOfROB()) {
 			if(output->getVerboseLevel() >= 16) {
-				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%llx %s FPFLAGS <- mask = %" PRIu64 " (0x%llx)\n",
+				output->verbose(CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s FPFLAGS <- mask = %" PRIu64 " (0x%" PRI_ADDR ")\n",
 					getInstructionAddress(), getInstCode(), imm_value, imm_value);
 			}
 

--- a/src/sst/elements/vanadis/inst/vfpmadd.h
+++ b/src/sst/elements/vanadis/inst/vfpmadd.h
@@ -88,7 +88,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: 0x%llx %s\n", getInstructionAddress(), getInstCode());
+                CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s\n", getInstructionAddress(), getInstCode());
         }
 #endif
 

--- a/src/sst/elements/vanadis/inst/vfpmin.h
+++ b/src/sst/elements/vanadis/inst/vfpmin.h
@@ -93,7 +93,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s\n", getInstructionAddress(),
                 getInstCode());
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vfpmsub.h
+++ b/src/sst/elements/vanadis/inst/vfpmsub.h
@@ -88,7 +88,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: 0x%llx %s\n", getInstructionAddress(), getInstCode());
+                CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s\n", getInstructionAddress(), getInstCode());
         }
 #endif
 

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -93,7 +93,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s\n", getInstructionAddress(),
                 getInstCode());
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -159,7 +159,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s (%s)\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s (%s)\n", getInstructionAddress(),
                 getInstCode(), convertCompareTypeToString(compare_type));
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vfpsignlogic.h
+++ b/src/sst/elements/vanadis/inst/vfpsignlogic.h
@@ -84,11 +84,11 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16 ) {
             if((8 == sizeof(fp_format)) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode())) {
-                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s / isa-in: { %" PRIu16 ", %" PRIu16 " } / { %" PRIu16 ", %" PRIu16 " } -> isa-out: { %" PRIu16 ", %" PRIu16 " }\n", 
+                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: { %" PRIu16 ", %" PRIu16 " } / { %" PRIu16 ", %" PRIu16 " } -> isa-out: { %" PRIu16 ", %" PRIu16 " }\n", 
                     getInstructionAddress(), getInstCode(), phys_fp_regs_in[0], phys_fp_regs_in[1], 
                     phys_fp_regs_in[2], phys_fp_regs_in[3], phys_fp_regs_out[0], phys_fp_regs_out[1]);
             } else {
-                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s / isa-in: %" PRIu16 " / %" PRIu16 " -> isa-out: %" PRIu16 "\n", 
+                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: %" PRIu16 " / %" PRIu16 " -> isa-out: %" PRIu16 "\n", 
                     getInstructionAddress(), getInstCode(), phys_fp_regs_in[0], phys_fp_regs_in[1], phys_fp_regs_out[0]);
             }
 		}

--- a/src/sst/elements/vanadis/inst/vfpsignlogic.h
+++ b/src/sst/elements/vanadis/inst/vfpsignlogic.h
@@ -84,11 +84,11 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16 ) {
             if((8 == sizeof(fp_format)) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode())) {
-                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: { %" PRIu16 ", %" PRIu16 " } / { %" PRIu16 ", %" PRIu16 " } -> isa-out: { %" PRIu16 ", %" PRIu16 " }\n", 
-                    getInstructionAddress(), getInstCode(), phys_fp_regs_in[0], phys_fp_regs_in[1], 
+                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: { %" PRIu16 ", %" PRIu16 " } / { %" PRIu16 ", %" PRIu16 " } -> isa-out: { %" PRIu16 ", %" PRIu16 " }\n",
+                    getInstructionAddress(), getInstCode(), phys_fp_regs_in[0], phys_fp_regs_in[1],
                     phys_fp_regs_in[2], phys_fp_regs_in[3], phys_fp_regs_out[0], phys_fp_regs_out[1]);
             } else {
-                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: %" PRIu16 " / %" PRIu16 " -> isa-out: %" PRIu16 "\n", 
+                output->verbose(CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s / isa-in: %" PRIu16 " / %" PRIu16 " -> isa-out: %" PRIu16 "\n",
                     getInstructionAddress(), getInstCode(), phys_fp_regs_in[0], phys_fp_regs_in[1], phys_fp_regs_out[0]);
             }
 		}
@@ -110,7 +110,7 @@ public:
 					result = std::copysign(src_1, src_2);
             } break;
             case VanadisFPSignLogicOperation::SIGN_XOR:
-       	    {
+            {
 					if(src_2_neg) {
 						result = src_1_neg ? (-src_1) : src_1;
 					} else {

--- a/src/sst/elements/vanadis/inst/vfpsqrt.h
+++ b/src/sst/elements/vanadis/inst/vfpsqrt.h
@@ -76,7 +76,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s\n", getInstructionAddress(),
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s\n", getInstructionAddress(),
                 getInstCode());
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -93,7 +93,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%llx) %s\n", getInstructionAddress(), getInstCode());
+                CALL_INFO, 16, 0, "Execute: (addr=0x%" PRI_ADDR ") %s\n", getInstructionAddress(), getInstCode());
         }
 #endif
 

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -74,7 +74,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
             CALL_INFO, 16, 0,
-            "Execute: 0x%llx %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- int-src: isa: %" PRIu16 " phys: %" PRIu16
+            "Execute: 0x%" PRI_ADDR " %s fp-dest isa: %" PRIu16 " phys: %" PRIu16 " <- int-src: isa: %" PRIu16 " phys: %" PRIu16
             "\n",
             getInstructionAddress(), getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_int_regs_in[0],
             phys_int_regs_in[0]);

--- a/src/sst/elements/vanadis/inst/vjl.h
+++ b/src/sst/elements/vanadis/inst/vjl.h
@@ -44,7 +44,7 @@ public:
 
     void printToBuffer(char* buffer, size_t buffer_size) override
     {
-        snprintf(buffer, buffer_size, "JL      %" PRIu64 " (0x%llx)", takenAddress, takenAddress);
+        snprintf(buffer, buffer_size, "JL      %" PRIu64 " (0x%" PRI_ADDR ")", takenAddress, takenAddress);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override
@@ -55,7 +55,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: JL jump-to: %" PRIu64 " / 0x%llx / link: %" PRIu16 " phys: %" PRIu16 " v: %" PRIu64 "/ 0x%llx\n",
+                "Execute: JL jump-to: %" PRIu64 " / 0x%" PRI_ADDR " / link: %" PRIu16 " phys: %" PRIu16 " v: %" PRIu64 "/ 0x%" PRI_ADDR "\n",
                 takenAddress, takenAddress, isa_int_regs_out[0], phys_int_regs_out[0], link_value, link_value);
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vjlr.h
+++ b/src/sst/elements/vanadis/inst/vjlr.h
@@ -57,7 +57,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: addr=(0x%0llx) JLR isa-link: %" PRIu16 " isa-addr: %" PRIu16 " + %" PRIu64 " phys-link: %" PRIu16
+                "Execute: addr=(0x%0" PRI_ADDR ") JLR isa-link: %" PRIu16 " isa-addr: %" PRIu16 " + %" PRIu64 " phys-link: %" PRIu16
                 " phys-addr: %" PRIu16 "\n",
                 getInstructionAddress(), isa_int_regs_out[0], isa_int_regs_in[0], imm, phys_int_regs_out[0],
                 phys_int_regs_in[0]);
@@ -70,7 +70,7 @@ public:
         regFile->setIntReg<uint64_t>(phys_int_regs_in[0], jump_to);
 
 #ifdef VANADIS_BUILD_DEBUG
-        output->verbose(CALL_INFO, 16, 0, "Execute JLR jump-to: 0x%0llx link-value: 0x%0llx\n", jump_to, link_value);
+        output->verbose(CALL_INFO, 16, 0, "Execute JLR jump-to: 0x%0" PRI_ADDR " link-value: 0x%0" PRI_ADDR "\n", jump_to, link_value);
 #endif
         takenAddress = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
 

--- a/src/sst/elements/vanadis/inst/vjr.h
+++ b/src/sst/elements/vanadis/inst/vjr.h
@@ -49,7 +49,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
-                CALL_INFO, 16, 0, "Execute: (addr=0x%0llx) JR   isa-in: %" PRIu16 " / phys-in: %" PRIu16 "\n",
+                CALL_INFO, 16, 0, "Execute: (addr=0x%0" PRI_ADDR ") JR   isa-in: %" PRIu16 " / phys-in: %" PRIu16 "\n",
                 getInstructionAddress(), isa_int_regs_in[0], phys_int_regs_in[0]);
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vjump.h
+++ b/src/sst/elements/vanadis/inst/vjump.h
@@ -43,7 +43,7 @@ public:
 
     void printToBuffer(char* buffer, size_t buffer_size) override
     {
-        snprintf(buffer, buffer_size, "JUMP    %" PRIu64 " / 0x%llx", takenAddress, takenAddress);
+        snprintf(buffer, buffer_size, "JUMP    %" PRIu64 " / 0x%" PRI_ADDR "", takenAddress, takenAddress);
     }
 
     void execute(SST::Output* output, VanadisRegisterFile* regFile) override { markExecuted(); }

--- a/src/sst/elements/vanadis/inst/vload.h
+++ b/src/sst/elements/vanadis/inst/vload.h
@@ -18,6 +18,10 @@
 
 #include "inst/vmemflagtype.h"
 
+#ifndef PRI_ADDR
+#define PRI_ADDR PRIx64
+#endif
+
 namespace SST {
 namespace Vanadis {
 
@@ -108,7 +112,7 @@ public:
             snprintf(
                 buffer, buffer_size,
                 "LOAD (%s, %" PRIu16 " bytes)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64
-                " (0x%llx) (phys: %5" PRIu16 " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])",
+                " (0x%" PRI_ADDR ") (phys: %5" PRIu16 " <- memory[%5" PRIu16 " + %" PRId64 " (0x%" PRI_ADDR ")])",
                 getTransactionTypeString(memAccessType), load_width, isa_int_regs_out[0], isa_int_regs_in[0], offset,
                 offset, phys_int_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
@@ -117,7 +121,7 @@ public:
             snprintf(
                 buffer, buffer_size,
                 "LOADFP (%s, %" PRIu16 " bytes)  %5" PRIu16 " <- memory[ %5" PRIu16 " + %" PRId64
-                " (0x%llx) (phys: %5" PRIu16 " <- memory[%5" PRIu16 " + %" PRId64 " (0x%llx)])",
+                " (0x%" PRI_ADDR ") (phys: %5" PRIu16 " <- memory[%5" PRIu16 " + %" PRId64 " (0x%" PRI_ADDR ")])",
                 getTransactionTypeString(memAccessType), load_width, isa_fp_regs_out[0], isa_int_regs_in[0], offset,
                 offset, phys_fp_regs_out[0], phys_int_regs_in[0], offset, offset);
         } break;
@@ -143,7 +147,7 @@ public:
             if(output->getVerboseLevel() >= 16) {
                 output->verbose(
                     CALL_INFO, 16, 0,
-                    "Execute: (0x%llx) LOAD addr-reg: %" PRIu16 " phys: %" PRIu16 " / offset: %" PRId64
+                    "Execute: (0x%" PRI_ADDR ") LOAD addr-reg: %" PRIu16 " phys: %" PRIu16 " / offset: %" PRId64
                     " / target: %" PRIu16 " phys: %" PRIu16 "\n",
                     getInstructionAddress(), isa_int_regs_in[0], phys_int_regs_in[0], offset, isa_int_regs_out[0],
                     phys_int_regs_out[0]);
@@ -154,7 +158,7 @@ public:
             if(output->getVerboseLevel() >= 16) {
                 output->verbose(
                     CALL_INFO, 16, 0,
-                    "Execute: (0x%llx) LOAD addr-reg: %" PRIu16 " phys: %" PRIu16 " / offset: %" PRId64
+                    "Execute: (0x%" PRI_ADDR ") LOAD addr-reg: %" PRIu16 " phys: %" PRIu16 " / offset: %" PRId64
                     " / target: %" PRIu16 " phys: %" PRIu16 "\n",
                     getInstructionAddress(), isa_int_regs_in[0], phys_int_regs_in[0], offset, isa_fp_regs_out[0],
                     phys_fp_regs_out[0]);
@@ -165,7 +169,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
-                CALL_INFO, 16, 0, "[execute-load]: transaction-type:  %s / ins: 0x%llx\n",
+                CALL_INFO, 16, 0, "[execute-load]: transaction-type:  %s / ins: 0x%" PRI_ADDR "\n",
                 getTransactionTypeString(memAccessType), getInstructionAddress());
             output->verbose(
                 CALL_INFO, 16, 0, "[execute-load]: reg[%5" PRIu16 "]:       %" PRIu64 "\n", phys_int_regs_in[0],

--- a/src/sst/elements/vanadis/inst/vmipsfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vmipsfpscmp.h
@@ -129,7 +129,7 @@ public:
     {
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
-            CALL_INFO, 16, 0, "Execute: 0x%llx %s (%s, %s)\n", getInstructionAddress(), getInstCode(),
+            CALL_INFO, 16, 0, "Execute: 0x%" PRI_ADDR " %s (%s, %s)\n", getInstructionAddress(), getInstCode(),
             convertCompareTypeToString(compare_type), (sizeof(fp_format) == 8) ? "64b" : "32b");
 #endif
         const bool compare_result = performCompare(output, regFile);

--- a/src/sst/elements/vanadis/inst/vmul.h
+++ b/src/sst/elements/vanadis/inst/vmul.h
@@ -71,7 +71,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
                 " / in=%" PRIu16 ", %" PRIu16 "\n",
                 getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                 isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);

--- a/src/sst/elements/vanadis/inst/vmulhigh.h
+++ b/src/sst/elements/vanadis/inst/vmulhigh.h
@@ -69,7 +69,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: 0x%llx %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
+                "Execute: 0x%" PRI_ADDR " %s phys: out=%" PRIu16 " in=%" PRIu16 ", %" PRIu16 ", isa: out=%" PRIu16
                 " / in=%" PRIu16 ", %" PRIu16 "\n",
                 getInstructionAddress(), getInstCode(), phys_int_regs_out[0], phys_int_regs_in[0], phys_int_regs_in[1],
                 isa_int_regs_out[0], isa_int_regs_in[0], isa_int_regs_in[1]);

--- a/src/sst/elements/vanadis/inst/vpartialload.h
+++ b/src/sst/elements/vanadis/inst/vpartialload.h
@@ -84,12 +84,12 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
-                CALL_INFO, 16, 0, "[execute-partload]: reg[%5" PRIu16 "]: %" PRIu64 " / 0x%llx\n", phys_int_regs_in[0],
+                CALL_INFO, 16, 0, "[execute-partload]: reg[%5" PRIu16 "]: %" PRIu64 " / 0x%" PRI_ADDR "\n", phys_int_regs_in[0],
                 mem_addr_reg_val, mem_addr_reg_val);
             output->verbose(
-                CALL_INFO, 16, 0, "[execute-partload]: offset           : %" PRIu64 " / 0x%llx\n", offset, offset);
+                CALL_INFO, 16, 0, "[execute-partload]: offset           : %" PRIu64 " / 0x%" PRI_ADDR "\n", offset, offset);
             output->verbose(
-                CALL_INFO, 16, 0, "[execute-partload]: (add)            : %" PRIu64 " / 0x%llx\n",
+                CALL_INFO, 16, 0, "[execute-partload]: (add)            : %" PRIu64 " / 0x%" PRI_ADDR "\n",
                 (mem_addr_reg_val + offset), (mem_addr_reg_val + offset));
         }
 #endif
@@ -102,7 +102,7 @@ public:
             output->verbose(
                 CALL_INFO, 16, 0, "[execute-partload]: (lower/upper load ? %s)\n", is_load_lower ? "lower" : "upper");
             output->verbose(
-                CALL_INFO, 16, 0, "[execute-partload]: load-addr: %" PRIu64 " / 0x%0llx / load-width: %" PRIu16 "\n",
+                CALL_INFO, 16, 0, "[execute-partload]: load-addr: %" PRIu64 " / 0x%0" PRI_ADDR " / load-width: %" PRIu16 "\n",
                 (*out_addr), (*out_addr), (*width));
             output->verbose(CALL_INFO, 16, 0, "[execute-partload]: register-offset: %" PRIu16 "\n", register_offset);
         }

--- a/src/sst/elements/vanadis/inst/vpartialstore.h
+++ b/src/sst/elements/vanadis/inst/vpartialstore.h
@@ -63,7 +63,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "[partial-store]: compute base address: phys-reg: %" PRIu16 " / offset: %" PRIu64 " / 0x%0llx\n",
+                "[partial-store]: compute base address: phys-reg: %" PRIu16 " / offset: %" PRIu64 " / 0x%0" PRI_ADDR "\n",
                 phys_int_regs_in[0], offset, offset);
         }
 #endif
@@ -78,7 +78,7 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
-                CALL_INFO, 16, 0, "[partial-store]: base_addr: 0x%0llx full-width: %" PRIu64 "\n", base_addr, width_64);
+                CALL_INFO, 16, 0, "[partial-store]: base_addr: 0x%0" PRI_ADDR " full-width: %" PRIu64 "\n", base_addr, width_64);
             output->verbose(CALL_INFO, 16, 0, "[partial-store]: store-type: %s\n", (is_left_store) ? "left" : "right");
             output->verbose(
                 CALL_INFO, 16, 0, "[partial-store]: partial-width: %" PRIu64 "\n", (is_left_store) ? left_len : right_len);

--- a/src/sst/elements/vanadis/inst/vpartialstore.h
+++ b/src/sst/elements/vanadis/inst/vpartialstore.h
@@ -105,7 +105,7 @@ public:
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "[partial-store]: store-addr: 0x%0llu / store-width: %" PRIu16 " / reg-offset: %" PRIu16 "\n",
+                "[partial-store]: store-addr: 0x%0" PRIu64 " / store-width: %" PRIu16 " / reg-offset: %" PRIu16 "\n",
                 (*store_addr), (*op_width), register_offset);
         }
 #endif

--- a/src/sst/elements/vanadis/inst/vpcaddi.h
+++ b/src/sst/elements/vanadis/inst/vpcaddi.h
@@ -57,7 +57,7 @@ public:
     {
         snprintf(
             buffer, buffer_size,
-            "%s %5" PRIu16 " <- 0x%llx + imm=%" PRId64 " (phys: %5" PRIu16 " <- 0x%llx + %" PRId64 ") = 0x%llx",
+            "%s %5" PRIu16 " <- 0x%" PRI_ADDR " + imm=%" PRId64 " (phys: %5" PRIu16 " <- 0x%" PRI_ADDR " + %" PRId64 ") = 0x%" PRI_ADDR "",
             getInstCode(), isa_int_regs_out[0], getInstructionAddress(), imm_value, phys_int_regs_out[0], getInstructionAddress(),
             imm_value, getInstructionAddress() + imm_value);
     }
@@ -67,8 +67,8 @@ public:
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
             CALL_INFO, 16, 0,
-            "Execute: 0x%llx %s phys: out=%" PRIu16 " in=0x%llx / imm=%" PRId64 ", isa: out=%" PRIu16
-            " = 0x%llx\n",
+            "Execute: 0x%" PRI_ADDR " %s phys: out=%" PRIu16 " in=0x%" PRI_ADDR " / imm=%" PRId64 ", isa: out=%" PRIu16
+            " = 0x%" PRI_ADDR "\n",
             getInstructionAddress(), getInstCode(), phys_int_regs_out[0], getInstructionAddress(), imm_value,
             isa_int_regs_out[0], (static_cast<int64_t>(getInstructionAddress()) + imm_value));
 #endif

--- a/src/sst/elements/vanadis/inst/vstore.h
+++ b/src/sst/elements/vanadis/inst/vstore.h
@@ -143,8 +143,8 @@ public:
         {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: (addr=0x%llx) STORE addr-reg: %" PRIu16 " / val-reg: %" PRIu16 " / offset: %" PRId64
-                " / width: %" PRIu16 " / store-addr: %" PRIu64 " (0x%llx)\n",
+                "Execute: (addr=0x%" PRI_ADDR ") STORE addr-reg: %" PRIu16 " / val-reg: %" PRIu16 " / offset: %" PRId64
+                " / width: %" PRIu16 " / store-addr: %" PRIu64 " (0x%" PRI_ADDR ")\n",
                 getInstructionAddress(), phys_int_regs_in[0], phys_int_regs_in[1], offset, store_width, (*store_addr),
                 (*store_addr));
         } break;
@@ -152,8 +152,8 @@ public:
         {
             output->verbose(
                 CALL_INFO, 16, 0,
-                "Execute: (addr=0x%llx) STOREFP addr-reg: %" PRIu16 " / val-reg: %" PRIu16 " / offset: %" PRId64
-                " / width: %" PRIu16 " / store-addr: %" PRIu64 " (0x%llx)\n",
+                "Execute: (addr=0x%" PRI_ADDR ") STOREFP addr-reg: %" PRIu16 " / val-reg: %" PRIu16 " / offset: %" PRId64
+                " / width: %" PRIu16 " / store-addr: %" PRIu64 " (0x%" PRI_ADDR ")\n",
                 getInstructionAddress(), phys_int_regs_in[0], phys_fp_regs_in[0], offset, store_width, (*store_addr),
                 (*store_addr));
         } break;

--- a/src/sst/elements/vanadis/inst/vsyscall.h
+++ b/src/sst/elements/vanadis/inst/vsyscall.h
@@ -60,7 +60,7 @@ public:
         const uint64_t code_reg_ptr = regFile->getIntReg<uint64_t>(isa_options->getISASysCallCodeReg());
 #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
-            CALL_INFO, 16, 0, "Execute: (addr=0x%0llx) SYSCALL (isa: %" PRIu16 ", os-code: %" PRIu64 ")\n",
+            CALL_INFO, 16, 0, "Execute: (addr=0x%0" PRI_ADDR ") SYSCALL (isa: %" PRIu16 ", os-code: %" PRIu64 ")\n",
             getInstructionAddress(), isa_options->getISASysCallCodeReg(), code_reg_ptr);
 #endif
         markExecuted();

--- a/src/sst/elements/vanadis/inst/vxori.h
+++ b/src/sst/elements/vanadis/inst/vxori.h
@@ -45,7 +45,7 @@ public:
         snprintf(
             buffer, buffer_size,
             "XORI    %5" PRIu16 " <- %5" PRIu16 " ^ imm=%" PRIu64 " (phys: %5" PRIu16 " <- %5" PRIu16 " ^ %" PRIu64
-            " (0x%llx))",
+            " (0x%" PRI_ADDR "))",
             isa_int_regs_out[0], isa_int_regs_in[0], imm_value, phys_int_regs_out[0], phys_int_regs_in[0], imm_value,
             imm_value);
     }
@@ -56,7 +56,7 @@ public:
         output->verbose(
             CALL_INFO, 16, 0,
             "Execute: (addr=%p) XORI phys: out=%" PRIu16 " in=%" PRIu16 " imm=%" PRIu64
-            " / (0x%llx) , isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
+            " / (0x%" PRI_ADDR ") , isa: out=%" PRIu16 " / in=%" PRIu16 "\n",
             (void*)getInstructionAddress(), phys_int_regs_out[0], phys_int_regs_in[0], imm_value, imm_value,
             isa_int_regs_out[0], isa_int_regs_in[0]);
 #endif

--- a/src/sst/elements/vanadis/lsq/vbasiclsq.h
+++ b/src/sst/elements/vanadis/lsq/vbasiclsq.h
@@ -50,11 +50,11 @@ public:
     SST_ELI_DOCUMENT_PORTS({ "dcache_link", "Connects the LSQ to the data cache", {} })
 
     SST_ELI_DOCUMENT_PARAMS(
-            { "max_stores", "Set the maximum number of stores permitted in the queue", "8" }, 
+            { "max_stores", "Set the maximum number of stores permitted in the queue", "8" },
             { "max_loads", "Set the maximum number of loads permitted in the queue", "16" },
             { "address_mask", "Can mask off address bits if needed during construction of a operation", "0xFFFFFFFFFFFFFFFF"},
             { "issues_per_cycle", "Maximum number of issues the LSQ can attempt per cycle.", "2"},
-            { "cache_line_width", "Number of bytes in a (L1) cache line", "64"} 
+            { "cache_line_width", "Number of bytes in a (L1) cache line", "64"}
         )
 
     SST_ELI_DOCUMENT_STATISTICS({ "bytes_read", "Count all the bytes read for data operations", "bytes", 1 },
@@ -76,7 +76,7 @@ public:
         max_stores(params.find<size_t>("max_stores", 8)),
         max_loads(params.find<size_t>("max_loads", 16)),
         max_issue_attempts_per_cycle(params.find("issues_per_cycle", 2)) {
-        
+
         std_mem_handlers = new VanadisBasicLoadStoreQueue::StandardMemHandlers(this, output);
 
         memInterface = loadUserSubComponent<Interfaces::StandardMem>(
@@ -179,8 +179,8 @@ public:
 
     // must be implemented to allow the memory system to initialize itself during
     // boot-up
-    void init(unsigned int phase) override { 
-        memInterface->init(phase); 
+    void init(unsigned int phase) override {
+        memInterface->init(phase);
 
         // update the cache line size each cycle to make sure we get updates
         cache_line_width = memInterface->getLineSize();
@@ -221,7 +221,7 @@ public:
                         load_entry->getLoadAddress(), load_entry->getLoadWidth());
                 }
             }
-  
+
             if(stores_pending_size > 0) {
                 for (int t = 0; t < hw_threads; t++) {
                     for(int i = stores_pending[t].size() - 1; i >= 0; i--) {
@@ -265,7 +265,7 @@ protected:
 
         StandardMemHandlers(VanadisBasicLoadStoreQueue* lsq, SST::Output* output) :
                 Interfaces::StandardMem::RequestHandler(output), lsq(lsq) {}
-        
+
         virtual ~StandardMemHandlers() {}
 
         virtual void handle(StandardMem::ReadResp* ev) {
@@ -329,14 +329,14 @@ protected:
                     str << std::setw(2) << static_cast<unsigned>(*it);
                 }
                 out->verbose(CALL_INFO, 0, VANADIS_DBG_LSQ_LOAD_FLG, "---> LSQ recv load event ins: 0x%" PRI_ADDR " / hw-thr: %" PRIu32 " / entry-addr: 0x%" PRI_ADDR " / entry-width: %" PRIu16 " / reg-offset: %" PRIu64 " / ev-addr: 0x%" PRI_ADDR " / ev-width: %" PRIu64 " / addr-offset %" PRIu64 " / sign-extend: %s / target-isa-reg: %" PRIu16 " / target-phys-reg: %" PRIu16 " / reg-type: %s / %s\n",
-                    load_ins->getInstructionAddress(), hw_thr, load_address, load_width, reg_offset, ev->vAddr, ev->size, 
+                    load_ins->getInstructionAddress(), hw_thr, load_address, load_width, reg_offset, ev->vAddr, ev->size,
                     addr_offset, (load_ins->performSignExtension() ? "yes" : "no"),
                     target_isa_reg, target_reg,
                     (load_ins->getValueRegisterType() == LOAD_INT_REGISTER) ? "int" : "fp",str.str().c_str());
 
             }
 
-            
+
             switch(load_ins->getValueRegisterType()) {
             case LOAD_INT_REGISTER: {
 
@@ -392,7 +392,7 @@ protected:
 
                 reg_width = lsq->registerFiles->at(hw_thr)->getFPRegWidth();
                 std::vector<uint8_t> register_value(reg_width);
-                
+
                 // copy entire register here
                 lsq->registerFiles->at(hw_thr)->copyFromFPRegister(target_reg, 0, &register_value[0], reg_width);
 
@@ -440,8 +440,8 @@ protected:
             }
 
             delete ev;
-        } 
-        
+        }
+
         virtual void handle(StandardMem::WriteResp* ev) {
             out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "-> handle write-response (virt-addr: 0x%" PRI_ADDR ")\n", ev->vAddr);
             lsq->stat_stored_bytes->addData(ev->size);
@@ -449,7 +449,7 @@ protected:
             bool std_store_found = false;
 
 
-            auto iter = lsq->std_stores_in_flight.find( ev->getID() ); 
+            auto iter = lsq->std_stores_in_flight.find( ev->getID() );
             if ( iter != lsq->std_stores_in_flight.end() ) {
                 lsq->std_stores_in_flight.erase(iter);
                 std_store_found = true;
@@ -490,7 +490,7 @@ protected:
                         const int64_t success_result = store_cond_ins->getResultSuccess();
 
                         out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG,
-                                        "---> LSQ LLSC-STORE rt: %" PRIu64 " <- %" PRIu16 " (success)\n", 
+                                        "---> LSQ LLSC-STORE rt: %" PRIu64 " <- %" PRIu16 " (success)\n",
                                         success_result, value_reg);
                         lsq->registerFiles->at(store_ins->getHWThread())->setIntReg<int64_t>(value_reg,
                             success_result);
@@ -529,7 +529,7 @@ protected:
                 return;
             }
         }
-    
+
         VanadisBasicLoadStoreQueue* lsq;
     };
 
@@ -604,7 +604,7 @@ protected:
         return false;
     }
 
-    bool issueStore(VanadisBasicStorePendingEntry* store_entry, 
+    bool issueStore(VanadisBasicStorePendingEntry* store_entry,
             VanadisStoreInstruction* store_ins) {
 
         const uint64_t store_address = store_entry->getStoreAddress();
@@ -622,7 +622,7 @@ protected:
         if(output->getVerboseLevel() >= 8) {
             std::vector<uint8_t> tmp(store_width);
             registerFiles->at(store_entry->getHWThread())->copyFromRegister(store_ins->getValueRegisterType() == STORE_FP_REGISTER ?
-                store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &tmp[0], store_width, 
+                store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &tmp[0], store_width,
                 store_ins->getValueRegisterType() == STORE_FP_REGISTER);
             std::ostringstream str;
             str << ", Payload: 0x";
@@ -639,7 +639,7 @@ protected:
         // handle this case later after we do a load of address and width calculation
         if(LIKELY(! needs_split)) {
             registerFiles->at(store_entry->getHWThread())->copyFromRegister(store_ins->getValueRegisterType() == STORE_FP_REGISTER ?
-                store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &payload[0], store_width, 
+                store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &payload[0], store_width,
                 store_ins->getValueRegisterType() == STORE_FP_REGISTER);
         }
 
@@ -666,10 +666,10 @@ protected:
 
                 payload.resize(store_width_left);
                 registerFiles->at(store_entry->getHWThread())->copyFromRegister(store_ins->getValueRegisterType() == STORE_FP_REGISTER ?
-                    store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &payload[0], store_width_left, 
+                    store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset(), &payload[0], store_width_left,
                     store_ins->getValueRegisterType() == STORE_FP_REGISTER);
 
-                store_req = new StandardMem::Write(store_address & address_mask, payload.size(), payload, 
+                store_req = new StandardMem::Write(store_address & address_mask, payload.size(), payload,
                     false, 0, store_address, store_ins->getInstructionAddress(), store_ins->getHWThread());
 
                 std_stores_in_flight.insert(store_req->getID());
@@ -679,11 +679,11 @@ protected:
 
                 payload.resize(store_width_right);
                 registerFiles->at(store_entry->getHWThread())->copyFromRegister(store_ins->getValueRegisterType() == STORE_FP_REGISTER ?
-                    store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset() + store_width_left, &payload[0], 
-                    store_width_right, 
+                    store_ins->getPhysFPRegIn(0) : store_ins->getPhysIntRegIn(1), store_ins->getRegisterOffset() + store_width_left, &payload[0],
+                    store_width_right,
                     store_ins->getValueRegisterType() == STORE_FP_REGISTER);
 
-                store_req = new StandardMem::Write(store_address_right & address_mask, payload.size(), payload, 
+                store_req = new StandardMem::Write(store_address_right & address_mask, payload.size(), payload,
                     false, 0, store_address_right, store_ins->getInstructionAddress(), store_ins->getHWThread());
                 memInterface->send(store_req);
                 std_stores_in_flight.insert(store_req->getID());
@@ -703,7 +703,7 @@ protected:
                     output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "}\n");
                 }
 
-                store_req = new StandardMem::Write(store_address & address_mask, payload.size(), payload, 
+                store_req = new StandardMem::Write(store_address & address_mask, payload.size(), payload,
                     false, 0, store_address, store_ins->getInstructionAddress(), store_ins->getHWThread());
                 std_stores_in_flight.insert(store_req->getID());
                 memInterface->send(store_req);
@@ -712,7 +712,7 @@ protected:
             }
         } break;
         case MEM_TRANSACTION_LLSC_LOAD:
-        {  
+        {
             output->fatal(CALL_INFO, -1, "Error - attempted to issue a LLSC-load via store instruction. Invalid operation.\n");
         } break;
         case MEM_TRANSACTION_LLSC_STORE:
@@ -722,7 +722,7 @@ protected:
             } else {
                 output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LLSC-store store-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                     store_address, store_width);
-                
+
                 store_req = new StandardMem::StoreConditional(store_address & address_mask, payload.size(), payload,
                             0, store_address, store_ins->getInstructionAddress(), store_ins->getHWThread() );
             }
@@ -734,7 +734,7 @@ protected:
             } else {
                 output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LOCK-store store-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                     store_address, store_width);
-                
+
                 store_req = new StandardMem::WriteUnlock(store_address & address_mask, payload.size(), payload,
                             0, store_address, store_ins->getInstructionAddress(), store_ins->getHWThread());
             }
@@ -787,7 +787,7 @@ protected:
                     // How many bytes are in the left most line?
                     const uint64_t load_width_right = (load_address + load_width) % cache_line_width;
                     assert(load_width_right > 0);
-                    
+
                     const uint64_t load_width_left = load_width - load_width_right;
                     assert(load_width_left > 0);
 
@@ -799,16 +799,16 @@ protected:
                             load_address, load_width_left, load_address + load_width_left, load_width_right);
                     }
 
-                    load_req = new StandardMem::Read(load_address & address_mask, load_width_left, 0, 
+                    load_req = new StandardMem::Read(load_address & address_mask, load_width_left, 0,
                         load_address, load_ins->getInstructionAddress(), load_ins->getHWThread());
-                    
+
                     load_entry->addRequest(load_req->getID());
                     memInterface->send(load_req);
 
-                    load_req = new StandardMem::Read((load_address + load_width_left) & address_mask, load_width_right, 0, 
+                    load_req = new StandardMem::Read((load_address + load_width_left) & address_mask, load_width_right, 0,
                         load_address + load_width_left, load_ins->getInstructionAddress(), load_ins->getHWThread());
                 } else {
-                    if(output->getVerboseLevel() >= 9) {   
+                    if(output->getVerboseLevel() >= 9) {
                         output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: standard load (not split) load-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                             load_address, load_width);
                     }
@@ -824,7 +824,7 @@ protected:
                         load_ins->flagError();
                         load_req = nullptr;
                     } else {
-                        load_req = new StandardMem::Read(load_address & address_mask, load_width, 0, 
+                        load_req = new StandardMem::Read(load_address & address_mask, load_width, 0,
                             load_address, load_ins->getInstructionAddress(), load_ins->getHWThread());
                     }
                 }
@@ -837,7 +837,7 @@ protected:
                 } else {
                     output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: LLSC-load (not split) load-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                         load_address, load_width);
-                    load_req = new StandardMem::LoadLink(load_address & address_mask, load_width, 0, 
+                    load_req = new StandardMem::LoadLink(load_address & address_mask, load_width, 0,
                                         load_address, load_ins->getInstructionAddress(), load_ins->getHWThread());
                 }
             } break;
@@ -903,7 +903,7 @@ protected:
                     output->fatal(CALL_INFO, -1, "Error: attempted to convert a load entry to a load instruction but failed, ins: 0x%" PRI_ADDR " / thr: %" PRIu32 "\n",
                         front_entry->getInstructionAddress(), front_entry->getHWThread());
                 }
-    
+
                 // can't do anything cycle, so return false
                 if(loads_pending.size() >= max_loads) {
                     //output->verbose(CALL_INFO, 16, 0, "--> cycle: %" PRIu64 " issue LOAD failed: max_loads\n", cycle);
@@ -911,7 +911,7 @@ protected:
                 }
 
                 if(output->getVerboseLevel() >= 16) {
-                    output->verbose(CALL_INFO, 16, 0, "-> queue front is load: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n", 
+                    output->verbose(CALL_INFO, 16, 0, "-> queue front is load: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n",
                         load_ins->getInstructionAddress(), load_ins->getHWThread());
                 }
 
@@ -932,7 +932,7 @@ protected:
                         output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " want load at 0x%" PRI_ADDR " / width: %" PRIu16 "\n",
                             load_ins->getInstructionAddress(), load_ins->getHWThread(), load_address, load_width);
                     }
-                    
+
                     // check to see if loading from this address would conflict with a store which
                     // we have pending, if yes, wait for conflict to clear and then we can proceed
                     if(UNLIKELY(checkStoreConflict(load_ins->getHWThread(), load_address, load_width))) {
@@ -985,17 +985,17 @@ protected:
                 }
 
                 if(output->getVerboseLevel() >= 16) {
-                    output->verbose(CALL_INFO, 16, 0, "-> queue front is store: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n", 
+                    output->verbose(CALL_INFO, 16, 0, "-> queue front is store: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
                 }
-                
+
                 VanadisRegisterFile* hw_thr_reg = registerFiles->at(store_ins->getHWThread());
 
                 uint64_t store_address = 0;
                 uint16_t store_width   = 0;
 
                 store_ins->computeStoreAddress(output, hw_thr_reg, &store_address, &store_width);
-                
+
                 if(store_ins->trapsError()) {
                     output->verbose(CALL_INFO, 16, 0, "----> warning: 0x%" PRI_ADDR " / thr: %" PRIu32 " traps error, marks executed and does not process.\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
@@ -1021,7 +1021,7 @@ protected:
                 //output->verbose(CALL_INFO, 16, 0, "--> cycle: %" PRIu64 " issue STORE succeeded\n", cycle);
                 return true;
             } break;
-            case VanadisBasicLoadStoreEntryOp::FENCE: 
+            case VanadisBasicLoadStoreEntryOp::FENCE:
             {
                 //output->verbose(CALL_INFO, 16, 0, "--> cycle: %" PRIu64 " attempt to issue FENCE\n", cycle);
                 VanadisInstruction* current_ins = op_q[thr].front()->getInstruction();
@@ -1035,17 +1035,17 @@ protected:
                     // if no pending loads, then we are good to go
                     can_execute = (!pendingLoads(current_fence_ins->getHWThread()));
                 }
-                
+
                 if(current_fence_ins->createsStoreFence()) {
                     // stores are fenced if there are no pending stores AND all issued to the memory system
                     // have returned so are currently visible.
-                    can_execute = can_execute && (stores_pending[current_fence_ins->getHWThread()].size() == 0) && 
+                    can_execute = can_execute && (stores_pending[current_fence_ins->getHWThread()].size() == 0) &&
                         (std_stores_in_flight.size() == 0);
                 }
 
                 if(can_execute) {
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, 0, "-> execute fence instruction (0x%" PRI_ADDR "), all checks have passed.\n", 
+                        output->verbose(CALL_INFO, 16, 0, "-> execute fence instruction (0x%" PRI_ADDR "), all checks have passed.\n",
                             current_fence_ins->getInstructionAddress());
                     }
                     current_fence_ins->markExecuted();

--- a/src/sst/elements/vanadis/lsq/vbasiclsq.h
+++ b/src/sst/elements/vanadis/lsq/vbasiclsq.h
@@ -196,7 +196,7 @@ public:
                 for(auto op_q_itr = op_q[i].begin(); op_q_itr != op_q[i].end(); op_q_itr++) {
                     VanadisBasicLoadStoreEntryOp op_type = (*op_q_itr)->getEntryOp();
 
-                    out.verbose(CALL_INFO, 16, 0, "-> [%4" PRId32 "] type: %5s ins: 0x%8llx thr: %4" PRIu32 "\n",
+                    out.verbose(CALL_INFO, 16, 0, "-> [%4" PRId32 "] type: %5s ins: 0x%8" PRI_ADDR " thr: %4" PRIu32 "\n",
                         next_line,
                         (op_type == VanadisBasicLoadStoreEntryOp::LOAD) ? "LOAD" :
                         (op_type == VanadisBasicLoadStoreEntryOp::STORE) ? "STORE" : "FENCE",
@@ -215,7 +215,7 @@ public:
             if(loads_pending.size() > 0) {
                 for(int i = loads_pending.size() - 1; i >= 0; i--) {
                     VanadisBasicLoadPendingEntry* load_entry = loads_pending.at(i);
-                    output->verbose(CALL_INFO, 8, 0, "-->   load[%5d] ins: 0x%llx / thr: %" PRIu32 " / addr: 0x%llx / width: %" PRIu64 "\n",
+                    output->verbose(CALL_INFO, 8, 0, "-->   load[%5d] ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " / addr: 0x%" PRI_ADDR " / width: %" PRIu64 "\n",
                         i, load_entry->getLoadInstruction()->getInstructionAddress(),
                         load_entry->getLoadInstruction()->getHWThread(),
                         load_entry->getLoadAddress(), load_entry->getLoadWidth());
@@ -227,7 +227,7 @@ public:
                     for(int i = stores_pending[t].size() - 1; i >= 0; i--) {
                         VanadisBasicStorePendingEntry* store_entry = stores_pending[t].at(i);
 
-                        output->verbose(CALL_INFO, 16, 0, "--> stores[%5d] ins: 0x%llx / thr: %" PRIu32 " / addr: 0x%llx / width: %" PRIu64 "\n",
+                        output->verbose(CALL_INFO, 16, 0, "--> stores[%5d] ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " / addr: 0x%" PRI_ADDR " / width: %" PRIu64 "\n",
                             i, store_entry->getStoreInstruction()->getInstructionAddress(),
                             store_entry->getStoreInstruction()->getHWThread(),
                             store_entry->getStoreAddress(), store_entry->getStoreWidth());
@@ -269,7 +269,7 @@ protected:
         virtual ~StandardMemHandlers() {}
 
         virtual void handle(StandardMem::ReadResp* ev) {
-            out->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_LOAD_FLG, "-> handle read-response (virt-addr: 0x%llx)\n", ev->vAddr);
+            out->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_LOAD_FLG, "-> handle read-response (virt-addr: 0x%" PRI_ADDR ")\n", ev->vAddr);
             lsq->stat_loaded_bytes->addData(ev->size);
 
             auto load_itr = lsq->loads_pending.begin();
@@ -301,7 +301,7 @@ protected:
             if(out->getVerboseLevel() >= 16) {
                 out->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_LOAD_FLG,
                                 "--> LSQ match load entry, unpacking payload "
-                                "(load-addr: 0x%0llx, load-thr: %" PRIu32 ").\n",
+                                "(load-addr: 0x%0" PRI_ADDR ", load-thr: %" PRIu32 ").\n",
                                 ev->pAddr, load_entry->getHWThread());
             }
 
@@ -328,7 +328,7 @@ protected:
                 for ( std::vector<uint8_t>::iterator it = ev->data.begin(); it != ev->data.end(); it++ ) {
                     str << std::setw(2) << static_cast<unsigned>(*it);
                 }
-                out->verbose(CALL_INFO, 0, VANADIS_DBG_LSQ_LOAD_FLG, "---> LSQ recv load event ins: 0x%llx / hw-thr: %" PRIu32 " / entry-addr: 0x%llx / entry-width: %" PRIu16 " / reg-offset: %" PRIu64 " / ev-addr: 0x%llx / ev-width: %" PRIu64 " / addr-offset %" PRIu64 " / sign-extend: %s / target-isa-reg: %" PRIu16 " / target-phys-reg: %" PRIu16 " / reg-type: %s / %s\n",
+                out->verbose(CALL_INFO, 0, VANADIS_DBG_LSQ_LOAD_FLG, "---> LSQ recv load event ins: 0x%" PRI_ADDR " / hw-thr: %" PRIu32 " / entry-addr: 0x%" PRI_ADDR " / entry-width: %" PRIu16 " / reg-offset: %" PRIu64 " / ev-addr: 0x%" PRI_ADDR " / ev-width: %" PRIu64 " / addr-offset %" PRIu64 " / sign-extend: %s / target-isa-reg: %" PRIu16 " / target-phys-reg: %" PRIu16 " / reg-type: %s / %s\n",
                     load_ins->getInstructionAddress(), hw_thr, load_address, load_width, reg_offset, ev->vAddr, ev->size, 
                     addr_offset, (load_ins->performSignExtension() ? "yes" : "no"),
                     target_isa_reg, target_reg,
@@ -422,7 +422,7 @@ protected:
             if(0 == load_entry->countRequests()) {
                 if(out->getVerboseLevel() >= 9) {
                     out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG,
-                        "---> LSQ Execute: %s (0x%llx / thr: %" PRIu32 ") load data instruction "
+                        "---> LSQ Execute: %s (0x%" PRI_ADDR " / thr: %" PRIu32 ") load data instruction "
                         "marked executed.\n",
                         load_ins->getInstCode(), load_ins->getInstructionAddress(), load_ins->getHWThread());
                 }
@@ -434,7 +434,7 @@ protected:
             } else {
                 if(out->getVerboseLevel() >= 9) {
                     out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG,
-                        "---> LSQ Execute: %s (0x%llx / thr:%" PRIu32 ") does not have all requests completed yet %zu left, will not execute until all done.\n",
+                        "---> LSQ Execute: %s (0x%" PRI_ADDR " / thr:%" PRIu32 ") does not have all requests completed yet %zu left, will not execute until all done.\n",
                             load_ins->getInstCode(), load_ins->getInstructionAddress(), load_ins->getHWThread(), load_entry->countRequests());
                 }
             }
@@ -443,7 +443,7 @@ protected:
         } 
         
         virtual void handle(StandardMem::WriteResp* ev) {
-            out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "-> handle write-response (virt-addr: 0x%llx)\n", ev->vAddr);
+            out->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "-> handle write-response (virt-addr: 0x%" PRI_ADDR ")\n", ev->vAddr);
             lsq->stat_stored_bytes->addData(ev->size);
 
             bool std_store_found = false;
@@ -520,7 +520,7 @@ protected:
                 default:
                 {
                     // this is a logical error. fatal()
-                    out->fatal(CALL_INFO, -1, "Error - reached a transaction NONE or LLSC_LOAD in a store return. Logical error (ins: 0x%llx / thr: %" PRIu32 ")\n",
+                    out->fatal(CALL_INFO, -1, "Error - reached a transaction NONE or LLSC_LOAD in a store return. Logical error (ins: 0x%" PRI_ADDR " / thr: %" PRIu32 ")\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
                 } break;
                 }
@@ -558,7 +558,7 @@ protected:
         VanadisStoreInstruction* store_ins = current_store->getStoreInstruction();
 
         if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "-> current store queue front is ins addr: 0x%llx\n", store_ins->getInstructionAddress());
+            output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "-> current store queue front is ins addr: 0x%" PRI_ADDR "\n", store_ins->getInstructionAddress());
         }
 
         // check we have not already dispatched this entry
@@ -581,7 +581,7 @@ protected:
                     delete current_store;
 
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "---> issued store: 0x%llx / thr: %" PRIu32 " into memory system using standard store operation\n",
+                        output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "---> issued store: 0x%" PRI_ADDR " / thr: %" PRIu32 " into memory system using standard store operation\n",
                             store_ins->getInstructionAddress(), store_ins->getHWThread());
                     }
 
@@ -589,7 +589,7 @@ protected:
                     store_ins->markExecuted();
                     stat_stores_executed->addData(1);
                 } else {
-                    output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "---> issued non-standard store: 0x%llx / thr: %" PRIu32 " (marked dispatch, will stall until response)\n",
+                    output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_STORE_FLG, "---> issued non-standard store: 0x%" PRI_ADDR " / thr: %" PRIu32 " (marked dispatch, will stall until response)\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
                     current_store->markDispatched();
                 }
@@ -630,7 +630,7 @@ protected:
             for ( std::vector<uint8_t>::iterator it = tmp.begin(); it != tmp.end(); it++ ) {
                 str << std::setw(2) << static_cast<unsigned>(*it);
             }
-            output->verbose(CALL_INFO, 0, VANADIS_DBG_LSQ_STORE_FLG, "--> thr %d, issue-store at ins: 0x%llx / store-addr: 0x%llx / width: %" PRIu64 " / partial: %s / split: %s / offset: %" PRIu32 " / %s\n",
+            output->verbose(CALL_INFO, 0, VANADIS_DBG_LSQ_STORE_FLG, "--> thr %d, issue-store at ins: 0x%" PRI_ADDR " / store-addr: 0x%" PRI_ADDR " / width: %" PRIu64 " / partial: %s / split: %s / offset: %" PRIu32 " / %s\n",
                 store_ins->getHWThread(), store_ins->getInstructionAddress(), store_address, store_width, store_ins->isPartialStore() ? "yes" : "no", needs_split ? "yes" : "no",
                 store_ins->getRegisterOffset(), str.str().c_str());
         }
@@ -660,7 +660,7 @@ protected:
                 const uint64_t store_address_right = store_address + store_width_left;
 
                 if(output->getVerboseLevel() >= 9) {
-                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> store-left-at: 0x%llx left-width: %" PRIu64 ", store-right-at: 0x%llx right-width: %" PRIu64 "\n",
+                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> store-left-at: 0x%" PRI_ADDR " left-width: %" PRIu64 ", store-right-at: 0x%" PRI_ADDR " right-width: %" PRIu64 "\n",
                         store_address, store_width_left, store_address_right, store_width_right);
                 }
 
@@ -691,7 +691,7 @@ protected:
                 return true;
             } else {
                 if(output->getVerboseLevel() >= 9) {
-                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: standard store ins: 0x%llx store-at: 0x%llx width: %" PRIu64 "\n",
+                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: standard store ins: 0x%" PRI_ADDR " store-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                         store_ins->getInstructionAddress(), store_address, store_width);
 
                     output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "-----> payload = {");
@@ -720,7 +720,7 @@ protected:
             if(UNLIKELY(needs_split)) {
                 output->fatal(CALL_INFO, -1, "Error - attempted to perform an LLSC-store over a split-cache line. This is not permitted.\n");
             } else {
-                output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LLSC-store store-at: 0x%llx width: %" PRIu64 "\n",
+                output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LLSC-store store-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                     store_address, store_width);
                 
                 store_req = new StandardMem::StoreConditional(store_address & address_mask, payload.size(), payload,
@@ -732,7 +732,7 @@ protected:
             if(UNLIKELY(needs_split)) {
                 output->fatal(CALL_INFO, -1, "Error - attempted to perform an LOCK-store over a split-cache line. This is not permitted.\n");
             } else {
-                output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LOCK-store store-at: 0x%llx width: %" PRIu64 "\n",
+                output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_STORE_FLG, "---> [memory-transaction]: LOCK-store store-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                     store_address, store_width);
                 
                 store_req = new StandardMem::WriteUnlock(store_address & address_mask, payload.size(), payload,
@@ -795,7 +795,7 @@ protected:
                     assert((load_right_start % cache_line_width) == 0);
 
                     if(output->getVerboseLevel() >= 9) {
-                        output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> split load at-left: 0x%llx left-width: %" PRIu64 " / at-right: 0x%llx right-width: %" PRIu64 "\n",
+                        output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> split load at-left: 0x%" PRI_ADDR " left-width: %" PRIu64 " / at-right: 0x%" PRI_ADDR " right-width: %" PRIu64 "\n",
                             load_address, load_width_left, load_address + load_width_left, load_width_right);
                     }
 
@@ -809,7 +809,7 @@ protected:
                         load_address + load_width_left, load_ins->getInstructionAddress(), load_ins->getHWThread());
                 } else {
                     if(output->getVerboseLevel() >= 9) {   
-                        output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: standard load (not split) load-at: 0x%llx width: %" PRIu64 "\n",
+                        output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: standard load (not split) load-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                             load_address, load_width);
                     }
 
@@ -835,7 +835,7 @@ protected:
                     output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> load is marked LLSC but it requires a cache line split, generates an error\n");
                     load_ins->flagError();
                 } else {
-                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: LLSC-load (not split) load-at: 0x%llx width: %" PRIu64 "\n",
+                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: LLSC-load (not split) load-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                         load_address, load_width);
                     load_req = new StandardMem::LoadLink(load_address & address_mask, load_width, 0, 
                                         load_address, load_ins->getInstructionAddress(), load_ins->getHWThread());
@@ -853,7 +853,7 @@ protected:
                     output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> load is marked LOCK but it requires a cache line split, this generates an error\n");
                     load_ins->flagError();
                 } else {
-                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: LOCK-load (not split) load-at: 0x%llx width: %" PRIu64 "\n",
+                    output->verbose(CALL_INFO, 9, VANADIS_DBG_LSQ_LOAD_FLG, "---> [memory-transaction]: LOCK-load (not split) load-at: 0x%" PRI_ADDR " width: %" PRIu64 "\n",
                         load_address, load_width);
                     load_req = new StandardMem::ReadLock(load_address & address_mask, load_width, 0,
                                         load_address, load_ins->getInstructionAddress(), load_ins->getHWThread());
@@ -863,7 +863,7 @@ protected:
 
         // if the instruction does not trap an error we will continue to process it
         if(LIKELY(! load_ins->trapsError())) {
-            output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_LOAD_FLG, "-----> ins: 0x%llx / thr: %" PRIu32 " processed and requests sent to memory system.\n",
+            output->verbose(CALL_INFO, 16, VANADIS_DBG_LSQ_LOAD_FLG, "-----> ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " processed and requests sent to memory system.\n",
                 load_ins->getInstructionAddress(), load_ins->getHWThread());
 
             assert(load_req != nullptr);
@@ -886,7 +886,7 @@ protected:
 
         if(! front_entry->getInstruction()->completedIssue()) {
             if(output->getVerboseLevel() >= 16) {
-                output->verbose(CALL_INFO, 16, 0, "--> ins: 0x%llx / thr: %" PRIu32 " has not completed issue, will not process this cycle.\n",
+                output->verbose(CALL_INFO, 16, 0, "--> ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has not completed issue, will not process this cycle.\n",
                     front_entry->getInstruction()->getInstructionAddress(), front_entry->getInstruction()->getHWThread());
             }
             return false;
@@ -900,7 +900,7 @@ protected:
                     front_entry->getInstruction());
 
                 if(UNLIKELY(load_ins == nullptr)) {
-                    output->fatal(CALL_INFO, -1, "Error: attempted to convert a load entry to a load instruction but failed, ins: 0x%llx / thr: %" PRIu32 "\n",
+                    output->fatal(CALL_INFO, -1, "Error: attempted to convert a load entry to a load instruction but failed, ins: 0x%" PRI_ADDR " / thr: %" PRIu32 "\n",
                         front_entry->getInstructionAddress(), front_entry->getHWThread());
                 }
     
@@ -911,7 +911,7 @@ protected:
                 }
 
                 if(output->getVerboseLevel() >= 16) {
-                    output->verbose(CALL_INFO, 16, 0, "-> queue front is load: ins: 0x%llx / thr: %" PRIu32 " has issued so will process...\n", 
+                    output->verbose(CALL_INFO, 16, 0, "-> queue front is load: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n", 
                         load_ins->getInstructionAddress(), load_ins->getHWThread());
                 }
 
@@ -924,12 +924,12 @@ protected:
 
                 if(UNLIKELY(load_ins->trapsError())) {
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%llx / thr: %" PRIu32 " traps error, will not process and allow pipeline to handle.\n",
+                        output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " traps error, will not process and allow pipeline to handle.\n",
                             load_ins->getInstructionAddress(), load_ins->getHWThread());
                     }
                 } else {
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%llx / thr: %" PRIu32 " want load at 0x%llx / width: %" PRIu16 "\n",
+                        output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " want load at 0x%" PRI_ADDR " / width: %" PRIu16 "\n",
                             load_ins->getInstructionAddress(), load_ins->getHWThread(), load_address, load_width);
                     }
                     
@@ -937,7 +937,7 @@ protected:
                     // we have pending, if yes, wait for conflict to clear and then we can proceed
                     if(UNLIKELY(checkStoreConflict(load_ins->getHWThread(), load_address, load_width))) {
                         if(output->getVerboseLevel() >= 16) {
-                            output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%llx / thr: %" PRIu32 " conflicts with store entry, will not issue until conflict is resolved (load-addr: 0x%llx / width: %" PRIu32 ")\n",
+                            output->verbose(CALL_INFO, 16, 0, "---> load ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " conflicts with store entry, will not issue until conflict is resolved (load-addr: 0x%" PRI_ADDR " / width: %" PRIu32 ")\n",
                                 load_ins->getInstructionAddress(), load_ins->getHWThread(), load_address, load_width);
                         }
 
@@ -973,7 +973,7 @@ protected:
                     front_entry->getInstruction());
 
                 if(UNLIKELY(store_ins == nullptr)) {
-                    output->fatal(CALL_INFO, -1, "Error: attempted to convert a store entry into store instruction but this failed (ins: 0x%llx, thr: %" PRIu32 ")\n",
+                    output->fatal(CALL_INFO, -1, "Error: attempted to convert a store entry into store instruction but this failed (ins: 0x%" PRI_ADDR ", thr: %" PRIu32 ")\n",
                         front_entry->getInstructionAddress(), front_entry->getHWThread());
                 }
 
@@ -985,7 +985,7 @@ protected:
                 }
 
                 if(output->getVerboseLevel() >= 16) {
-                    output->verbose(CALL_INFO, 16, 0, "-> queue front is store: ins: 0x%llx / thr: %" PRIu32 " has issued so will process...\n", 
+                    output->verbose(CALL_INFO, 16, 0, "-> queue front is store: ins: 0x%" PRI_ADDR " / thr: %" PRIu32 " has issued so will process...\n", 
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
                 }
                 
@@ -997,12 +997,12 @@ protected:
                 store_ins->computeStoreAddress(output, hw_thr_reg, &store_address, &store_width);
                 
                 if(store_ins->trapsError()) {
-                    output->verbose(CALL_INFO, 16, 0, "----> warning: 0x%llx / thr: %" PRIu32 " traps error, marks executed and does not process.\n",
+                    output->verbose(CALL_INFO, 16, 0, "----> warning: 0x%" PRI_ADDR " / thr: %" PRIu32 " traps error, marks executed and does not process.\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());
                     store_ins->markExecuted();
                 } else {
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, 0, "----> computed store address: 0x%llx width: %" PRIu16 " thr: %" PRIu32 "\n",
+                        output->verbose(CALL_INFO, 16, 0, "----> computed store address: 0x%" PRI_ADDR " width: %" PRIu16 " thr: %" PRIu32 "\n",
                             store_address, store_width, store_ins->getHWThread());
                     }
 
@@ -1045,7 +1045,7 @@ protected:
 
                 if(can_execute) {
                     if(output->getVerboseLevel() >= 16) {
-                        output->verbose(CALL_INFO, 16, 0, "-> execute fence instruction (0x%llx), all checks have passed.\n", 
+                        output->verbose(CALL_INFO, 16, 0, "-> execute fence instruction (0x%" PRI_ADDR "), all checks have passed.\n", 
                             current_fence_ins->getInstructionAddress());
                     }
                     current_fence_ins->markExecuted();
@@ -1075,7 +1075,7 @@ protected:
         const bool splits_line = cache_line_left != cache_line_right;
 
         if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "---> check split addr: %" PRIu64 " (0x%llx) / width: %" PRIu64 " / cache-line: %" PRIu64 " / line-left: %" PRIu64 " / line-right: %" PRIu64 " / split: %3s\n",
+            output->verbose(CALL_INFO, 16, 0, "---> check split addr: %" PRIu64 " (0x%" PRI_ADDR ") / width: %" PRIu64 " / cache-line: %" PRIu64 " / line-left: %" PRIu64 " / line-right: %" PRIu64 " / split: %3s\n",
                 address, address, width, cache_line_width, cache_line_left, cache_line_right, splits_line ? "yes" : "no");
         }
 

--- a/src/sst/elements/vanadis/lsq/vmemwriterec.h
+++ b/src/sst/elements/vanadis/lsq/vmemwriterec.h
@@ -49,8 +49,8 @@ public:
 
         line_value = (line_value | bit_update);
 
-        // printf("mark-address: 0x%llx / line: %" PRIu64 " / offset: %" PRIu64 " /
-        // before 0x%llx / after 0x%llx\n", byte_addr, 	line, line_offset,
+        // printf("mark-address: 0x%" PRI_ADDR " / line: %" PRIu64 " / offset: %" PRIu64 " /
+        // before 0x%" PRI_ADDR " / after 0x%" PRI_ADDR "\n", byte_addr, 	line, line_offset,
         // memory_state[line], line_value);
 
         memory_state[line] = line_value;
@@ -66,8 +66,8 @@ public:
 
         const bool is_marked = (line_value & bit_value) != 0;
 
-        printf("check-address: 0x%llx / line: %" PRIu64 " / offset: %" PRIu64
-               " / value: 0x%llx / bit_value: 0x%llx / marked: %3s\n",
+        printf("check-address: 0x%" PRI_ADDR " / line: %" PRIu64 " / offset: %" PRIu64
+               " / value: 0x%" PRI_ADDR " / bit_value: 0x%" PRI_ADDR " / marked: %3s\n",
                byte_addr, line, line_offset, line_value, bit_value, is_marked ? "yes" : "no");
 
         return is_marked;

--- a/src/sst/elements/vanadis/os/syscall/access.h
+++ b/src/sst/elements/vanadis/os/syscall/access.h
@@ -27,7 +27,7 @@ public:
     VanadisAccessSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallAccessEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "access" ) 
     {
-        m_output->verbose(CALL_INFO, 16, 0, "[syscall-access] access( 0x%llx, %" PRIu64 " )\n", event->getPathPointer(), event->getAccessMode());
+        m_output->verbose(CALL_INFO, 16, 0, "[syscall-access] access( 0x%" PRI_ADDR ", %" PRIu64 " )\n", event->getPathPointer(), event->getAccessMode());
 
         readString(event->getPathPointer(),m_filename);
     }

--- a/src/sst/elements/vanadis/os/syscall/brk.h
+++ b/src/sst/elements/vanadis/os/syscall/brk.h
@@ -31,8 +31,8 @@ public:
         if (event->getUpdatedBRK() < brk) {
 
             m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
-                                "[syscall-brk]: brk provided (0x%llx) is less than existing brk "
-                                "point (0x%llx), so returning current brk point\n",
+                                "[syscall-brk]: brk provided (0x%" PRI_ADDR ") is less than existing brk "
+                                "point (0x%" PRI_ADDR "), so returning current brk point\n",
                                 event->getUpdatedBRK(), brk);
         } else {
             if ( ! process->setBrk( event->getUpdatedBRK() ) ) {
@@ -40,7 +40,7 @@ public:
             }
 
             m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
-                                "[syscall-brk] old brk: 0x%llx -> new brk: 0x%llx (diff: %" PRIu64 ")\n", brk,
+                                "[syscall-brk] old brk: 0x%" PRI_ADDR " -> new brk: 0x%" PRI_ADDR " (diff: %" PRIu64 ")\n", brk,
                                 event->getUpdatedBRK(), (event->getUpdatedBRK() - brk));
             process->printRegions( "after brk" );
         }

--- a/src/sst/elements/vanadis/os/syscall/clone.cc
+++ b/src/sst/elements/vanadis/os/syscall/clone.cc
@@ -99,7 +99,7 @@ void VanadisCloneSyscall::handleEvent( VanadisCoreEvent* ev )
     req->setIntRegs( resp->intRegs );
     req->setFpRegs( resp->fpRegs );
 
-     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone] core=%d thread=%d tid=%d instPtr=%llx\n",
+     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone] core=%d thread=%d tid=%d instPtr=%" PRI_ADDR "\n",
                  m_threadID->core, m_threadID->hwThread, m_newThread->gettid(), resp->getInstPtr() );
 #if 0 //debug
     for ( int i = 0; i < req->getIntRegs().size(); i++ ) {

--- a/src/sst/elements/vanadis/os/syscall/fork.cc
+++ b/src/sst/elements/vanadis/os/syscall/fork.cc
@@ -74,7 +74,7 @@ void VanadisForkSyscall::handleEvent( VanadisCoreEvent* ev )
     req->setFpRegs( resp->fpRegs );
 
 #if 0 // debug
-    printf("thread=%d instPtr=%llx\n",resp->getThread(), resp->getInstPtr() );
+    printf("thread=%d instPtr=%" PRI_ADDR "\n",resp->getThread(), resp->getInstPtr() );
     for ( int i = 0; i < resp->intRegs.size(); i++ ) {
         printf("int r%d %" PRIx64 "\n",i,resp->intRegs[i]);
     }

--- a/src/sst/elements/vanadis/os/syscall/fstat.h
+++ b/src/sst/elements/vanadis/os/syscall/fstat.h
@@ -67,7 +67,7 @@ public:
     VanadisFstatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallFstatEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "fstat" ) 
     {
-	    m_output->verbose(CALL_INFO, 16, 0, "-> call is fstat( %d, 0x%0llx )\n", event->getFileHandle(), event->getStructAddress());
+	    m_output->verbose(CALL_INFO, 16, 0, "-> call is fstat( %d, 0x%0" PRI_ADDR " )\n", event->getFileHandle(), event->getStructAddress());
 
         setReturnFail(-LINUX_EINVAL);
 

--- a/src/sst/elements/vanadis/os/syscall/ioctl.h
+++ b/src/sst/elements/vanadis/os/syscall/ioctl.h
@@ -28,7 +28,7 @@ public:
         : VanadisSyscall( os, coreLink, process, event, "ioctl" ) 
     {
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
-                            "[syscall-ioctl] ioctl( %" PRId64 ", r: %c / w: %c / ptr: 0x%llx / size: %" PRIu64
+                            "[syscall-ioctl] ioctl( %" PRId64 ", r: %c / w: %c / ptr: 0x%" PRI_ADDR " / size: %" PRIu64
                             " / op: %" PRIu64 " / drv: %" PRIu64 " )\n",
                             event->getFileDescriptor(), event->isRead() ? 'y' : 'n',
                             event->isWrite() ? 'y' : 'n', event->getDataPointer(), event->getDataLength(),

--- a/src/sst/elements/vanadis/os/syscall/iovec.h
+++ b/src/sst/elements/vanadis/os/syscall/iovec.h
@@ -70,7 +70,7 @@ public:
     {
 
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
-                            "[syscall-%s] call is %s( %" PRId64 ", 0x%0llx, %" PRId64 " )\n",
+                            "[syscall-%s] call is %s( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                             getName().c_str(), getName().c_str(), event->getFileDescriptor(), event->getIOVecAddress(), event->getIOVecCount());
 
         m_fd = process->getFileDescriptor( event->getFileDescriptor() );

--- a/src/sst/elements/vanadis/os/syscall/lseek.h
+++ b/src/sst/elements/vanadis/os/syscall/lseek.h
@@ -33,7 +33,7 @@ public:
         int fd = process->getFileDescriptor( event->getFileDescriptor() );
         if ( -1 == fd ) {
             m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,
-                                "[syscall-%s] file handle %" PRId64
+                                "[syscall-%s] file handle %" PRId32
                                 " is not currently open, return an error code.\n",
                                 getName().c_str(), event->getFileDescriptor());
 

--- a/src/sst/elements/vanadis/os/syscall/openat.h
+++ b/src/sst/elements/vanadis/os/syscall/openat.h
@@ -44,7 +44,7 @@ public:
             m_output->verbose(CALL_INFO, 16, 0, "sst fd=%d pathname=%s\n", m_dirFd, process->getFilePath(m_dirFd).c_str());
         }
 
-        m_output->verbose( CALL_INFO, 16, 0, "[syscall-openat] -> call is openat( %" PRId64 ", 0x%0llx, %" PRId64 " )\n",
+        m_output->verbose( CALL_INFO, 16, 0, "[syscall-openat] -> call is openat( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                 event->getDirectoryFileDescriptor(), event->getPathPointer(), event->getFlags());
 
         readString(event->getPathPointer(),m_filename);

--- a/src/sst/elements/vanadis/os/syscall/read.h
+++ b/src/sst/elements/vanadis/os/syscall/read.h
@@ -27,7 +27,7 @@ public:
     VanadisReadSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallReadEvent* event  )
         : VanadisSyscall( os, coreLink, process, event, "read" ), m_numRead(0), m_eof(false)
     {
-        m_output->verbose(CALL_INFO, 16, 0, "-> call is read( %" PRId64 ", 0x%0llx, %" PRId64 " )\n",
+        m_output->verbose(CALL_INFO, 16, 0, "-> call is read( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                             event->getFileDescriptor(), event->getBufferAddress(), event->getBufferCount());
 
         m_fd = process->getFileDescriptor( event->getFileDescriptor());

--- a/src/sst/elements/vanadis/os/syscall/readlink.h
+++ b/src/sst/elements/vanadis/os/syscall/readlink.h
@@ -27,7 +27,7 @@ public:
     VanadisReadlinkSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallReadLinkEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "readlink" ), m_data( event->getBufferSize() ), m_done(false)
     {
-        m_output->verbose(CALL_INFO, 16, 0, "[syscall-readlink] -> readlink( 0x%0llx, 0x%llx, %" PRId64 " )\n",
+        m_output->verbose(CALL_INFO, 16, 0, "[syscall-readlink] -> readlink( 0x%0" PRI_ADDR ", 0x%" PRI_ADDR ", %" PRId64 " )\n",
                                 event->getPathPointer(), event->getBufferPointer(),
                                 event->getBufferSize());
 

--- a/src/sst/elements/vanadis/os/syscall/uname.h
+++ b/src/sst/elements/vanadis/os/syscall/uname.h
@@ -27,7 +27,7 @@ public:
     VanadisUnameSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallUnameEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "uname" ) 
     {
-        m_output->verbose(CALL_INFO, 16, 0, "[syscall-uname] ---> uname struct is at address 0x%0llx\n", event->getUnameInfoAddress());
+        m_output->verbose(CALL_INFO, 16, 0, "[syscall-uname] ---> uname struct is at address 0x%0" PRI_ADDR "\n", event->getUnameInfoAddress());
 
 #if 0 
 struct new_utsname {

--- a/src/sst/elements/vanadis/os/syscall/unlinkat.h
+++ b/src/sst/elements/vanadis/os/syscall/unlinkat.h
@@ -44,7 +44,7 @@ public:
             m_output->verbose(CALL_INFO, 16, 0, "sst fd=%d pathname=%s\n", m_dirFd, process->getFilePath(m_dirFd).c_str());
         }
 
-        m_output->verbose( CALL_INFO, 16, 0, "[syscall-unlinkat] -> call is unlinkat( %" PRId64 ", 0x%0llx, %" PRId64 " )\n",
+        m_output->verbose( CALL_INFO, 16, 0, "[syscall-unlinkat] -> call is unlinkat( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                 event->getDirectoryFileDescriptor(), event->getPathPointer(), event->getFlags());
 
         readString(event->getPathPointer(),m_filename);

--- a/src/sst/elements/vanadis/os/syscall/write.h
+++ b/src/sst/elements/vanadis/os/syscall/write.h
@@ -27,7 +27,7 @@ public:
     VanadisWriteSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallWriteEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "write" ), m_numWritten(0)
     {
-        m_output->verbose(CALL_INFO, 16, 0, "[syscall-write] -> call is write( %" PRId64 ", 0x%0llx, %" PRId64 " )\n",
+        m_output->verbose(CALL_INFO, 16, 0, "[syscall-write] -> call is write( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                             event->getFileDescriptor(), event->getBufferAddress(), event->getBufferCount());
 
         m_fd = process->getFileDescriptor( event->getFileDescriptor());

--- a/src/sst/elements/vanadis/os/vappruntimememory.h
+++ b/src/sst/elements/vanadis/os/vappruntimememory.h
@@ -380,7 +380,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
             (uint32_t)aux_data_block.size());
     output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "---> Aux entry count:                    %d\n", aux_entry_count);
     output->verbose(
-            CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Setting SP to (not-aligned):          %" PRIu64 " / 0x%0llx\n", start_stack_address,
+            CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Setting SP to (not-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", start_stack_address,
             start_stack_address);
 
     uint64_t arg_env_space_needed = 1 + arg_count + 1 + env_count + 1 + aux_entry_count;
@@ -394,7 +394,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
     output->verbose(
             CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT,
             "Aligning stack address to 64 bytes (%" PRIu64 " - %" PRIu64 " - padding: %" PRIu64 " = %" PRIu64
-            " / 0x%0llx)\n",
+            " / 0x%0" PRI_ADDR ")\n",
             start_stack_address, (uint64_t)arg_env_space_and_data_needed, padding_needed, aligned_start_stack_address,
             aligned_start_stack_address);
 
@@ -408,7 +408,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
 
     for ( size_t i = 0; i < arg_start_offsets.size(); ++i ) {
         output->verbose(
-                CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting arg%" PRIu32 " to point to address %" PRIu64 " / 0x%llx\n", (uint32_t)i,
+                CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting arg%" PRIu32 " to point to address %" PRIu64 " / 0x%" PRI_ADDR "\n", (uint32_t)i,
                 arg_env_data_start + arg_start_offsets[i], arg_env_data_start + arg_start_offsets[i]);
         vanadis_vec_copy_in<Type>(stack_data, (Type)(arg_env_data_start + arg_start_offsets[i]));
     }
@@ -417,7 +417,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
 
     for ( size_t i = 0; i < env_start_offsets.size(); ++i ) {
         output->verbose(
-                CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting env%" PRIu32 " to point to address %" PRIu64 " / 0x%llx\n", (uint32_t)i,
+                CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting env%" PRIu32 " to point to address %" PRIu64 " / 0x%" PRI_ADDR "\n", (uint32_t)i,
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i],
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i]);
 
@@ -444,7 +444,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
     }
 
     output->verbose(
-            CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Pushing %" PRIu64 " bytes to the start of stack (0x%llx) via memory init event..\n",
+            CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Pushing %" PRIu64 " bytes to the start of stack (0x%" PRI_ADDR ") via memory init event..\n",
             (uint64_t)stack_data.size(), start_stack_address);
 
 #if 0  // PHDR

--- a/src/sst/elements/vanadis/os/velfloader.cc
+++ b/src/sst/elements/vanadis/os/velfloader.cc
@@ -109,7 +109,7 @@ void loadElfFile( Output* output, Interfaces::StandardMem* mem_if, MMU_Lib::MMU*
 
     output->verbose( CALL_INFO, 2, 0,
                     ">> Setting initial break point to image size in "
-                    "memory ( brk: 0x%llx )\n",
+                    "memory ( brk: 0x%" PRI_ADDR " )\n",
                     initial_brk);
     processInfo->initBrk( initial_brk );
 }

--- a/src/sst/elements/vanadis/os/vriscvcpuos.h
+++ b/src/sst/elements/vanadis/os/vriscvcpuos.h
@@ -305,7 +305,7 @@ public:
         uint64_t offset   = getArgRegister(1);
         int32_t whence   = getArgRegister(2);
 
-        output->verbose(CALL_INFO, 8, 0, "lseek( %" PRIdXX ", %" PRIdXX", %" PRIdXX " )\n", fd, offset, whence);
+        output->verbose(CALL_INFO, 8, 0, "lseek( %" PRId32 ", %" PRIu64 ", %" PRId32 " )\n", fd, offset, whence);
         return new VanadisSyscallLseekEvent(core_id, hw_thr, BitType, fd, offset, whence);
     }
 

--- a/src/sst/elements/vanadis/os/vriscvcpuos.h
+++ b/src/sst/elements/vanadis/os/vriscvcpuos.h
@@ -254,7 +254,7 @@ public:
             assert( map_flags == 0 );
 
             output->verbose(CALL_INFO, 8, 0,
-                        "mmap2( 0x%llx, %" PRIu64 ", %" PRId32 ", %" PRId32 ", %d, %" PRIu64 ")\n",
+                        "mmap2( 0x%" PRI_ADDR ", %" PRIu64 ", %" PRId32 ", %" PRId32 ", %d, %" PRIu64 ")\n",
                         map_addr, map_len, map_prot, map_flags, fd, offset );
 
             return new VanadisSyscallMemoryMapEvent(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B,
@@ -267,7 +267,7 @@ public:
         uint64_t time_addr  = getArgRegister( 1 );
 
         output->verbose(CALL_INFO, 8, 0,
-                            "clock_gettime64( %" PRId64 ", 0x%llx )\n", clk_type, time_addr);
+                            "clock_gettime64( %" PRId64 ", 0x%" PRI_ADDR " )\n", clk_type, time_addr);
 
         return new VanadisSyscallGetTime64Event(core_id, hw_thr, VanadisOSBitType::VANADIS_OS_64B, clk_type, time_addr);
     }
@@ -279,7 +279,7 @@ public:
         int32_t  signal_set_size    = getArgRegister( 3 );
 
         output->verbose(CALL_INFO, 8, 0,
-                            "rt_sigprocmask( %" PRId32 ", 0x%llx, 0x%llx, %" PRId32 ")\n",
+                            "rt_sigprocmask( %" PRId32 ", 0x%" PRI_ADDR ", 0x%" PRI_ADDR ", %" PRId32 ")\n",
                             how, signal_set_in, signal_set_out, signal_set_size);
 
         printf("Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented return success\n");

--- a/src/sst/elements/vanadis/util/vcmpop.h
+++ b/src/sst/elements/vanadis/util/vcmpop.h
@@ -95,7 +95,7 @@ registerCompareValues(VanadisRegisterCompareType compareType, VanadisRegisterFil
                         (compare_result ? "true" : "false"));
     } break;
     default: {
-        output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%llx\n",
+        output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%" PRI_ADDR "\n",
                         ins->getInstructionAddress());
         ins->flagError();
     } break;
@@ -145,7 +145,7 @@ registerCompareValues(VanadisRegisterFile* regFile, VanadisInstruction* ins,
                         (compare_result ? "true" : "false"));
     } break;
     default: {
-        output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%llx\n",
+        output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%" PRI_ADDR "\n",
                         ins->getInstructionAddress());
         ins->flagError();
     } break;

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -405,12 +405,12 @@ VANADIS_COMPONENT::startThread(int thr, uint64_t stackStart, uint64_t instructio
 
     if ( initial_config_ip > 0 ) {
         output->verbose(
-                CALL_INFO, 8, 0, "Overrding entry point for core-0, thread-0, set to 0x%llx\n", initial_config_ip);
+                CALL_INFO, 8, 0, "Overrding entry point for core-0, thread-0, set to 0x%" PRI_ADDR "\n", initial_config_ip);
         thread_decoders[thr]->setInstructionPointer(initial_config_ip);
     }
     else {
         output->verbose(
-            CALL_INFO, 8, 0, "Utilizing entry point from binary (auto-detected) 0x%llx\n",
+            CALL_INFO, 8, 0, "Utilizing entry point from binary (auto-detected) 0x%" PRI_ADDR "\n",
             thread_decoders[thr]->getInstructionPointer());
     }
 }
@@ -520,7 +520,7 @@ VANADIS_COMPONENT::performIssue(const uint64_t cycle, int hwThr, uint32_t& rob_s
                         if ( j == 0 ) {
                         ins->printToBuffer(instPrintBuffer, 1024);
                         output->verbose(
-                            CALL_INFO, 8, VANADIS_DBG_ISSUE_FLG, "%d: --> Attempting issue for: rob[%" PRIu32 "]: 0x%llx / %s\n", i, j,
+                            CALL_INFO, 8, VANADIS_DBG_ISSUE_FLG, "%d: --> Attempting issue for: rob[%" PRIu32 "]: 0x%" PRI_ADDR " / %s\n", i, j,
                             ins->getInstructionAddress(), instPrintBuffer);
                         }
                     }
@@ -576,7 +576,7 @@ VANADIS_COMPONENT::performIssue(const uint64_t cycle, int hwThr, uint32_t& rob_s
                             if ( output_verbosity >= 8 ) {
                                 ins->printToBuffer(instPrintBuffer, 1024);
                                 output->verbose(
-                                    CALL_INFO, 8, VANADIS_DBG_ISSUE_FLG, "%d: ----> Issued for: %s / 0x%llx / status: %d\n",
+                                    CALL_INFO, 8, VANADIS_DBG_ISSUE_FLG, "%d: ----> Issued for: %s / 0x%" PRI_ADDR " / status: %d\n",
                                     ins->getHWThread(), instPrintBuffer, ins->getInstructionAddress(), status);
                                 if ( print_rob ) {
                                     printRob(i,rob[i]);
@@ -723,7 +723,7 @@ void VANADIS_COMPONENT::printRob(int rob_num, VanadisCircularQueue<VanadisInstru
     for ( int j = (int)rob->size() - 1; j >= 0; --j ) {
         output->verbose(
             CALL_INFO, 8, 0,
-            "%d: ----> ROB[%2d]: ins: 0x%016llx / %10s / error: %3s / "
+            "%d: ----> ROB[%2d]: ins: 0x%016" PRI_ADDR " / %10s / error: %3s / "
             "issued: %3s / spec: %3s / rob-front: %3s / exe: %3s\n",
             rob_num, j, rob->peekAt(j)->getInstructionAddress(), rob->peekAt(j)->getInstCode(),
             rob->peekAt(j)->trapsError() ? "yes" : "no", rob->peekAt(j)->completedIssue() ? "yes" : "no",
@@ -766,7 +766,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
 
         output->fatal(
             CALL_INFO, -1,
-            "Instruction 0x%llx flags an error (instruction-type=%s) at "
+            "Instruction 0x%" PRI_ADDR " flags an error (instruction-type=%s) at "
             "cycle %" PRIu64 " (inst: %s)\n",
             rob_front->getInstructionAddress(), rob_front->getInstCode(), cycle, inst_asm_buffer);
 
@@ -807,7 +807,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                         if ( UNLIKELY(delay_ins->trapsError()) ) {
                             output->fatal(
                                 CALL_INFO, -1,
-                                "Instruction (delay-slot) 0x%llx flags an error "
+                                "Instruction (delay-slot) 0x%" PRI_ADDR " flags an error "
                                 "(instruction-type: %s)\n",
                                 delay_ins->getInstructionAddress(), delay_ins->getInstCode());
                         }
@@ -848,14 +848,14 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                 if(output->getVerboseLevel() >= 8) {
                 output->verbose(
                     CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG,
-                    "%d ----> Retire: speculated addr: 0x%llx / result addr: 0x%llx / "
+                    "%d ----> Retire: speculated addr: 0x%" PRI_ADDR " / result addr: 0x%" PRI_ADDR " / "
                     "pipeline-clear: %s\n",
                     spec_ins->getHWThread(), spec_ins->getSpeculatedAddress(), pipeline_reset_addr, perform_pipeline_clear ? "yes" : "no");
 
                 output->verbose(
                     CALL_INFO, 9, VANADIS_DBG_RETIRE_FLG,
                     "----> Updating branch predictor with new information "
-                    "(new addr: 0x%llx)\n",
+                    "(new addr: 0x%" PRI_ADDR ")\n",
                     pipeline_reset_addr);
                 if ( print_rob ) {
                     printRob(rob_num,rob);
@@ -877,8 +877,8 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
 
                     output->verbose(
                         CALL_INFO, 0, 0,
-                        "ins: 0x%llx / speculated-address: 0x%llx / taken: 0x%llx / "
-                        "reset: 0x%llx / clear-check: %3s / pipe-clear: %3s / "
+                        "ins: 0x%" PRI_ADDR " / speculated-address: 0x%" PRI_ADDR " / taken: 0x%" PRI_ADDR " / "
+                        "reset: 0x%" PRI_ADDR " / clear-check: %3s / pipe-clear: %3s / "
                         "delay-cleanup: %3s\n",
                         spec_ins->getInstructionAddress(), spec_ins->getSpeculatedAddress(),
                         spec_ins->getTakenAddress(), pipeline_reset_addr,
@@ -888,7 +888,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                     // stop simulation
                     output->fatal(
                         CALL_INFO, -2,
-                        "Retired instruction address 0x%llx, requested "
+                        "Retired instruction address 0x%" PRI_ADDR ", requested "
                         "terminate on retire this address.\n",
                         pause_on_retire_address);
                 }
@@ -906,7 +906,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                 rob_front->printToBuffer(inst_asm_buffer, 32768);
 
                 output->verbose(
-                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "%d: ----> Retire: 0x%0llx / %s\n", rob_front->getHWThread(), rob_front->getInstructionAddress(),
+                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "%d: ----> Retire: 0x%0" PRI_ADDR " / %s\n", rob_front->getHWThread(), rob_front->getInstructionAddress(),
                     inst_asm_buffer);
 
                 delete[] inst_asm_buffer;
@@ -916,7 +916,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
             }
 #endif
             if ( pipelineTrace != nullptr ) {
-                fprintf(pipelineTrace, "0x%08llx %s\n", rob_front->getInstructionAddress(), rob_front->getInstCode());
+                fprintf(pipelineTrace, "0x%08" PRI_ADDR " %s\n", rob_front->getInstructionAddress(), rob_front->getInstCode());
             }
 
 			if(UNLIKELY(rob_front->updatesFPFlags())) {
@@ -949,12 +949,12 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                 VanadisInstruction* delay_ins = rob->pop();
 #ifdef VANADIS_BUILD_DEBUG
                 output->verbose(
-                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "----> Retire delay: 0x%llx / %s\n", delay_ins->getInstructionAddress(),
+                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "----> Retire delay: 0x%" PRI_ADDR " / %s\n", delay_ins->getInstructionAddress(),
                     delay_ins->getInstCode());
 #endif
                 if ( pipelineTrace != nullptr ) {
                     fprintf(
-                        pipelineTrace, "0x%08llx %s\n", delay_ins->getInstructionAddress(), delay_ins->getInstCode());
+                        pipelineTrace, "0x%08" PRI_ADDR " %s\n", delay_ins->getInstructionAddress(), delay_ins->getInstCode());
                 }
 
 				if(UNLIKELY(rob_front->updatesFPFlags())) {
@@ -1003,7 +1003,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                 // stop simulation
                 output->fatal(
                     CALL_INFO, -2,
-                    "Retired instruction address 0x%llx, requested terminate "
+                    "Retired instruction address 0x%" PRI_ADDR ", requested terminate "
                     "on retire this address.\n",
                     pause_on_retire_address);
             }
@@ -1011,7 +1011,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
             if ( UNLIKELY(perform_pipeline_clear) ) {
 #ifdef VANADIS_BUILD_DEBUG
                 output->verbose(
-                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "----> perform a pipeline clear thread %" PRIu32 ", reset to address: 0x%llx\n",
+                    CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG, "----> perform a pipeline clear thread %" PRIu32 ", reset to address: 0x%" PRI_ADDR "\n",
                     ins_thread, pipeline_reset_addr);
 #endif
                 handleMisspeculate(ins_thread, pipeline_reset_addr);
@@ -1041,7 +1041,7 @@ VANADIS_COMPONENT::performRetire(int rob_num, VanadisCircularQueue<VanadisInstru
                     output->verbose(
                         CALL_INFO, 8, VANADIS_DBG_RETIRE_FLG,
                         "[syscall] -> calling OS handler in decode engine "
-                        "(ins-addr: 0x%0llx)...\n",
+                        "(ins-addr: 0x%0" PRI_ADDR ")...\n",
                         the_syscall_ins->getInstructionAddress());
 #endif
                     bool ret, flushLSQ;
@@ -1093,7 +1093,7 @@ VANADIS_COMPONENT::mapInstructiontoFunctionalUnit(
 
 #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= 16) {
-                output->verbose(CALL_INFO, 16, 0, "------> mapped 0x%llx / %s to func-unit: %" PRIu16 "\n",
+                output->verbose(CALL_INFO, 16, 0, "------> mapped 0x%" PRI_ADDR " / %s to func-unit: %" PRIu16 "\n",
                     ins->getInstructionAddress(), ins->getInstCode(), next_fu->getUnitID());
             }
 #endif
@@ -1159,7 +1159,7 @@ VANADIS_COMPONENT::allocateFunctionalUnit(VanadisInstruction* ins)
         if ( nullptr == fence_ins ) {
             output->fatal(
                 CALL_INFO, -1,
-                "Error: instruction (0x%0llx /thr: %" PRIu32 ") is a fence but not "
+                "Error: instruction (0x%0" PRI_ADDR " /thr: %" PRIu32 ") is a fence but not "
                 "convertable to a fence instruction.\n",
                 ins->getInstructionAddress(), ins->getHWThread());
         }
@@ -1539,7 +1539,7 @@ VANADIS_COMPONENT::assignRegistersToInstruction(
 
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%llx int reg-in for isa: %" PRIu16 " will mapped to phys: %" PRIu16 "\n",
+            output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%" PRI_ADDR " int reg-in for isa: %" PRIu16 " will mapped to phys: %" PRIu16 "\n",
                 ins->getInstructionAddress(), isa_reg_in, phys_reg_in);
         }
 #endif
@@ -1560,7 +1560,7 @@ VANADIS_COMPONENT::assignRegistersToInstruction(
 
 #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
-            output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%llx fp reg-in for isa: %" PRIu16 " will mapped to phys: %" PRIu16 "\n",
+            output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%" PRI_ADDR " fp reg-in for isa: %" PRIu16 " will mapped to phys: %" PRIu16 "\n",
                 ins->getInstructionAddress(), isa_reg_in, phys_reg_in);
         }
 #endif
@@ -1627,7 +1627,7 @@ VANADIS_COMPONENT::assignRegistersToInstruction(
 
 #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= 16) {
-                output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%llx int reg-out for isa: %" PRIu16 " output will map to phys: %" PRIu16 "\n",
+                output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%" PRI_ADDR " int reg-out for isa: %" PRIu16 " output will map to phys: %" PRIu16 "\n",
                     ins->getInstructionAddress(), ins_isa_reg, out_reg);
             }
 #endif
@@ -1653,7 +1653,7 @@ VANADIS_COMPONENT::assignRegistersToInstruction(
 
 #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= 16) {
-                output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%llx fp reg-out for isa: %" PRIu16 " output will map to phys: %" PRIu16 "\n",
+                output->verbose(CALL_INFO, 16, 0, "-----> creating ins-addr: 0x%" PRI_ADDR " fp reg-out for isa: %" PRIu16 " output will map to phys: %" PRIu16 "\n",
                     ins->getInstructionAddress(), ins_isa_reg, out_reg);
             }
 #endif
@@ -1793,7 +1793,7 @@ VANADIS_COMPONENT::printStatus(SST::Output& output)
             VanadisInstruction* next_ins = next_rob->peekAt(i - 1);
             output.verbose(
                 CALL_INFO, 0, 0,
-                "---> rob[%5" PRIu16 "]: addr: 0x%08llx / %10s / spec: %3s / err: "
+                "---> rob[%5" PRIu16 "]: addr: 0x%08" PRI_ADDR " / %10s / spec: %3s / err: "
                 "%3s / issued: %3s / front: %3s / exe: %3s\n",
                 (uint16_t)(i - 1), next_ins->getInstructionAddress(), next_ins->getInstCode(),
                 next_ins->isSpeculated() ? "yes" : "no", next_ins->trapsError() ? "yes" : "no",
@@ -1864,7 +1864,7 @@ VANADIS_COMPONENT::handleMisspeculate(const uint32_t hw_thr, const uint64_t new_
 {
 #ifdef VANADIS_BUILD_DEBUG
     if(output->getVerboseLevel() >= 16) {
-        output->verbose(CALL_INFO, 16, 0, "-> Handle mis-speculation on %" PRIu32 " (new-ip: 0x%llx)...\n", hw_thr, new_ip);
+        output->verbose(CALL_INFO, 16, 0, "-> Handle mis-speculation on %" PRIu32 " (new-ip: 0x%" PRI_ADDR ")...\n", hw_thr, new_ip);
     }
 #endif
     clearFuncUnit(hw_thr, fu_int_arith);
@@ -1938,7 +1938,7 @@ VANADIS_COMPONENT::syscallReturn(uint32_t thr)
 #ifdef VANADIS_BUILD_DEBUG
     output->verbose(
         CALL_INFO, 8, 0,
-        "[syscall-return]: syscall on thread %" PRIu32 " (0x%0llx) is completed, return to processing.\n", thr,
+        "[syscall-return]: syscall on thread %" PRIu32 " (0x%0" PRI_ADDR ") is completed, return to processing.\n", thr,
         syscall_ins->getInstructionAddress());
 #endif
     syscall_ins->markExecuted();

--- a/src/sst/elements/vanadis/velf/velfinfo.h
+++ b/src/sst/elements/vanadis/velf/velfinfo.h
@@ -215,7 +215,7 @@ public:
 
     void print(SST::Output* output, uint32_t index) {
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF,
-                        "Relocation (index: %" PRIu32 " / address: %" PRIu64 " (0x%0llx) / info: %" PRIu64 "\n", index,
+                        "Relocation (index: %" PRIu32 " / address: %" PRIu64 " (0x%0" PRI_ADDR ") / info: %" PRIu64 "\n", index,
                         rel_address, rel_address, symbol_info);
     }
 
@@ -262,7 +262,7 @@ public:
 
     void print(SST::Output* output, size_t index) {
         output->verbose(CALL_INFO, 32, VANADIS_OS_DBG_READ_ELF,
-                        "Symbol (index: %" PRIu32 " / name: %s / offset: %" PRIu64 " / address: 0x%0llx / sz: %" PRIu64
+                        "Symbol (index: %" PRIu32 " / name: %s / offset: %" PRIu64 " / address: 0x%0" PRI_ADDR " / sz: %" PRIu64
                         ", type: %s / bind: %s / sndx: %" PRIu64 ")\n",
                         (uint32_t)index, symbolName.c_str(), sym_name_offset, sym_address, sym_size,
                         getSymbolTypeString(sym_type), getSymbolBindTypeString(sym_bind), sym_sndx);
@@ -309,7 +309,7 @@ public:
 
     void print(SST::Output* output, uint64_t index) {
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, ">> Program Header Entry:    %" PRIu64 "\n", index);
-        output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Header Type:           %" PRIu64 " / 0x%llx / %s\n", hdr_type_num,
+        output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Header Type:           %" PRIu64 " / 0x%" PRI_ADDR " / %s\n", hdr_type_num,
                         hdr_type_num, getELFProgramHeaderTypeString(hdr_type));
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Image Offset:          %" PRIu64 "\n", imgOffset);
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Virtual Memory Start:  %" PRIu64 " / %p\n", virtMemAddrStart,
@@ -320,7 +320,7 @@ public:
                         (void*)imgDataLen);
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Image Mem Length:      %" PRIu64 " / %p\n", memDataLen,
                         (void*)memDataLen);
-        output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Flags:                 %" PRIu64 " / 0x%0llx\n", segment_flags,
+        output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Flags:                 %" PRIu64 " / 0x%0" PRI_ADDR "\n", segment_flags,
                         segment_flags);
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "---> Alignment:             %" PRIu64 " / %p\n", alignment,
                         (void*)alignment);
@@ -715,7 +715,7 @@ readBinarySymbolTable(SST::Output* output, const char* path, VanadisELFInfo* elf
 
     const bool binary_is_32 = elf_info->isELF32();
 
-    output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "Symbol Table located at %" PRIu64 " / 0x%0llx in executable (is 32bit? %s).\n",
+    output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_READ_ELF, "Symbol Table located at %" PRIu64 " / 0x%0" PRI_ADDR " in executable (is 32bit? %s).\n",
                     symbolSection->getImageOffset(), symbolSection->getImageOffset(), binary_is_32 ? "yes" : "no");
 
     // Wind forward to the symbol table entries

--- a/src/sst/elements/vanadis/vfuncunit.h
+++ b/src/sst/elements/vanadis/vfuncunit.h
@@ -117,7 +117,7 @@ public:
 
         for (auto q_itr = pending_execute.begin(); q_itr != pending_execute.end(); q_itr++) {
             VanadisFunctionalUnitInsRecord* q_front = pending_execute.front();
-            output->verbose(CALL_INFO, 16, 0, "----> func-unit: %" PRIu16 " %" PRIu16 " entries / entry: %" PRIu16 " / %s / 0x%llx / cycles: %" PRIu16 " out of %" PRIu16 "\n",
+            output->verbose(CALL_INFO, 16, 0, "----> func-unit: %" PRIu16 " %" PRIu16 " entries / entry: %" PRIu16 " / %s / 0x%" PRI_ADDR " / cycles: %" PRIu16 " out of %" PRIu16 "\n",
                 fu_id, (uint16_t) pending_execute.size(), index++, q_front->getInstruction()->getInstCode(),
                 q_front->getInstruction()->getInstructionAddress(), q_front->getCycles(), latency);
         }

--- a/src/sst/elements/vanadis/vinsloader.h
+++ b/src/sst/elements/vanadis/vinsloader.h
@@ -282,7 +282,7 @@ public:
 
         do {
             output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG,
-                            "[ins-loader] ---> issue ins-load line-start: 0x%llx, line-len: %" PRIu64
+                            "[ins-loader] ---> issue ins-load line-start: 0x%" PRI_ADDR ", line-len: %" PRIu64
                             " read-len=%" PRIu64 " \n",
                             line_start, line_start_offset, cache_line_width);
 
@@ -290,7 +290,7 @@ public:
 					// line is already in the cache, touch to make sure it is kept in LRU
 					predecode_cache->touch(line_start);
 
-					output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ----> line (start-addr: 0x%llx) is already in pre-decode cache, updated LRU priority\n",
+					output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ----> line (start-addr: 0x%" PRI_ADDR ") is already in pre-decode cache, updated LRU priority\n",
 						line_start);
 				} else {
 	            bool found_pending_load = false;
@@ -303,7 +303,7 @@ public:
 	            }
 
 	            if (!found_pending_load) {
-						output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ----> creating a load for line at 0x%llx, len=%" PRIu64 "\n",
+						output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ----> creating a load for line at 0x%" PRI_ADDR ", len=%" PRIu64 "\n",
 							line_start, cache_line_width);
 
 	                SST::Interfaces::StandardMem::Read* req_line = new SST::Interfaces::StandardMem::Read(
@@ -349,7 +349,7 @@ private:
 	void printPendingLoads(SST::Output* output) {
 		output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader]: Pending loads table\n");
 		for( auto next_load : pending_loads ) {
-			output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader]:   load: 0x%llx / size %" PRIu64 "\n",
+			output->verbose(CALL_INFO, 8, VANADIS_DBG_INS_LDR_FLG, "[ins-loader]:   load: 0x%" PRI_ADDR " / size %" PRIu64 "\n",
 				next_load.second->pAddr, next_load.second->size);
 		}
 	}

--- a/src/sst/elements/vanadis/vinsloader.h
+++ b/src/sst/elements/vanadis/vinsloader.h
@@ -123,7 +123,7 @@ public:
             }
 
             if(output_verbosity >= 16) {
-                output->verbose(CALL_INFO, 16, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ---> hit (addr=0x%llx), caching line in predecoder.\n",
+                output->verbose(CALL_INFO, 16, VANADIS_DBG_INS_LDR_FLG, "[ins-loader] ---> hit (addr=0x%" PRI_ADDR "), caching line in predecoder.\n",
                             resp->pAddr);
             }
 
@@ -159,7 +159,7 @@ public:
 
         if(output_verbosity >= 16) {
         output->verbose(CALL_INFO, 16, VANADIS_DBG_INS_LDR_FLG,
-                        "[fill-decode]: ins-addr: 0x%llx line-offset: %" PRIu64 " line-start=%" PRIu64 " / 0x%llx\n",
+                        "[fill-decode]: ins-addr: 0x%" PRI_ADDR " line-offset: %" PRIu64 " line-start=%" PRIu64 " / 0x%" PRI_ADDR "\n",
                         addr, inst_line_offset, cache_line_start, cache_line_start);
         }
 


### PR DESCRIPTION
These appear with Clang on Linux and Apple Clang.

This requires https://github.com/sstsimulator/sst-core/pull/1010 in order to work.

Redo of #2249 that had the wrong base branch.