### PR TITLE
Fix issue with mispelled parameter name in pyfirefly

### DIFF
--- a/src/sst/elements/firefly/pyfirefly.py
+++ b/src/sst/elements/firefly/pyfirefly.py
@@ -108,7 +108,7 @@ class BasicNicConfiguration(TemplateBase):
             "rxMatchDelay_ns", "txDelay_ns",
             "hostReadDelay_ns",
             "tracedPkt", "tracedNode",
-            "maxSendMachineQsize", "maxRecvMachineQSize",
+            "maxSendMachineQsize", "maxRecvMachineQsize",
             "numSendMachines", "numRecvNicUnits",
             "messageSendAlignment", "nicAllocationPolicy",
             "packetOverhead", "packetSize",


### PR DESCRIPTION
The maxRecvMachineQsize parameter was misspelled in the BasicNicConfiguration python object, so the parameter could never be set since it didn't match the spelling in the C++ model.