### PR TITLE
set simdopwidth for ARIEL_START_INSTRUCTION to fix bug with stats

### DIFF
--- a/src/sst/elements/ariel/frontend/pin3/fesimple.cc
+++ b/src/sst/elements/ariel/frontend/pin3/fesimple.cc
@@ -402,11 +402,12 @@ VOID WriteInstructionWrite(ADDRINT* address, UINT32 writeSize, THREADID thr, ADD
     tunnel->writeMessage(thr, ac);
 }
 
-VOID WriteStartInstructionMarker(UINT32 thr, ADDRINT ip)
+VOID WriteStartInstructionMarker(UINT32 thr, ADDRINT ip, UINT32 simdOpWidth)
 {
     ArielCommand ac;
     ac.command = ARIEL_START_INSTRUCTION;
     ac.instPtr = (uint64_t) ip;
+    ac.inst.simdElemCount = simdOpWidth;
     tunnel->writeMessage(thr, ac);
 }
 
@@ -425,7 +426,7 @@ VOID WriteInstructionReadWrite(THREADID thr, ADDRINT* readAddr, UINT32 readSize,
 
     if(enable_output) {
         if(thr < core_count) {
-            WriteStartInstructionMarker( thr, ip );
+            WriteStartInstructionMarker( thr, ip, simdOpWidth);
             WriteInstructionRead(  readAddr,  readSize,  thr, ip, instClass, simdOpWidth );
             WriteInstructionWrite( writeAddr, writeSize, thr, ip, instClass, simdOpWidth );
             WriteEndInstructionMarker( thr, ip );
@@ -440,7 +441,7 @@ VOID WriteInstructionReadOnly(THREADID thr, ADDRINT* readAddr, UINT32 readSize, 
     if(enable_output) {
         if(thr < core_count) {
             if (first)
-                WriteStartInstructionMarker(thr, ip);
+                WriteStartInstructionMarker(thr, ip, simdOpWidth);
             WriteInstructionRead(  readAddr,  readSize,  thr, ip, instClass, simdOpWidth );
             if (last)
                 WriteEndInstructionMarker(thr, ip);
@@ -468,7 +469,7 @@ VOID WriteInstructionWriteOnly(THREADID thr, ADDRINT* writeAddr, UINT32 writeSiz
     if(enable_output) {
         if(thr < core_count) {
             if (first)
-                WriteStartInstructionMarker(thr, ip);
+                WriteStartInstructionMarker(thr, ip, simdOpWidth);
             WriteInstructionWrite(writeAddr, writeSize,  thr, ip, instClass, simdOpWidth);
             if (last)
                 WriteEndInstructionMarker(thr, ip);


### PR DESCRIPTION
Fixes #2327 by setting simdElemCount when ARIEL_START_INSTRUCTION is created.