### PR TITLE
Remove redundant initializeTestModule_SingleInstance() methods

### DIFF
--- a/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
@@ -4,29 +4,6 @@ from sst_unittest import *
 from sst_unittest_support import *
 import os
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setup_ariel_test_files()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
 
 class testcase_Ariel(SSTTestCase):
 
@@ -37,8 +14,8 @@ class testcase_Ariel(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setup_ariel_test_files()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
@@ -5,30 +5,6 @@ from sst_unittest_support import *
 import os
 import inspect
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setup_ariel_test_files()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
-
 
 class testcase_Ariel(SSTTestCase):
 
@@ -39,8 +15,8 @@ class testcase_Ariel(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setup_ariel_test_files()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/balar/tests/testsuite_default_balar.py
+++ b/src/sst/elements/balar/tests/testsuite_default_balar.py
@@ -6,25 +6,6 @@ from sst_unittest_support import *
 import os
 import shutil
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        # Put your single instance Init Code Here
-        class_inst._setupbalarTestFiles()
-        module_init = 1
-
-    module_sema.release()
-
-################################################################################
 
 class testcase_balar(SSTTestCase):
 
@@ -35,7 +16,7 @@ class testcase_balar(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupbalarTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
+++ b/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
@@ -3,14 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-
-################################################################################
 
 class testcase_cacheTracer_Component(SSTTestCase):
 

--- a/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
+++ b/src/sst/elements/cacheTracer/tests/testsuite_default_cacheTracer.py
@@ -9,19 +9,6 @@ from sst_unittest_support import *
 module_init = 0
 module_sema = threading.Semaphore()
 
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
 
 ################################################################################
 
@@ -34,7 +21,6 @@ class testcase_cacheTracer_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
+++ b/src/sst/elements/cassini/tests/testsuite_default_cassini_prefetch.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_cassini_prefetch(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_cassini_prefetch(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/cramSim/tests/testsuite_default_cramSim.py
+++ b/src/sst/elements/cramSim/tests/testsuite_default_cramSim.py
@@ -6,29 +6,6 @@ from sst_unittest_support import *
 import os
 import shutil
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupcramSimTestFiles()
-            module_init = 1
-        except:
-            pass
-        module_init = 1
-
-    module_sema.release()
-
-################################################################################
 
 class testcase_cramSim_Component(SSTTestCase):
 
@@ -39,7 +16,7 @@ class testcase_cramSim_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupcramSimTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
@@ -74,24 +74,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[1])))
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupESshmemTestFiles()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Ember_ESshmem(SSTTestCase):
 
@@ -102,7 +84,7 @@ class testcase_Ember_ESshmem(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupESshmemTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/ember/tests/testsuite_default_ember_nightly.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_nightly.py
@@ -5,28 +5,6 @@ from sst_unittest_support import *
 
 import os
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._cleanupEmberTestFiles()
-            class_inst._setupEmberTestFiles()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_EmberNightly(SSTTestCase):
 
@@ -37,7 +15,8 @@ class testcase_EmberNightly(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._cleanupEmberTestFiles()
+        self._setupEmberTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/ember/tests/testsuite_default_ember_qos.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_qos.py
@@ -5,27 +5,6 @@ from sst_unittest_support import *
 
 import os
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupQOSTestFiles()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_QOS(SSTTestCase):
 
@@ -36,7 +15,7 @@ class testcase_QOS(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupQOSTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
@@ -135,24 +135,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[1])))
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupEmberTestFiles()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_EmberSweep(SSTTestCase):
 
@@ -163,7 +145,7 @@ class testcase_EmberSweep(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupEmberTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/gensa/tests/testsuite_default_gensa.py
+++ b/src/sst/elements/gensa/tests/testsuite_default_gensa.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_gensa_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_gensa_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/kingsley/tests/testsuite_default_kingsley.py
+++ b/src/sst/elements/kingsley/tests/testsuite_default_kingsley.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_kingsley_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_kingsley_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/llyr/tests/testsuite_default_llyr.py
+++ b/src/sst/elements/llyr/tests/testsuite_default_llyr.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_llyr_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_llyr_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_hybridsim.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_hybridsim.py
@@ -4,29 +4,6 @@ from sst_unittest import *
 from sst_unittest_support import *
 import os
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
 
 class testcase_memHierarchy_hybridsim(SSTTestCase):
 
@@ -37,7 +14,6 @@ class testcase_memHierarchy_hybridsim(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
@@ -5,27 +5,7 @@ from sst_unittest_support import *
 import os.path
 import re
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
 
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 ################################################################################
 ################################################################################
 
@@ -38,7 +18,6 @@ class testcase_memHierarchy_memHA(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
@@ -7,29 +7,6 @@ import shutil
 import fnmatch
 import csv
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setup_sieve_test_files()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
 
 class testcase_memHierarchy_memHSieve(SSTTestCase):
 
@@ -40,8 +17,8 @@ class testcase_memHierarchy_memHSieve(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setup_sieve_test_files()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_sdl.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_sdl.py
@@ -4,29 +4,6 @@ from sst_unittest import *
 from sst_unittest_support import *
 import os.path
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
 
 class testcase_memHierarchy_sdl(SSTTestCase):
 
@@ -37,7 +14,6 @@ class testcase_memHierarchy_sdl(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-module_init = 0
-module_sema = threading.Semaphore()
-
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-module_init = 0
-module_sema = threading.Semaphore()
-
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_openMP_diropenMP(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
@@ -6,24 +6,6 @@ from sst_unittest_support import *
 module_init = 0
 module_sema = threading.Semaphore()
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_openMP_noncacheable(SSTTestCase):
 
@@ -34,7 +16,6 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-module_init = 0
-module_sema = threading.Semaphore()
-
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_openMP_openMP(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_memH_openMP_openMP(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
@@ -145,24 +145,6 @@ def gen_custom_name(testcase_func, param_num, param):
         )
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
 
@@ -173,7 +155,6 @@ class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
@@ -120,24 +120,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[9])))           # prefetch
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_sweep_dirsweep(SSTTestCase):
 
@@ -148,7 +130,6 @@ class testcase_memH_sweep_dirsweep(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
@@ -10,8 +10,6 @@ import datetime
 
 dirpath = os.path.dirname(sys.modules[__name__].__file__)
 
-module_init = 0
-module_sema = threading.Semaphore()
 sweep_test_matrix = []
 
 ################################################################################
@@ -122,24 +120,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[9])))           # prefetch
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_sweep_dirsweepB(SSTTestCase):
 
@@ -150,7 +130,6 @@ class testcase_memH_sweep_dirsweepB(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
@@ -122,24 +122,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[9])))           # prefetch
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_sweep_dirsweepI(SSTTestCase):
 
@@ -150,7 +132,6 @@ class testcase_memH_sweep_dirsweepI(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
@@ -120,24 +120,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[9])))           # prefetch
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_memH_sweep_openMP(SSTTestCase):
 
