### PR TITLE
Merlin python updates

### DIFF
--- a/src/sst/elements/merlin/Makefile.am
+++ b/src/sst/elements/merlin/Makefile.am
@@ -107,12 +107,14 @@ EXTRA_DIST = \
 	tests/dragon_128_platform_test.py \
 	tests/dragon_128_platform_test_cm.py \
 	tests/platform_file_dragon_128.py \
+	tests/dragon_128_test_deferred.py \
 	tests/polarfly_455_test.py \
 	tests/polarstar_504_test.py \
 	tests/refFiles/test_merlin_dragon_128_platform_test.out \
 	tests/refFiles/test_merlin_dragon_128_platform_test_cm.out \
 	tests/refFiles/test_merlin_dragon_128_test.out \
 	tests/refFiles/test_merlin_dragon_128_test_fl.out \
+	tests/refFiles/test_merlin_dragon_128_test_deferred.out \
 	tests/refFiles/test_merlin_dragon_72_test.out \
 	tests/refFiles/test_merlin_fattree_128_test.out \
 	tests/refFiles/test_merlin_fattree_256_test.out \

--- a/src/sst/elements/merlin/interfaces/pymerlin-interface.py
+++ b/src/sst/elements/merlin/interfaces/pymerlin-interface.py
@@ -26,7 +26,7 @@ class LinkControl(NetworkInterface):
         self._subscribeToPlatformParamSet("network_interface")
 
     # returns subcomp, port_name
-    def build(self,comp,slot,slot_num,job_id,job_size,logical_nid,use_nid_remap = False):
+    def build(self,comp,slot,slot_num,job_id,job_size,logical_nid,use_nid_remap = False, link=None):
         if self._check_first_build():
             set_name = "params_%s"%self._instance_name
             sst.addGlobalParams(set_name, self._getGroupParams("params"))
@@ -39,7 +39,12 @@ class LinkControl(NetworkInterface):
         self._applyStatisticsSettings(sub)
         sub.addGlobalParamSet("params_%s"%self._instance_name)
         sub.addParam("logical_nid",logical_nid)
-        return sub,"rtr_port"
+
+        if link:
+            sub.addLink(link, "rtr_port");
+            return True
+        else:
+            return sub,"rtr_port"
 
 
 class ReorderLinkControl(NetworkInterface):
@@ -62,11 +67,14 @@ class ReorderLinkControl(NetworkInterface):
     def setNetworkInterface(self,interface):
         self.network_interface = interface
 
-    def build(self,comp,slot,slot_num,job_id,job_size,nid,use_nid_map = False):
+    def build(self,comp,slot,slot_num,job_id,job_size,nid,use_nid_map = False, link = None):
         sub = comp.setSubComponent(slot,"merlin.reorderlinkcontrol",slot_num)
         #self._applyStatisticsSettings(sub)
         #sub.addParams(self._params)
-        return self.network_interface.build(sub,"networkIF",0,job_id,job_size,nid,use_nid_map)
+
+        return NetworkInterface._instanceNetworkInterfaceBackCompat(
+            self.network_interface,sub,"networkIF",0,job_id,job_size,nid,use_nid_map,link)
+
 
     # Functions to enable statistics
     def enableAllStatistics(self,stat_params,apply_to_children=False):

--- a/src/sst/elements/merlin/pymerlin-endpoint.py
+++ b/src/sst/elements/merlin/pymerlin-endpoint.py
@@ -28,7 +28,7 @@ class TestJob(Job):
     def getName(self):
         return "TestJob"
 
-    def build(self, nID, extraKeys):
+    def build(self, nID, extraKeys, link = None):
         nic = sst.Component("testNic_%d"%nID, "merlin.test_nic")
         self._applyStatisticsSettings(nic)
         nic.addParams(self._getGroupParams("main"))
@@ -38,9 +38,8 @@ class TestJob(Job):
         nic.addParam("id", id)
 
         #  Add the linkcontrol
-        networkif, port_name = self.network_interface.build(nic,"networkIF",0,self.job_id,self.size,id,True)
-
-        return (networkif,port_name)
+        return NetworkInterface._instanceNetworkInterfaceBackCompat(
+            self.network_interface,nic,"networkIF",0,self.job_id,self.size,id,True,link)
 
 
 class OfferedLoadJob(Job):

--- a/src/sst/elements/merlin/router.h
+++ b/src/sst/elements/merlin/router.h
@@ -486,6 +486,11 @@ public:
     // Parameters are:  num_ports, id, num_vns
     SST_ELI_REGISTER_SUBCOMPONENT_API(SST::Merlin::Topology, int, int, int)
 
+    SST_ELI_DOCUMENT_PARAMS(
+        {"network_name",      "Name of the network.  Required if two networks of the same topology are used in the same simulation; primarily use to namespace global shared object used by the topology."}
+    )
+
+
     enum PortState {R2R, R2N, UNCONNECTED, FAILED};
     Topology(ComponentId_t cid) : SubComponent(cid), output(getSimulationOutput()) {}
     virtual ~Topology() {}

--- a/src/sst/elements/merlin/tests/dragon_128_test_deferred.py
+++ b/src/sst/elements/merlin/tests/dragon_128_test_deferred.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+#
+# Copyright 2009-2023 NTESS. Under the terms
+# of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# Copyright (c) 2009-2023, NTESS
+# All rights reserved.
+#
+# This file is part of the SST software package. For license
+# information, see the LICENSE file in the top level directory of the
+# distribution.
+
+import sst
+from sst.merlin.base import *
+from sst.merlin.endpoint import *
+from sst.merlin.interface import *
+from sst.merlin.topology import *
+
+if __name__ == "__main__":
+
+    # This file creates two dragonfly networks of different sizes and
+    # instances the endpoints using deferred build.
+
+    # Network 1
+    ### Setup the topology
+    topo = topoDragonFly()
+    topo.hosts_per_router = 4
+    topo.routers_per_group = 8
+    topo.intergroup_links = 4
+    topo.num_groups = 5
+    topo.algorithm = "ugal"
+    topo.network_name = "net1"
+
+    # Set up the routers
+    router = hr_router()
+    router.link_bw = "4GB/s"
+    router.flit_size = "8B"
+    router.xbar_bw = "6GB/s"
+    router.input_latency = "20ns"
+    router.output_latency = "20ns"
+    router.input_buf_size = "4kB"
+    router.output_buf_size = "4kB"
+    router.num_vns = 2
+    router.xbar_arb = "merlin.xbar_arb_lru"
+
+    topo.router = router
+    topo.link_latency = "20ns"
+
+    ### set up the endpoint
+    networkif = LinkControl()
+    networkif.link_bw = "4GB/s"
+    networkif.input_buf_size = "1kB"
+    networkif.output_buf_size = "1kB"
+
+    networkif_ro = ReorderLinkControl()
+    networkif_ro.network_interface = networkif
+    
+    ep = TestJob(0,topo.getNumNodes())
+    ep.network_interface = networkif_ro
+    #ep.num_messages = 10
+    #ep.message_size = "8B"
+    #ep.send_untimed_bcast = False
+    
+    system = System()
+    system.setTopology(topo)
+
+    system.deferred_build()
+
+    # Need to push the name prefix to match the network name
+    sst.pushNamePrefix(topo.network_name)
+    ep.createLinearNidMap()
+    for x in range(topo.getNumNodes()):
+        ep.build(x, {}, system.getLinkForEndpoint(x))
+    sst.popNamePrefix()
+
+    ##### Done with first network
+
+    # Newtork 2
+    ### Setup the topology
+    topo = topoDragonFly()
+    topo.hosts_per_router = 4
+    topo.routers_per_group = 8
+    topo.intergroup_links = 4
+    topo.num_groups = 4
+    topo.algorithm = "ugal"
+    topo.network_name = "net2"
+
+    # Set up the routers
+    router = hr_router()
+    router.link_bw = "4GB/s"
+    router.flit_size = "8B"
+    router.xbar_bw = "6GB/s"
+    router.input_latency = "20ns"
+    router.output_latency = "20ns"
+    router.input_buf_size = "4kB"
+    router.output_buf_size = "4kB"
+    router.num_vns = 2
+    router.xbar_arb = "merlin.xbar_arb_lru"
+
+    topo.router = router
+    topo.link_latency = "20ns"
+
+    ### set up the endpoint
+    networkif = LinkControl()
+    networkif.link_bw = "4GB/s"
+    networkif.input_buf_size = "1kB"
+    networkif.output_buf_size = "1kB"
+
+    networkif_ro = ReorderLinkControl()
+    networkif_ro.network_interface = networkif
+    
+    ep = TestJob(0,topo.getNumNodes())
+    ep.network_interface = networkif_ro
+    #ep.num_messages = 10
+    #ep.message_size = "8B"
+    #ep.send_untimed_bcast = False
+    
+    system = System()
+    system.setTopology(topo)
+
+    system.deferred_build()
+
+    # Need to push the name prefix to match the network name
+    sst.pushNamePrefix(topo.network_name)
+    ep.createLinearNidMap()
+    for x in range(topo.getNumNodes()):
+        ep.build(x, {}, system.getLinkForEndpoint(x))
+    sst.popNamePrefix()
+
+
+    # sst.setStatisticLoadLevel(9)
+
+    # sst.setStatisticOutput("sst.statOutputCSV");
+    # sst.setStatisticOutputOptions({
+    #     "filepath" : "stats.csv",
+    #     "separator" : ", "
+    # })
+

