### PR TITLE
remove initializeClass() method

### DIFF
--- a/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
@@ -30,11 +30,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Ariel(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
@@ -32,11 +32,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Ariel(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/balar/tests/testsuite_default_balar.py
+++ b/src/sst/elements/balar/tests/testsuite_default_balar.py
@@ -28,11 +28,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_balar(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
+++ b/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_cacheTracer_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
+++ b/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_cassini_prefetch(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/cramSim/tests/testsuite_default_cramSim.py
+++ b/src/sst/elements/cramSim/tests/testsuite_default_cramSim.py
@@ -32,11 +32,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_cramSim_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
@@ -95,11 +95,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Ember_ESshmem(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/ember/tests/testsuite_default_ember_nightly.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_nightly.py
@@ -30,11 +30,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_EmberNightly(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/ember/tests/testsuite_default_ember_qos.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_qos.py
@@ -29,11 +29,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_QOS(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
@@ -156,11 +156,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_EmberSweep(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/gensa/tests/testsuite_default_gensa.py
+++ b/src/sst/elements/gensa/tests/testsuite_default_gensa.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_gensa_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/kingsley/tests/testsuite_default_kingsley.py
+++ b/src/sst/elements/kingsley/tests/testsuite_default_kingsley.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_kingsley_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/llyr/tests/testsuite_default_llyr.py
+++ b/src/sst/elements/llyr/tests/testsuite_default_llyr.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_llyr_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_hybridsim.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_hybridsim.py
@@ -30,11 +30,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memHierarchy_hybridsim(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
@@ -31,11 +31,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memHierarchy_memHA(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
@@ -33,11 +33,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memHierarchy_memHSieve(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_sdl.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_sdl.py
@@ -30,11 +30,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memHierarchy_sdl(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_openMP_diropenMP(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_openMP_noncacheable(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_openMP_openMP(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
@@ -166,11 +166,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
@@ -141,11 +141,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_sweep_dirsweep(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
@@ -143,11 +143,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_sweep_dirsweepB(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
@@ -143,11 +143,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_sweep_dirsweepI(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
@@ -141,11 +141,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_memH_sweep_openMP(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/merlin/tests/testsuite_default_merlin.py
+++ b/src/sst/elements/merlin/tests/testsuite_default_merlin.py
@@ -36,11 +36,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_merlin_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/messier/tests/testsuite_default_Messier.py
+++ b/src/sst/elements/messier/tests/testsuite_default_Messier.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Messier_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_miranda_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -38,11 +38,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_prospero(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
+++ b/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
@@ -84,11 +84,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_rdmaNic(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/samba/tests/testsuite_default_Samba.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_Samba_Component(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/shogun/tests/testsuite_default_shogun.py
+++ b/src/sst/elements/shogun/tests/testsuite_default_shogun.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_shogun(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -145,11 +145,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_vanadis(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/vaultsim/tests/testsuite_default_VaultSim.py
+++ b/src/sst/elements/vaultsim/tests/testsuite_default_VaultSim.py
@@ -27,11 +27,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_VaultSim(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)

--- a/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
+++ b/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
@@ -32,11 +32,6 @@ def initializeTestModule_SingleInstance(class_inst):
 
 class testcase_SiriusZodiacTrace(SSTTestCase):
 
-    def initializeClass(self, testName):
-        super(type(self), self).initializeClass(testName)
-        # Put test based setup code here. it is called before testing starts
-        # NOTE: This method is called once for every test
-
     def setUp(self):
         super(type(self), self).setUp()
         initializeTestModule_SingleInstance(self)


### PR DESCRIPTION
`initializeClass()` is never used across any of our testing. Its functionality is replicated by `setUpClass()` which is a standard pattern used by unittest.