@@ -148,7 +130,6 @@ class testcase_memH_sweep_openMP(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/merlin/tests/testsuite_default_merlin.py
+++ b/src/sst/elements/merlin/tests/testsuite_default_merlin.py
@@ -12,27 +12,6 @@ try:
 except:
     pass
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_merlin_Component(SSTTestCase):
 
@@ -43,7 +22,6 @@ class testcase_merlin_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/messier/tests/testsuite_default_Messier.py
+++ b/src/sst/elements/messier/tests/testsuite_default_Messier.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Messier_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_Messier_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_miranda_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_miranda_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -10,31 +10,6 @@ USE_TAR_TRACES = False
 WITH_TIMINGDRAM = True
 NO_TIMINGDRAM = False
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setup_prospero_test_dirs()
-            class_inst._create_prospero_PIN_trace_files()
-            class_inst._download_prospero_TAR_trace_files()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
-################################################################################
-################################################################################
 
 class testcase_prospero(SSTTestCase):
 
@@ -45,8 +20,10 @@ class testcase_prospero(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setup_prospero_test_dirs()
+        self._create_prospero_PIN_trace_files()
+        self._download_prospero_TAR_trace_files()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
+++ b/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
@@ -63,24 +63,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[1])))
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupRdmaNicTestFiles()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_rdmaNic(SSTTestCase):
 
@@ -91,8 +73,8 @@ class testcase_rdmaNic(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setupRdmaNicTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/samba/tests/testsuite_default_Samba.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_Samba_Component(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_Samba_Component(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/shogun/tests/testsuite_default_shogun.py
+++ b/src/sst/elements/shogun/tests/testsuite_default_shogun.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_shogun(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_shogun(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -124,24 +124,6 @@ def gen_custom_name(testcase_func, param_num, param):
         parameterized.to_safe_name(str(param.args[1])))
     return testcasename
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupTests()
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_vanadis(SSTTestCase):
 
@@ -152,8 +134,8 @@ class testcase_vanadis(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
+        self._setupTests()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test

--- a/src/sst/elements/vaultsim/tests/testsuite_default_VaultSim.py
+++ b/src/sst/elements/vaultsim/tests/testsuite_default_VaultSim.py
@@ -3,27 +3,6 @@
 from sst_unittest import *
 from sst_unittest_support import *
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            pass
-        except:
-            pass
-        module_init = 1
-    module_sema.release()
-
-################################################################################
 
 class testcase_VaultSim(SSTTestCase):
 
@@ -34,7 +13,6 @@ class testcase_VaultSim(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
         # Put test based setup code here. it is called once before every test
 
     def tearDown(self):

--- a/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
+++ b/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
@@ -6,29 +6,6 @@ from sst_unittest_support import *
 #import os
 #import shutil
 
-################################################################################
-# Code to support a single instance module initialize, must be called setUp method
-
-module_init = 0
-module_sema = threading.Semaphore()
-
-def initializeTestModule_SingleInstance(class_inst):
-    global module_init
-    global module_sema
-
-    module_sema.acquire()
-    if module_init != 1:
-        try:
-            # Put your single instance Init Code Here
-            class_inst._setupSiriusZodiacTraceTestFiles()
-            module_init = 1
-        except:
-            pass
-        module_init = 1
-
-    module_sema.release()
-
-################################################################################
 
 class testcase_SiriusZodiacTrace(SSTTestCase):
 
@@ -39,7 +16,7 @@ class testcase_SiriusZodiacTrace(SSTTestCase):
 
     def setUp(self):
         super(type(self), self).setUp()
-        initializeTestModule_SingleInstance(self)
+        self._setupSiriusZodiacTraceTestFiles()
 
     def tearDown(self):
         # Put test based teardown code here. it is called once after every test


### PR DESCRIPTION
`initializeTestModule_SingleInstance()` is mostly unnecessary boilerplate code.  Remove those methods and move the few instances where something is called to the `setUp()` method.