--- a/src/sst/elements/merlin/tests/refFiles/test_merlin_dragon_128_test_deferred.out
+++ b/src/sst/elements/merlin/tests/refFiles/test_merlin_dragon_128_test_deferred.out
@@ -1,0 +1,865 @@
+2312:  0 Finished sending packets (total of 10)
+2312:  1 Finished sending packets (total of 10)
+2312:  2 Finished sending packets (total of 10)
+2312:  3 Finished sending packets (total of 10)
+2312:  4 Finished sending packets (total of 10)
+2312:  5 Finished sending packets (total of 10)
+2312:  6 Finished sending packets (total of 10)
+2312:  7 Finished sending packets (total of 10)
+2312:  8 Finished sending packets (total of 10)
+2312:  9 Finished sending packets (total of 10)
+2312:  10 Finished sending packets (total of 10)
+2312:  11 Finished sending packets (total of 10)
+2312:  12 Finished sending packets (total of 10)
+2312:  13 Finished sending packets (total of 10)
+2312:  14 Finished sending packets (total of 10)
+2312:  15 Finished sending packets (total of 10)
+2312:  16 Finished sending packets (total of 10)
+2312:  17 Finished sending packets (total of 10)
+2312:  18 Finished sending packets (total of 10)
+2312:  19 Finished sending packets (total of 10)
+2312:  20 Finished sending packets (total of 10)
+2312:  21 Finished sending packets (total of 10)
+2312:  22 Finished sending packets (total of 10)
+2312:  23 Finished sending packets (total of 10)
+2312:  24 Finished sending packets (total of 10)
+2312:  25 Finished sending packets (total of 10)
+2312:  26 Finished sending packets (total of 10)
+2312:  27 Finished sending packets (total of 10)
+2312:  28 Finished sending packets (total of 10)
+2312:  29 Finished sending packets (total of 10)
+2312:  30 Finished sending packets (total of 10)
+2312:  31 Finished sending packets (total of 10)
+2312:  32 Finished sending packets (total of 10)
+2312:  33 Finished sending packets (total of 10)
+2312:  34 Finished sending packets (total of 10)
+2312:  35 Finished sending packets (total of 10)
+2312:  36 Finished sending packets (total of 10)
+2312:  37 Finished sending packets (total of 10)
+2312:  38 Finished sending packets (total of 10)
+2312:  39 Finished sending packets (total of 10)
+2312:  40 Finished sending packets (total of 10)
+2312:  41 Finished sending packets (total of 10)
+2312:  42 Finished sending packets (total of 10)
+2312:  43 Finished sending packets (total of 10)
+2312:  44 Finished sending packets (total of 10)
+2312:  45 Finished sending packets (total of 10)
+2312:  46 Finished sending packets (total of 10)
+2312:  47 Finished sending packets (total of 10)
+2312:  48 Finished sending packets (total of 10)
+2312:  49 Finished sending packets (total of 10)
+2312:  50 Finished sending packets (total of 10)
+2312:  51 Finished sending packets (total of 10)
+2312:  52 Finished sending packets (total of 10)
+2312:  53 Finished sending packets (total of 10)
+2312:  54 Finished sending packets (total of 10)
+2312:  55 Finished sending packets (total of 10)
+2312:  56 Finished sending packets (total of 10)
+2312:  57 Finished sending packets (total of 10)
+2312:  58 Finished sending packets (total of 10)
+2312:  59 Finished sending packets (total of 10)
+2312:  60 Finished sending packets (total of 10)
+2312:  61 Finished sending packets (total of 10)
+2312:  62 Finished sending packets (total of 10)
+2312:  63 Finished sending packets (total of 10)
+2312:  64 Finished sending packets (total of 10)
+2312:  65 Finished sending packets (total of 10)
+2312:  66 Finished sending packets (total of 10)
+2312:  67 Finished sending packets (total of 10)
+2312:  68 Finished sending packets (total of 10)
+2312:  69 Finished sending packets (total of 10)
+2312:  70 Finished sending packets (total of 10)
+2312:  71 Finished sending packets (total of 10)
+2312:  72 Finished sending packets (total of 10)
+2312:  73 Finished sending packets (total of 10)
+2312:  74 Finished sending packets (total of 10)
+2312:  75 Finished sending packets (total of 10)
+2312:  76 Finished sending packets (total of 10)
+2312:  77 Finished sending packets (total of 10)
+2312:  78 Finished sending packets (total of 10)
+2312:  79 Finished sending packets (total of 10)
+2312:  80 Finished sending packets (total of 10)
+2312:  81 Finished sending packets (total of 10)
+2312:  82 Finished sending packets (total of 10)
+2312:  83 Finished sending packets (total of 10)
+2312:  84 Finished sending packets (total of 10)
+2312:  85 Finished sending packets (total of 10)
+2312:  86 Finished sending packets (total of 10)
+2312:  87 Finished sending packets (total of 10)
+2312:  88 Finished sending packets (total of 10)
+2312:  89 Finished sending packets (total of 10)
+2312:  90 Finished sending packets (total of 10)
+2312:  91 Finished sending packets (total of 10)
+2312:  92 Finished sending packets (total of 10)
+2312:  93 Finished sending packets (total of 10)
+2312:  94 Finished sending packets (total of 10)
+2312:  95 Finished sending packets (total of 10)
+2312:  96 Finished sending packets (total of 10)
+2312:  97 Finished sending packets (total of 10)
+2312:  98 Finished sending packets (total of 10)
+2312:  99 Finished sending packets (total of 10)
+2312:  100 Finished sending packets (total of 10)
+2312:  101 Finished sending packets (total of 10)
+2312:  102 Finished sending packets (total of 10)
+2312:  103 Finished sending packets (total of 10)
+2312:  104 Finished sending packets (total of 10)
+2312:  105 Finished sending packets (total of 10)
+2312:  106 Finished sending packets (total of 10)
+2312:  107 Finished sending packets (total of 10)
+2312:  108 Finished sending packets (total of 10)
+2312:  109 Finished sending packets (total of 10)
+2312:  110 Finished sending packets (total of 10)
+2312:  111 Finished sending packets (total of 10)
+2312:  112 Finished sending packets (total of 10)
+2312:  113 Finished sending packets (total of 10)
+2312:  114 Finished sending packets (total of 10)
+2312:  115 Finished sending packets (total of 10)
+2312:  116 Finished sending packets (total of 10)
+2312:  117 Finished sending packets (total of 10)
+2312:  118 Finished sending packets (total of 10)
+2312:  119 Finished sending packets (total of 10)
+2312:  120 Finished sending packets (total of 10)
+2312:  121 Finished sending packets (total of 10)
+2312:  122 Finished sending packets (total of 10)
+2312:  123 Finished sending packets (total of 10)
+2312:  124 Finished sending packets (total of 10)
+2312:  125 Finished sending packets (total of 10)
+2312:  126 Finished sending packets (total of 10)
+2312:  127 Finished sending packets (total of 10)
+2952:  0 Finished sending packets (total of 10)
+2952:  1 Finished sending packets (total of 10)
+2952:  2 Finished sending packets (total of 10)
+2952:  3 Finished sending packets (total of 10)
+2952:  4 Finished sending packets (total of 10)
+2952:  5 Finished sending packets (total of 10)
+2952:  6 Finished sending packets (total of 10)
+2952:  7 Finished sending packets (total of 10)
+2952:  8 Finished sending packets (total of 10)
+2952:  9 Finished sending packets (total of 10)
+2952:  10 Finished sending packets (total of 10)
+2952:  11 Finished sending packets (total of 10)
+2952:  12 Finished sending packets (total of 10)
+2952:  13 Finished sending packets (total of 10)
+2952:  14 Finished sending packets (total of 10)
+2952:  15 Finished sending packets (total of 10)
+2952:  16 Finished sending packets (total of 10)
+2952:  17 Finished sending packets (total of 10)
+2952:  18 Finished sending packets (total of 10)
+2952:  19 Finished sending packets (total of 10)
+2952:  20 Finished sending packets (total of 10)
+2952:  21 Finished sending packets (total of 10)
+2952:  22 Finished sending packets (total of 10)
+2952:  23 Finished sending packets (total of 10)
+2952:  24 Finished sending packets (total of 10)
+2952:  25 Finished sending packets (total of 10)
+2952:  26 Finished sending packets (total of 10)
+2952:  27 Finished sending packets (total of 10)
+2952:  28 Finished sending packets (total of 10)
+2952:  29 Finished sending packets (total of 10)
+2952:  30 Finished sending packets (total of 10)
+2952:  31 Finished sending packets (total of 10)
+2952:  32 Finished sending packets (total of 10)
+2952:  33 Finished sending packets (total of 10)
+2952:  34 Finished sending packets (total of 10)
+2952:  35 Finished sending packets (total of 10)
+2952:  36 Finished sending packets (total of 10)
+2952:  37 Finished sending packets (total of 10)
+2952:  38 Finished sending packets (total of 10)
+2952:  39 Finished sending packets (total of 10)
+2952:  40 Finished sending packets (total of 10)
+2952:  41 Finished sending packets (total of 10)
+2952:  42 Finished sending packets (total of 10)
+2952:  43 Finished sending packets (total of 10)
+2952:  44 Finished sending packets (total of 10)
+2952:  45 Finished sending packets (total of 10)
+2952:  46 Finished sending packets (total of 10)
+2952:  47 Finished sending packets (total of 10)
+2952:  48 Finished sending packets (total of 10)
+2952:  49 Finished sending packets (total of 10)
+2952:  50 Finished sending packets (total of 10)
+2952:  51 Finished sending packets (total of 10)
+2952:  52 Finished sending packets (total of 10)
+2952:  53 Finished sending packets (total of 10)
+2952:  54 Finished sending packets (total of 10)
+2952:  55 Finished sending packets (total of 10)
+2952:  56 Finished sending packets (total of 10)
+2952:  57 Finished sending packets (total of 10)
+2952:  58 Finished sending packets (total of 10)
+2952:  59 Finished sending packets (total of 10)
+2952:  60 Finished sending packets (total of 10)
+2952:  61 Finished sending packets (total of 10)
+2952:  62 Finished sending packets (total of 10)
+2952:  63 Finished sending packets (total of 10)
+2952:  64 Finished sending packets (total of 10)
+2952:  65 Finished sending packets (total of 10)
+2952:  66 Finished sending packets (total of 10)
+2952:  67 Finished sending packets (total of 10)
+2952:  68 Finished sending packets (total of 10)
+2952:  69 Finished sending packets (total of 10)
+2952:  70 Finished sending packets (total of 10)
+2952:  71 Finished sending packets (total of 10)
+2952:  72 Finished sending packets (total of 10)
+2952:  73 Finished sending packets (total of 10)
+2952:  74 Finished sending packets (total of 10)
+2952:  75 Finished sending packets (total of 10)
+2952:  76 Finished sending packets (total of 10)
+2952:  77 Finished sending packets (total of 10)
+2952:  78 Finished sending packets (total of 10)
+2952:  79 Finished sending packets (total of 10)
+2952:  80 Finished sending packets (total of 10)
+2952:  81 Finished sending packets (total of 10)
+2952:  82 Finished sending packets (total of 10)
+2952:  83 Finished sending packets (total of 10)
+2952:  84 Finished sending packets (total of 10)
+2952:  85 Finished sending packets (total of 10)
+2952:  86 Finished sending packets (total of 10)
+2952:  87 Finished sending packets (total of 10)
+2952:  88 Finished sending packets (total of 10)
+2952:  89 Finished sending packets (total of 10)
+2952:  90 Finished sending packets (total of 10)
+2952:  91 Finished sending packets (total of 10)
+2952:  92 Finished sending packets (total of 10)
+2952:  93 Finished sending packets (total of 10)
+2952:  94 Finished sending packets (total of 10)
+2952:  95 Finished sending packets (total of 10)
+2952:  96 Finished sending packets (total of 10)
+2952:  97 Finished sending packets (total of 10)
+2952:  98 Finished sending packets (total of 10)
+2952:  99 Finished sending packets (total of 10)
+2952:  100 Finished sending packets (total of 10)
+2952:  101 Finished sending packets (total of 10)
+2952:  102 Finished sending packets (total of 10)
+2952:  103 Finished sending packets (total of 10)
+2952:  104 Finished sending packets (total of 10)
+2952:  105 Finished sending packets (total of 10)
+2952:  106 Finished sending packets (total of 10)
+2952:  107 Finished sending packets (total of 10)
+2952:  108 Finished sending packets (total of 10)
+2952:  109 Finished sending packets (total of 10)
+2952:  110 Finished sending packets (total of 10)
+2952:  111 Finished sending packets (total of 10)
+2952:  112 Finished sending packets (total of 10)
+2952:  113 Finished sending packets (total of 10)
+2952:  114 Finished sending packets (total of 10)
+2952:  115 Finished sending packets (total of 10)
+2952:  116 Finished sending packets (total of 10)
+2952:  117 Finished sending packets (total of 10)
+2952:  118 Finished sending packets (total of 10)
+2952:  119 Finished sending packets (total of 10)
+2952:  120 Finished sending packets (total of 10)
+2952:  121 Finished sending packets (total of 10)
+2952:  122 Finished sending packets (total of 10)
+2952:  123 Finished sending packets (total of 10)
+2952:  124 Finished sending packets (total of 10)
+2952:  125 Finished sending packets (total of 10)
+2952:  126 Finished sending packets (total of 10)
+2952:  127 Finished sending packets (total of 10)
+2952:  128 Finished sending packets (total of 10)
+2952:  129 Finished sending packets (total of 10)
+2952:  130 Finished sending packets (total of 10)
+2952:  131 Finished sending packets (total of 10)
+2952:  132 Finished sending packets (total of 10)
+2952:  133 Finished sending packets (total of 10)
+2952:  134 Finished sending packets (total of 10)
+2952:  135 Finished sending packets (total of 10)
+2952:  136 Finished sending packets (total of 10)
+2952:  137 Finished sending packets (total of 10)
+2952:  138 Finished sending packets (total of 10)
+2952:  139 Finished sending packets (total of 10)
+2952:  140 Finished sending packets (total of 10)
+2952:  141 Finished sending packets (total of 10)
+2952:  142 Finished sending packets (total of 10)
+2952:  143 Finished sending packets (total of 10)
+2952:  144 Finished sending packets (total of 10)
+2952:  145 Finished sending packets (total of 10)
+2952:  146 Finished sending packets (total of 10)
+2952:  147 Finished sending packets (total of 10)
+2952:  148 Finished sending packets (total of 10)
+2952:  149 Finished sending packets (total of 10)
+2952:  150 Finished sending packets (total of 10)
+2952:  151 Finished sending packets (total of 10)
+2952:  152 Finished sending packets (total of 10)
+2952:  153 Finished sending packets (total of 10)
+2952:  154 Finished sending packets (total of 10)
+2952:  155 Finished sending packets (total of 10)
+2952:  156 Finished sending packets (total of 10)
+2952:  157 Finished sending packets (total of 10)
+2952:  158 Finished sending packets (total of 10)
+2952:  159 Finished sending packets (total of 10)
+5613: NIC 64 received all packets (total of 1600)!
+5622: NIC 72 received all packets (total of 1600)!
+5625: NIC 65 received all packets (total of 1600)!
+5626: NIC 139 received all packets (total of 1600)!
+5627: NIC 27 received all packets (total of 1600)!
+5630: NIC 26 received all packets (total of 1600)!
+5636: NIC 76 received all packets (total of 1600)!
+5640: NIC 84 received all packets (total of 1600)!
+5645: NIC 77 received all packets (total of 1600)!
+5645: NIC 130 received all packets (total of 1600)!
+5646: NIC 16 received all packets (total of 1600)!
+5647: NIC 22 received all packets (total of 1600)!
+5648: NIC 132 received all packets (total of 1600)!
+5651: NIC 45 received all packets (total of 1600)!
+5651: NIC 138 received all packets (total of 1600)!
+5652: NIC 79 received all packets (total of 1600)!
+5656: NIC 5 received all packets (total of 1600)!
+5657: NIC 52 received all packets (total of 1600)!
+5658: NIC 56 received all packets (total of 1600)!
+5659: NIC 32 received all packets (total of 1600)!
+5659: NIC 57 received all packets (total of 1600)!
+5659: NIC 83 received all packets (total of 1600)!
+5660: NIC 142 received all packets (total of 1600)!
+5662: NIC 85 received all packets (total of 1600)!
+5663: NIC 38 received all packets (total of 1600)!
+5667: NIC 39 received all packets (total of 1600)!
+5669: NIC 36 received all packets (total of 1600)!
+5670: NIC 33 received all packets (total of 1600)!
+5671: NIC 21 received all packets (total of 1600)!
+5671: NIC 34 received all packets (total of 1600)!
+5673: NIC 37 received all packets (total of 1600)!
+5674: NIC 35 received all packets (total of 1600)!
+5674: NIC 40 received all packets (total of 1600)!
+5674: NIC 144 received all packets (total of 1600)!
+5675: NIC 44 received all packets (total of 1600)!
+5676: NIC 1 received all packets (total of 1600)!
+5677: NIC 93 received all packets (total of 1600)!
+5677: NIC 129 received all packets (total of 1600)!
+5680: NIC 2 received all packets (total of 1600)!
+5681: NIC 133 received all packets (total of 1600)!
+5683: NIC 101 received all packets (total of 1600)!
+5683: NIC 119 received all packets (total of 1600)!
+5683: NIC 145 received all packets (total of 1600)!
+5684: NIC 25 received all packets (total of 1600)!
+5684: NIC 49 received all packets (total of 1600)!
+5685: NIC 28 received all packets (total of 1600)!
+5685: NIC 147 received all packets (total of 1600)!
+5686: NIC 4 received all packets (total of 1600)!
+5686: NIC 66 received all packets (total of 1600)!
+5686: NIC 94 received all packets (total of 1600)!
+5686: NIC 141 received all packets (total of 1600)!
+5687: NIC 9 received all packets (total of 1600)!
+5687: NIC 14 received all packets (total of 1600)!
+5687: NIC 46 received all packets (total of 1600)!
+5687: NIC 51 received all packets (total of 1600)!
+5687: NIC 62 received all packets (total of 1600)!
+5690: NIC 6 received all packets (total of 1600)!
+5690: NIC 10 received all packets (total of 1600)!
+5690: NIC 47 received all packets (total of 1600)!
+5690: NIC 63 received all packets (total of 1600)!
+5693: NIC 61 received all packets (total of 1600)!
+5694: NIC 53 received all packets (total of 1600)!
+5694: NIC 99 received all packets (total of 1600)!
+5694: NIC 102 received all packets (total of 1600)!
+5695: NIC 41 received all packets (total of 1600)!
+5696: NIC 54 received all packets (total of 1600)!
+5698: NIC 0 received all packets (total of 1600)!
+5698: NIC 42 received all packets (total of 1600)!
+5698: NIC 43 received all packets (total of 1600)!
+5699: NIC 12 received all packets (total of 1600)!
+5699: NIC 31 received all packets (total of 1600)!
+5699: NIC 48 received all packets (total of 1600)!
+5699: NIC 60 received all packets (total of 1600)!
+5699: NIC 82 received all packets (total of 1600)!
+5699: NIC 89 received all packets (total of 1600)!
+5699: NIC 146 received all packets (total of 1600)!
+5701: NIC 3 received all packets (total of 1600)!
+5701: NIC 7 received all packets (total of 1600)!
+5701: NIC 113 received all packets (total of 1600)!
+5702: NIC 13 received all packets (total of 1600)!
+5702: NIC 50 received all packets (total of 1600)!
+5702: NIC 92 received all packets (total of 1600)!
+5702: NIC 131 received all packets (total of 1600)!
+5703: NIC 15 received all packets (total of 1600)!
+5703: NIC 135 received all packets (total of 1600)!
+5705: NIC 8 received all packets (total of 1600)!
+5705: NIC 17 received all packets (total of 1600)!
+5705: NIC 55 received all packets (total of 1600)!
+5705: NIC 67 received all packets (total of 1600)!
+5706: NIC 70 received all packets (total of 1600)!
+5706: NIC 107 received all packets (total of 1600)!
+5706: NIC 136 received all packets (total of 1600)!
+5706: NIC 158 received all packets (total of 1600)!
+5707: NIC 11 received all packets (total of 1600)!
+5707: NIC 23 received all packets (total of 1600)!
+5707: NIC 58 received all packets (total of 1600)!
+5709: NIC 18 received all packets (total of 1600)!
+5709: NIC 24 received all packets (total of 1600)!
+5709: NIC 71 received all packets (total of 1600)!
+5709: NIC 74 received all packets (total of 1600)!
+5710: NIC 59 received all packets (total of 1600)!
+5711: NIC 19 received all packets (total of 1600)!
+5711: NIC 29 received all packets (total of 1600)!
+5711: NIC 112 received all packets (total of 1600)!
+5713: NIC 20 received all packets (total of 1600)!
+5714: NIC 30 received all packets (total of 1600)!
+5714: NIC 86 received all packets (total of 1600)!
+5714: NIC 137 received all packets (total of 1600)!
+5717: NIC 87 received all packets (total of 1600)!
+5719: NIC 90 received all packets (total of 1600)!
+5719: NIC 159 received all packets (total of 1600)!
+5721: NIC 68 received all packets (total of 1600)!
+5721: NIC 91 received all packets (total of 1600)!
+5723: NIC 69 received all packets (total of 1600)!
+5726: NIC 73 received all packets (total of 1600)!
+5728: NIC 100 received all packets (total of 1600)!
+5729: NIC 75 received all packets (total of 1600)!
+5730: NIC 78 received all packets (total of 1600)!
+5731: NIC 103 received all packets (total of 1600)!
+5731: NIC 154 received all packets (total of 1600)!
+5733: NIC 80 received all packets (total of 1600)!
+5735: NIC 81 received all packets (total of 1600)!
+5738: NIC 157 received all packets (total of 1600)!
+5741: NIC 88 received all packets (total of 1600)!
+5741: NIC 98 received all packets (total of 1600)!
+5742: NIC 95 received all packets (total of 1600)!
+5742: NIC 134 received all packets (total of 1600)!
+5743: NIC 140 received all packets (total of 1600)!
+5750: NIC 148 received all packets (total of 1600)!
+5751: NIC 109 received all packets (total of 1600)!
+5754: NIC 152 received all packets (total of 1600)!
+5755: NIC 96 received all packets (total of 1600)!
+5757: NIC 128 received all packets (total of 1600)!
+5757: NIC 153 received all packets (total of 1600)!
+5758: NIC 120 received all packets (total of 1600)!
+5759: NIC 97 received all packets (total of 1600)!
+5759: NIC 143 received all packets (total of 1600)!
+5761: NIC 121 received all packets (total of 1600)!
+5762: NIC 114 received all packets (total of 1600)!
+5763: NIC 149 received all packets (total of 1600)!
+5766: NIC 115 received all packets (total of 1600)!
+5766: NIC 150 received all packets (total of 1600)!
+5767: NIC 151 received all packets (total of 1600)!
+5770: NIC 155 received all packets (total of 1600)!
+5771: NIC 156 received all packets (total of 1600)!
+5774: NIC 122 received all packets (total of 1600)!
+5775: NIC 104 received all packets (total of 1600)!
+5779: NIC 125 received all packets (total of 1600)!
+5782: NIC 126 received all packets (total of 1600)!
+5784: NIC 110 received all packets (total of 1600)!
+5788: NIC 118 received all packets (total of 1600)!
+5795: NIC 105 received all packets (total of 1600)!
+5798: NIC 106 received all packets (total of 1600)!
+5799: NIC 108 received all packets (total of 1600)!
+5802: NIC 111 received all packets (total of 1600)!
+5803: NIC 116 received all packets (total of 1600)!
+5806: NIC 117 received all packets (total of 1600)!
+5807: NIC 123 received all packets (total of 1600)!
+5809: NIC 124 received all packets (total of 1600)!
+5811: NIC 127 received all packets (total of 1600)!
+6003: NIC 107 received all packets (total of 1280)!
+6037: NIC 97 received all packets (total of 1280)!
+6041: NIC 99 received all packets (total of 1280)!
+6049: NIC 105 received all packets (total of 1280)!
+6055: NIC 110 received all packets (total of 1280)!
+6063: NIC 113 received all packets (total of 1280)!
+6069: NIC 106 received all packets (total of 1280)!
+6073: NIC 109 received all packets (total of 1280)!
+6077: NIC 108 received all packets (total of 1280)!
+6078: NIC 118 received all packets (total of 1280)!
+6083: NIC 123 received all packets (total of 1280)!
+6083: NIC 124 received all packets (total of 1280)!
+6085: NIC 111 received all packets (total of 1280)!
+6091: NIC 122 received all packets (total of 1280)!
+6101: NIC 98 received all packets (total of 1280)!
+6103: NIC 96 received all packets (total of 1280)!
+6107: NIC 100 received all packets (total of 1280)!
+6110: NIC 101 received all packets (total of 1280)!
+6115: NIC 103 received all packets (total of 1280)!
+6118: NIC 102 received all packets (total of 1280)!
+6123: NIC 104 received all packets (total of 1280)!
+6125: NIC 114 received all packets (total of 1280)!
+6137: NIC 115 received all packets (total of 1280)!
+6154: NIC 112 received all packets (total of 1280)!
+6155: NIC 121 received all packets (total of 1280)!
+6158: NIC 116 received all packets (total of 1280)!
+6161: NIC 125 received all packets (total of 1280)!
+6162: NIC 117 received all packets (total of 1280)!
+6167: NIC 119 received all packets (total of 1280)!
+6169: NIC 78 received all packets (total of 1280)!
+6171: NIC 120 received all packets (total of 1280)!
+6171: NIC 126 received all packets (total of 1280)!
+6173: NIC 81 received all packets (total of 1280)!
+6177: NIC 127 received all packets (total of 1280)!
+6199: NIC 68 received all packets (total of 1280)!
+6217: NIC 74 received all packets (total of 1280)!
+6223: NIC 75 received all packets (total of 1280)!
+6225: NIC 84 received all packets (total of 1280)!
+6233: NIC 88 received all packets (total of 1280)!
+6234: NIC 70 received all packets (total of 1280)!
+6235: NIC 79 received all packets (total of 1280)!
+6239: NIC 16 received all packets (total of 1280)!
+6239: NIC 94 received all packets (total of 1280)!
+6243: NIC 80 received all packets (total of 1280)!
+6245: NIC 95 received all packets (total of 1280)!
+6251: NIC 71 received all packets (total of 1280)!
+6254: NIC 92 received all packets (total of 1280)!
+6255: NIC 93 received all packets (total of 1280)!
+6261: NIC 64 received all packets (total of 1280)!
+6263: NIC 65 received all packets (total of 1280)!
+6263: NIC 76 received all packets (total of 1280)!
+6271: NIC 66 received all packets (total of 1280)!
+6275: NIC 82 received all packets (total of 1280)!
+6277: NIC 67 received all packets (total of 1280)!
+6281: NIC 69 received all packets (total of 1280)!
+6286: NIC 85 received all packets (total of 1280)!
+6287: NIC 89 received all packets (total of 1280)!
+6293: NIC 72 received all packets (total of 1280)!
+6301: NIC 73 received all packets (total of 1280)!
+6302: NIC 90 received all packets (total of 1280)!
+6305: NIC 22 received all packets (total of 1280)!
+6305: NIC 91 received all packets (total of 1280)!
+6307: NIC 77 received all packets (total of 1280)!
+6309: NIC 0 received all packets (total of 1280)!
+6310: NIC 20 received all packets (total of 1280)!
+6311: NIC 83 received all packets (total of 1280)!
+6313: NIC 86 received all packets (total of 1280)!
+6314: NIC 23 received all packets (total of 1280)!
+6315: NIC 87 received all packets (total of 1280)!
+6327: NIC 11 received all packets (total of 1280)!
+6327: NIC 48 received all packets (total of 1280)!
+6333: NIC 5 received all packets (total of 1280)!
+6337: NIC 12 received all packets (total of 1280)!
+6341: NIC 31 received all packets (total of 1280)!
+6345: NIC 21 received all packets (total of 1280)!
+6347: NIC 13 received all packets (total of 1280)!
+6349: NIC 17 received all packets (total of 1280)!
+6367: NIC 25 received all packets (total of 1280)!
+6387: NIC 28 received all packets (total of 1280)!
+6391: NIC 4 received all packets (total of 1280)!
+6398: NIC 1 received all packets (total of 1280)!
+6398: NIC 10 received all packets (total of 1280)!
+6403: NIC 15 received all packets (total of 1280)!
+6405: NIC 2 received all packets (total of 1280)!
+6407: NIC 3 received all packets (total of 1280)!
+6411: NIC 24 received all packets (total of 1280)!
+6413: NIC 6 received all packets (total of 1280)!
+6414: NIC 26 received all packets (total of 1280)!
+6415: NIC 7 received all packets (total of 1280)!
+6419: NIC 27 received all packets (total of 1280)!
+6421: NIC 8 received all packets (total of 1280)!
+6423: NIC 9 received all packets (total of 1280)!
+6425: NIC 14 received all packets (total of 1280)!
+6426: NIC 18 received all packets (total of 1280)!
+6429: NIC 19 received all packets (total of 1280)!
+6431: NIC 29 received all packets (total of 1280)!
+6434: NIC 30 received all packets (total of 1280)!
+6455: NIC 46 received all packets (total of 1280)!
+6459: NIC 39 received all packets (total of 1280)!
+6464: NIC 59 received all packets (total of 1280)!
+6467: NIC 32 received all packets (total of 1280)!
+6474: NIC 45 received all packets (total of 1280)!
+6478: NIC 40 received all packets (total of 1280)!
+6479: NIC 35 received all packets (total of 1280)!
+6482: NIC 34 received all packets (total of 1280)!
+6488: NIC 36 received all packets (total of 1280)!
+6490: NIC 52 received all packets (total of 1280)!
+6493: NIC 37 received all packets (total of 1280)!
+6506: NIC 38 received all packets (total of 1280)!
+6511: NIC 57 received all packets (total of 1280)!
+6518: NIC 42 received all packets (total of 1280)!
+6519: NIC 58 received all packets (total of 1280)!
+6535: NIC 56 received all packets (total of 1280)!
+6543: NIC 49 received all packets (total of 1280)!
+6547: NIC 47 received all packets (total of 1280)!
+6552: NIC 50 received all packets (total of 1280)!
+6559: NIC 53 received all packets (total of 1280)!
+6564: NIC 54 received all packets (total of 1280)!
+6579: NIC 60 received all packets (total of 1280)!
+6582: NIC 61 received all packets (total of 1280)!
+6585: NIC 33 received all packets (total of 1280)!
+6586: NIC 41 received all packets (total of 1280)!
+6589: NIC 43 received all packets (total of 1280)!
+6591: NIC 44 received all packets (total of 1280)!
+6594: NIC 51 received all packets (total of 1280)!
+6595: NIC 55 received all packets (total of 1280)!
+6599: NIC 62 received all packets (total of 1280)!
+6602: NIC 63 received all packets (total of 1280)!
+Nic 127 had 1032 stalled cycles.
+Nic 126 had 1032 stalled cycles.
+Nic 125 had 1032 stalled cycles.
+Nic 124 had 1032 stalled cycles.
+Nic 123 had 1032 stalled cycles.
+Nic 122 had 1032 stalled cycles.
+Nic 121 had 1032 stalled cycles.
+Nic 120 had 1032 stalled cycles.
+Nic 119 had 1032 stalled cycles.
+Nic 118 had 1032 stalled cycles.
+Nic 117 had 1032 stalled cycles.
+Nic 116 had 1032 stalled cycles.
+Nic 115 had 1032 stalled cycles.
+Nic 114 had 1032 stalled cycles.
+Nic 113 had 1032 stalled cycles.
+Nic 112 had 1032 stalled cycles.
+Nic 111 had 1032 stalled cycles.
+Nic 110 had 1032 stalled cycles.
+Nic 109 had 1032 stalled cycles.
+Nic 108 had 1032 stalled cycles.
+Nic 107 had 1032 stalled cycles.
+Nic 106 had 1032 stalled cycles.
+Nic 105 had 1032 stalled cycles.
+Nic 104 had 1032 stalled cycles.
+Nic 103 had 1032 stalled cycles.
+Nic 102 had 1032 stalled cycles.
+Nic 101 had 1032 stalled cycles.
+Nic 100 had 1032 stalled cycles.
+Nic 99 had 1032 stalled cycles.
+Nic 98 had 1032 stalled cycles.
+Nic 97 had 1032 stalled cycles.
+Nic 96 had 1032 stalled cycles.
+Nic 95 had 1032 stalled cycles.
+Nic 94 had 1032 stalled cycles.
+Nic 93 had 1032 stalled cycles.
+Nic 92 had 1032 stalled cycles.
+Nic 91 had 1032 stalled cycles.
+Nic 90 had 1032 stalled cycles.
+Nic 89 had 1032 stalled cycles.
+Nic 88 had 1032 stalled cycles.
+Nic 87 had 1032 stalled cycles.
+Nic 86 had 1032 stalled cycles.
+Nic 85 had 1032 stalled cycles.
+Nic 84 had 1032 stalled cycles.
+Nic 83 had 1032 stalled cycles.
+Nic 82 had 1032 stalled cycles.
+Nic 81 had 1032 stalled cycles.
+Nic 80 had 1032 stalled cycles.
+Nic 79 had 1032 stalled cycles.
+Nic 78 had 1032 stalled cycles.
+Nic 77 had 1032 stalled cycles.
+Nic 76 had 1032 stalled cycles.
+Nic 75 had 1032 stalled cycles.
+Nic 74 had 1032 stalled cycles.
+Nic 73 had 1032 stalled cycles.
+Nic 72 had 1032 stalled cycles.
+Nic 71 had 1032 stalled cycles.
+Nic 70 had 1032 stalled cycles.
+Nic 69 had 1032 stalled cycles.
+Nic 68 had 1032 stalled cycles.
+Nic 67 had 1032 stalled cycles.
+Nic 66 had 1032 stalled cycles.
+Nic 65 had 1032 stalled cycles.
+Nic 64 had 1032 stalled cycles.
+Nic 63 had 1032 stalled cycles.
+Nic 62 had 1032 stalled cycles.
+Nic 61 had 1032 stalled cycles.
+Nic 60 had 1032 stalled cycles.
+Nic 59 had 1032 stalled cycles.
+Nic 58 had 1032 stalled cycles.
+Nic 57 had 1032 stalled cycles.
+Nic 56 had 1032 stalled cycles.
+Nic 55 had 1032 stalled cycles.
+Nic 54 had 1032 stalled cycles.
+Nic 53 had 1032 stalled cycles.
+Nic 52 had 1032 stalled cycles.
+Nic 51 had 1032 stalled cycles.
+Nic 50 had 1032 stalled cycles.
+Nic 49 had 1032 stalled cycles.
+Nic 48 had 1032 stalled cycles.
+Nic 47 had 1032 stalled cycles.
+Nic 46 had 1032 stalled cycles.
+Nic 45 had 1032 stalled cycles.
+Nic 44 had 1032 stalled cycles.
+Nic 43 had 1032 stalled cycles.
+Nic 42 had 1032 stalled cycles.
+Nic 41 had 1032 stalled cycles.
+Nic 40 had 1032 stalled cycles.
+Nic 39 had 1032 stalled cycles.
+Nic 38 had 1032 stalled cycles.
+Nic 37 had 1032 stalled cycles.
+Nic 36 had 1032 stalled cycles.
+Nic 35 had 1032 stalled cycles.
+Nic 34 had 1032 stalled cycles.
+Nic 33 had 1032 stalled cycles.
+Nic 32 had 1032 stalled cycles.
+Nic 31 had 1032 stalled cycles.
+Nic 30 had 1032 stalled cycles.
+Nic 29 had 1032 stalled cycles.
+Nic 28 had 1032 stalled cycles.
+Nic 27 had 1032 stalled cycles.
+Nic 26 had 1032 stalled cycles.
+Nic 25 had 1032 stalled cycles.
+Nic 24 had 1032 stalled cycles.
+Nic 23 had 1032 stalled cycles.
+Nic 22 had 1032 stalled cycles.
+Nic 21 had 1032 stalled cycles.
+Nic 20 had 1032 stalled cycles.
+Nic 19 had 1032 stalled cycles.
+Nic 18 had 1032 stalled cycles.
+Nic 17 had 1032 stalled cycles.
+Nic 16 had 1032 stalled cycles.
+Nic 15 had 1032 stalled cycles.
+Nic 14 had 1032 stalled cycles.
+Nic 13 had 1032 stalled cycles.
+Nic 12 had 1032 stalled cycles.
+Nic 11 had 1032 stalled cycles.
+Nic 10 had 1032 stalled cycles.
+Nic 9 had 1032 stalled cycles.
+Nic 8 had 1032 stalled cycles.
+Nic 7 had 1032 stalled cycles.
+Nic 6 had 1032 stalled cycles.
+Nic 5 had 1032 stalled cycles.
+Nic 4 had 1032 stalled cycles.
+Nic 3 had 1032 stalled cycles.
+Nic 2 had 1032 stalled cycles.
+Nic 1 had 1032 stalled cycles.
+Nic 0 had 1032 stalled cycles.
+Nic 159 had 1352 stalled cycles.
+Nic 158 had 1352 stalled cycles.
+Nic 157 had 1352 stalled cycles.
+Nic 156 had 1352 stalled cycles.
+Nic 155 had 1352 stalled cycles.
+Nic 154 had 1352 stalled cycles.
+Nic 153 had 1352 stalled cycles.
+Nic 152 had 1352 stalled cycles.
+Nic 151 had 1352 stalled cycles.
+Nic 150 had 1352 stalled cycles.
+Nic 149 had 1352 stalled cycles.
+Nic 148 had 1352 stalled cycles.
+Nic 147 had 1352 stalled cycles.
+Nic 146 had 1352 stalled cycles.
+Nic 145 had 1352 stalled cycles.
+Nic 144 had 1352 stalled cycles.
+Nic 143 had 1352 stalled cycles.
+Nic 142 had 1352 stalled cycles.
+Nic 141 had 1352 stalled cycles.
+Nic 140 had 1352 stalled cycles.
+Nic 139 had 1352 stalled cycles.
+Nic 138 had 1352 stalled cycles.
+Nic 137 had 1352 stalled cycles.
+Nic 136 had 1352 stalled cycles.
+Nic 135 had 1352 stalled cycles.
+Nic 134 had 1352 stalled cycles.
+Nic 133 had 1352 stalled cycles.
+Nic 132 had 1352 stalled cycles.
+Nic 131 had 1352 stalled cycles.
+Nic 130 had 1352 stalled cycles.
+Nic 129 had 1352 stalled cycles.
+Nic 128 had 1352 stalled cycles.
+Nic 127 had 1352 stalled cycles.
+Nic 126 had 1352 stalled cycles.
+Nic 125 had 1352 stalled cycles.
+Nic 124 had 1352 stalled cycles.
+Nic 123 had 1352 stalled cycles.
+Nic 122 had 1352 stalled cycles.
+Nic 121 had 1352 stalled cycles.
+Nic 120 had 1352 stalled cycles.
+Nic 119 had 1352 stalled cycles.
+Nic 118 had 1352 stalled cycles.
+Nic 117 had 1352 stalled cycles.
+Nic 116 had 1352 stalled cycles.
+Nic 115 had 1352 stalled cycles.
+Nic 114 had 1352 stalled cycles.
+Nic 113 had 1352 stalled cycles.
+Nic 112 had 1352 stalled cycles.
+Nic 111 had 1352 stalled cycles.
+Nic 110 had 1352 stalled cycles.
+Nic 109 had 1352 stalled cycles.
+Nic 108 had 1352 stalled cycles.
+Nic 107 had 1352 stalled cycles.
+Nic 106 had 1352 stalled cycles.
+Nic 105 had 1352 stalled cycles.
+Nic 104 had 1352 stalled cycles.
+Nic 103 had 1352 stalled cycles.
+Nic 102 had 1352 stalled cycles.
+Nic 101 had 1352 stalled cycles.
+Nic 100 had 1352 stalled cycles.
+Nic 99 had 1352 stalled cycles.
+Nic 98 had 1352 stalled cycles.
+Nic 97 had 1352 stalled cycles.
+Nic 96 had 1352 stalled cycles.
+Nic 95 had 1352 stalled cycles.
+Nic 94 had 1352 stalled cycles.
+Nic 93 had 1352 stalled cycles.
+Nic 92 had 1352 stalled cycles.
+Nic 91 had 1352 stalled cycles.
+Nic 90 had 1352 stalled cycles.
+Nic 89 had 1352 stalled cycles.
+Nic 88 had 1352 stalled cycles.
+Nic 87 had 1352 stalled cycles.
+Nic 86 had 1352 stalled cycles.
+Nic 85 had 1352 stalled cycles.
+Nic 84 had 1352 stalled cycles.
+Nic 83 had 1352 stalled cycles.
+Nic 82 had 1352 stalled cycles.
+Nic 81 had 1352 stalled cycles.
+Nic 80 had 1352 stalled cycles.
+Nic 79 had 1352 stalled cycles.
+Nic 78 had 1352 stalled cycles.
+Nic 77 had 1352 stalled cycles.
+Nic 76 had 1352 stalled cycles.
+Nic 75 had 1352 stalled cycles.
+Nic 74 had 1352 stalled cycles.
+Nic 73 had 1352 stalled cycles.
+Nic 72 had 1352 stalled cycles.
+Nic 71 had 1352 stalled cycles.
+Nic 70 had 1352 stalled cycles.
+Nic 69 had 1352 stalled cycles.
+Nic 68 had 1352 stalled cycles.
+Nic 67 had 1352 stalled cycles.
+Nic 66 had 1352 stalled cycles.
+Nic 65 had 1352 stalled cycles.
+Nic 64 had 1352 stalled cycles.
+Nic 63 had 1352 stalled cycles.
+Nic 62 had 1352 stalled cycles.
+Nic 61 had 1352 stalled cycles.
+Nic 60 had 1352 stalled cycles.
+Nic 59 had 1352 stalled cycles.
+Nic 58 had 1352 stalled cycles.
+Nic 57 had 1352 stalled cycles.
+Nic 56 had 1352 stalled cycles.
+Nic 55 had 1352 stalled cycles.
+Nic 54 had 1352 stalled cycles.
+Nic 53 had 1352 stalled cycles.
+Nic 52 had 1352 stalled cycles.
+Nic 51 had 1352 stalled cycles.
+Nic 50 had 1352 stalled cycles.
+Nic 49 had 1352 stalled cycles.
+Nic 48 had 1352 stalled cycles.
+Nic 47 had 1352 stalled cycles.
+Nic 46 had 1352 stalled cycles.
+Nic 45 had 1352 stalled cycles.
+Nic 44 had 1352 stalled cycles.
+Nic 43 had 1352 stalled cycles.
+Nic 42 had 1352 stalled cycles.
+Nic 41 had 1352 stalled cycles.
+Nic 40 had 1352 stalled cycles.
+Nic 39 had 1352 stalled cycles.
+Nic 38 had 1352 stalled cycles.
+Nic 37 had 1352 stalled cycles.
+Nic 36 had 1352 stalled cycles.
+Nic 35 had 1352 stalled cycles.
+Nic 34 had 1352 stalled cycles.
+Nic 33 had 1352 stalled cycles.
+Nic 32 had 1352 stalled cycles.
+Nic 31 had 1352 stalled cycles.
+Nic 30 had 1352 stalled cycles.
+Nic 29 had 1352 stalled cycles.
+Nic 28 had 1352 stalled cycles.
+Nic 27 had 1352 stalled cycles.
+Nic 26 had 1352 stalled cycles.
+Nic 25 had 1352 stalled cycles.
+Nic 24 had 1352 stalled cycles.
+Nic 23 had 1352 stalled cycles.
+Nic 22 had 1352 stalled cycles.
+Nic 21 had 1352 stalled cycles.
+Nic 20 had 1352 stalled cycles.
+Nic 19 had 1352 stalled cycles.
+Nic 18 had 1352 stalled cycles.
+Nic 17 had 1352 stalled cycles.
+Nic 16 had 1352 stalled cycles.
+Nic 15 had 1352 stalled cycles.
+Nic 14 had 1352 stalled cycles.
+Nic 13 had 1352 stalled cycles.
+Nic 12 had 1352 stalled cycles.
+Nic 11 had 1352 stalled cycles.
+Nic 10 had 1352 stalled cycles.
+Nic 9 had 1352 stalled cycles.
+Nic 8 had 1352 stalled cycles.
+Nic 7 had 1352 stalled cycles.
+Nic 6 had 1352 stalled cycles.
+Nic 5 had 1352 stalled cycles.
+Nic 4 had 1352 stalled cycles.
+Nic 3 had 1352 stalled cycles.
+Nic 2 had 1352 stalled cycles.
+Nic 1 had 1352 stalled cycles.
+Nic 0 had 1352 stalled cycles.
+Simulation is complete, simulated time: 6.602 us

