### PR TITLE
Add to stats more efficiently in various turnClockOn() functions

### DIFF
--- a/src/sst/elements/memHierarchy/cacheController.cc
+++ b/src/sst/elements/memHierarchy/cacheController.cc
@@ -203,9 +203,7 @@ void Cache::turnClockOn() {
     timestamp_ = time - 1;
     coherenceMgr_->updateTimestamp(timestamp_);
     int64_t cyclesOff = timestamp_ - lastActiveClockCycle_;
-    for (int64_t i = 0; i < cyclesOff; i++) {           // TODO more efficient way to do this? Don't want to add in one-shot or we get weird averages/sum sq.
-        statMSHROccupancy->addData(mshr_->getSize());
-    }
+    statMSHROccupancy->addDataNTimes(cyclesOff, mshr_->getSize());
     //dbg_->debug(_L3_, "%s turning clock ON at cycle %" PRIu64 ", timestamp %" PRIu64 ", ns %" PRIu64 "\n", this->getName().c_str(), getCurrentSimCycle(), timestamp_, getCurrentSimTimeNano());
     clockIsOn_ = true;
 }

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -628,9 +628,7 @@ void DirectoryController::turnClockOn() {
     timestamp = reregisterClock(defaultTimeBase, clockHandler);
     timestamp--; // reregisterClock returns next cycle clock will be enabled, set timestamp to current cycle
     uint64_t inactiveCycles = timestamp - lastActiveClockCycle;
-    for (uint64_t i = 0; i < inactiveCycles; i++) {
-        stat_MSHROccupancy->addData(mshr->getSize());
-    }
+    stat_MSHROccupancy->addDataNTimes(inactiveCycles, mshr->getSize());
 }
 
 

--- a/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
+++ b/src/sst/elements/memHierarchy/membackend/memBackendConvertor.cc
@@ -148,8 +148,7 @@ bool MemBackendConvertor::clock(Cycle_t cycle) {
  */
 void MemBackendConvertor::turnClockOn(Cycle_t cycle) {
     Cycle_t cyclesOff = cycle - m_cycleCount;
-    for (Cycle_t i = 0; i < cyclesOff; i++)
-        stat_outstandingReqs->addData( m_pendingRequests.size() );
+    stat_outstandingReqs->addDataNTimes( cyclesOff, m_pendingRequests.size() );
     m_cycleCount = cycle;
     m_clockOn = true;
 }
@@ -233,8 +232,7 @@ void MemBackendConvertor::finish(Cycle_t endCycle) {
     // stat_outstandingReqs may vary slightly in parallel & serial
     if (endCycle > m_cycleCount) {
         Cycle_t cyclesOff = endCycle - m_cycleCount;
-        for (Cycle_t i = 0; i < cyclesOff; i++)
-            stat_outstandingReqs->addData( m_pendingRequests.size() );
+        stat_outstandingReqs->addDataNTimes( cyclesOff, m_pendingRequests.size() );
         m_cycleCount = endCycle;
     }
     stat_totalCycles->addData(m_cycleCount);


### PR DESCRIPTION
I've actually seen these stats take a good chunk of SST's runtime in our simulations, so this should help.