--- a/src/sst/elements/merlin/tests/testsuite_default_merlin.py
+++ b/src/sst/elements/merlin/tests/testsuite_default_merlin.py
@@ -86,6 +86,9 @@ class testcase_merlin_Component(SSTTestCase):
     def test_merlin_dragon_128_fl(self):
         self.merlin_test_template("dragon_128_test_fl")
 
+    def test_merlin_dragon_128_deferred(self):
+        self.merlin_test_template("dragon_128_test_deferred")
+
 
     @unittest.skipIf(not(('sympy.polys.galoistools' in sys.modules) and ('sympy.polys.domains' in sys.modules)), "Polarfly construction requires sympy")
     def test_merlin_polarfly_455(self):

--- a/src/sst/elements/merlin/topology/dragonfly.cc
+++ b/src/sst/elements/merlin/topology/dragonfly.cc
@@ -30,7 +30,7 @@ using namespace SST::Merlin;
 
 
 void
-RouteToGroup::init_write(const std::string& basename, int group_id, global_route_mode_t route_mode,
+RouteToGroup::init_write(std::string basename, int group_id, global_route_mode_t route_mode,
                          const dgnflyParams& params, const std::vector<int64_t>& global_link_map,
                          bool config_failed_links, const std::vector<FailedLink>& failed_links_vec)
 {
@@ -120,7 +120,7 @@ RouteToGroup::init_write(const std::string& basename, int group_id, global_route
 }
 
 void
-RouteToGroup::init(const std::string& basename, int group_id, global_route_mode_t route_mode,
+RouteToGroup::init(std::string basename, int group_id, global_route_mode_t route_mode,
                    const dgnflyParams& params, bool config_failed_links)
 {
     data.initialize(basename+"group_to_global_port");
@@ -240,6 +240,9 @@ topo_dragonfly::topo_dragonfly(ComponentId_t cid, Params &p, int num_ports, int 
     params.n = p.find<uint32_t>("intergroup_links");
     params.m = p.find<uint32_t>("intragroup_links", 1);
 
+    std::string prefix = p.find<std::string>("network_name","network");
+    prefix += "_";
+
     global_start = params.p + ((params.a - 1) * params.m);
 
     group_id = rtr_id / params.a;
@@ -278,11 +281,11 @@ topo_dragonfly::topo_dragonfly(ComponentId_t cid, Params &p, int num_ports, int 
 
         std::vector<FailedLink> failed_links;
         p.find_array<FailedLink>("failed_links", failed_links);
-        group_to_global_port.init_write("network_", group_id, global_route_mode, params, global_link_map,
+        group_to_global_port.init_write(prefix, group_id, global_route_mode, params, global_link_map,
                                         config_failed_links, failed_links);
     }
     else {
-        group_to_global_port.init("network_", group_id, global_route_mode, params, config_failed_links);
+        group_to_global_port.init(prefix, group_id, global_route_mode, params, config_failed_links);
     }
 
     // Setup the routing algorithms

--- a/src/sst/elements/merlin/topology/dragonfly.h
+++ b/src/sst/elements/merlin/topology/dragonfly.h
@@ -139,12 +139,11 @@ private:
 public:
     RouteToGroup() {}
 
-    // void init(SharedRegion* sr, size_t g, size_t r);
-    void init_write(const std::string& basename, int group_id, global_route_mode_t route_mode,
+    void init_write(std::string basename, int group_id, global_route_mode_t route_mode,
                     const dgnflyParams& params, const std::vector<int64_t>& global_link_map,
                     bool config_failed_links, const std::vector<FailedLink>& failed_links);
 
-    void init(const std::string& basename, int group_id, global_route_mode_t route_mode,
+    void init(std::string basename, int group_id, global_route_mode_t route_mode,
               const dgnflyParams& params, bool config_failed_links);
 
     const RouterPortPair& getRouterPortPair(int group, int route_number) const;
@@ -200,6 +199,7 @@ public:
         {"dragonfly.global_link_map",       "Array specifying connectivity of global links in each dragonfly group."},
         {"dragonfly.global_route_mode",     "Mode for intepreting global link map [absolute (default) | relative].","absolute"},
 
+        {"network_name",          "Name of the network", "network"},
         {"hosts_per_router",      "Number of hosts connected to each router."},
         {"routers_per_group",     "Number of links used to connect to routers in same group."},
         {"intergroup_per_router", "Number of links per router connected to other groups."},

--- a/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
@@ -106,14 +106,14 @@ class topoFatTree(Topology):
             
     
     def getRouterNameForLocation(self,location):
-        return "%srtr_l%s_g%d_r%d"%(self._prefix,location[0],location[1],location[2])
+        return "rtr_l%s_g%d_r%d"%(location[0],location[1],location[2])
     
     def findRouterByLocation(self,location):
         return sst.findComponentByName(self.getRouterNameForLocation(location));
     
     
     
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
 
         if not self.host_link_latency:
             self.host_link_latency = self.link_latency

--- a/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
@@ -101,13 +101,13 @@ class topoHyperX(Topology):
         return self.getRouterNameForLocation(self._idToLoc(rtr_id))
         
     def getRouterNameForLocation(self,location):
-        return "%srtr_%s"%(self._prefix,self._formatShape(location))
+        return "rtr_%s"%(self._formatShape(location))
     
     def findRouterByLocation(self,location):
         return sst.findComponentByName(self.getRouterNameForLocation(location))
         
     
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
         if self.host_link_latency is None:
             self.host_link_latency = self.link_latency
 

--- a/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
@@ -101,12 +101,12 @@ class _topoMeshBase(Topology):
         return self.getRouterNameForLocation(self._idToLoc(rtr_id))
         
     def getRouterNameForLocation(self,location):
-        return "%srtr_%s"%(self._prefix,self._formatShape(location))
+        return "rtr_%s"%(self._formatShape(location))
     
     def findRouterByLocation(self,location):
         return sst.findComponentByName(self.getRouterNameForLocation(location))
         
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
         if self.host_link_latency is None:
             self.host_link_latency = self.link_latency
         
@@ -228,9 +228,9 @@ class topoSingle(Topology):
         return self.num_ports
 
     def getRouterNameForId(self,rtr_id):
-        return "%srouter"%self._prefix
+        return "router"
         
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
         rtr = self._instanceRouter(self.num_ports,0)
 
         topo = rtr.setSubComponent(self.router.getTopologySlotName(),"merlin.singlerouter",0)

--- a/src/sst/elements/merlin/topology/pymerlin-topo-polarfly.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-polarfly.py
@@ -419,7 +419,7 @@ class topoPolarFly(Topology):
                 print( " ".join(str(e) for e in node) + " ", file=f)
         
 
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
         if self._check_first_build():
             sst.addGlobalParams("params_%s"%self._instance_name, self._getGroupParams("main"))
 

--- a/src/sst/elements/merlin/topology/pymerlin-topo-polarstar.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-polarstar.py
@@ -610,7 +610,7 @@ class topoPolarStar(Topology):
         return adj_ps
     
     
-    def build(self, endpoint):
+    def _build_impl(self, endpoint):
 
         if self._check_first_build():
             sst.addGlobalParams("params_%s"%self._instance_name, self._getGroupParams("main"))


### PR DESCRIPTION
Changed merlin python topology builders so that they call pushNamePrefix() with the network name and added deferred build to System object so you can build without endpoints and get the links later to connect.
