### PR TITLE
mask-mpi: add missing collectives

### DIFF
--- a/src/sst/elements/iris/sumi/allgather.h
+++ b/src/sst/elements/iris/sumi/allgather.h
@@ -56,10 +56,6 @@ namespace SST::Iris::sumi {
 class AllgatherCollective : public DagCollective
 {
  public:
-//FIXME
-//  SPKT_DECLARE_BASE(AllgatherCollective)
-//  SPKT_DECLARE_CTOR(CollectiveEngine*, void*, void*,
-//                    int, int, int, int, Communicator*)
 
  protected:
   AllgatherCollective(CollectiveEngine* engine, void* dst, void* src,
@@ -111,13 +107,6 @@ class BruckAllgatherCollective :
   public AllgatherCollective
 {
  public:
-//FIXME
-//  SPKT_REGISTER_DERIVED(
-//    AllgatherCollective,
-//    BruckAllgatherCollective,
-//    "macro",
-//    "bruck",
-//    "Bruck log(N) allgather collective")
 
   BruckAllgatherCollective(CollectiveEngine* engine, void* dst, void* src,
                   int nelems, int type_size, int tag, int cq_id, Communicator* comm)
@@ -184,13 +173,6 @@ class RingAllgatherCollective :
   public AllgatherCollective
 {
  public:
-//FIXME
-//  SPKT_REGISTER_DERIVED(
-//    AllgatherCollective,
-//    RingAllgatherCollective,
-//    "macro",
-//    "ring",
-//    "O(N) ring allgather collective")
 
   RingAllgatherCollective(CollectiveEngine* engine, void* dst, void* src,
                           int nelems, int type_size, int tag, int cq_id, Communicator* comm)

--- a/src/sst/elements/iris/sumi/alltoall.h
+++ b/src/sst/elements/iris/sumi/alltoall.h
@@ -48,17 +48,12 @@ Questions? Contact sst-macro-help@sandia.gov
 #include <iris/sumi/collective_actor.h>
 #include <iris/sumi/collective_message.h>
 #include <iris/sumi/comm_functions.h>
-//#include <mercury/common/factory.h>
 #include <sst/core/eli/elementbuilder.h>
 
 namespace SST::Iris::sumi {
 
 class AllToAllCollective : public DagCollective {
  public:
-//FIXME
-//  SPKT_DECLARE_BASE(AllToAllCollective)
-//  SPKT_DECLARE_CTOR(CollectiveEngine*, void*, void*,
-//                    int, int, int, int, Communicator*)
 
   AllToAllCollective(CollectiveEngine* engine, void* dst, void* src,
                      int nelems, int type_size, int tag, int cq_id,
@@ -107,13 +102,6 @@ class BruckAlltoallCollective :
   public AllToAllCollective
 {
  public:
-//FIXME
-//  SPKT_REGISTER_DERIVED(
-//    AllToAllCollective,
-//    BruckAlltoallCollective,
-//    "macro",
-//    "bruck",
-//    "Bruck log(N) all-to-all collective")
 
   BruckAlltoallCollective(CollectiveEngine* engine, void* dst, void* src,
                             int nelems, int type_size, int tag, int cq_id, Communicator* comm)
@@ -173,13 +161,6 @@ class DirectAlltoallCollective :
   public AllToAllCollective
 {
  public:
-//FIXME
-//  SPKT_REGISTER_DERIVED(
-//    AllToAllCollective,
-//    DirectAlltoallCollective,
-//    "macro",
-//    "direct",
-//    "direct all-to-all collective")
 
     DirectAlltoallCollective(CollectiveEngine* engine, void *dst, void *src, int nelems,
                               int type_size, int tag, int cq_id, Communicator* comm) :

--- a/src/sst/elements/iris/sumi/sim_transport.cc
+++ b/src/sst/elements/iris/sumi/sim_transport.cc
@@ -332,12 +332,14 @@ SimTransport::memcopy(void* dst, void* src, uint64_t bytes)
   if (isNonNullBuffer(dst) && isNonNullBuffer(src)){
     ::memcpy(dst, src, bytes);
   }
+  //FIXME
   //api_parent_app_->computeBlockMemcpy(bytes);
 }
 
 void
 SimTransport::memcopyDelay(uint64_t bytes)
 {
+  //FIXME
   //api_parent_app_->computeBlockMemcpy(bytes);
 }
 
@@ -360,6 +362,7 @@ SimTransport::nidlist() const
 void
 SimTransport::compute(SST::Hg::TimeDelta t)
 {
+  //FIXME
   //api_parent_app_->compute(t);
 }
 
@@ -753,47 +756,62 @@ CollectiveDoneMessage*
 CollectiveEngine::alltoall(void *dst, void *src, int nelems, int type_size, int tag,
                             int cq_id, Communicator* comm)
 {
-//  auto* msg = skipCollective(Collective::alltoall, cq_id, comm, dst, src, nelems, type_size, tag);
-//  if (msg) return msg;
+  auto* msg = skipCollective(Collective::alltoall, cq_id, comm, dst, src, nelems, type_size, tag);
+  if (msg) {
+    return msg;
+  }
 
-//  if (!comm) comm = global_domain_;
+  if (!comm) comm = global_domain_;
 
-//  //FIXME
-//  auto* fact = AllToAllCollective::getBuilderLibrary("macro");
-//  auto* builder = fact->getBuilder(alltoall_type_);
-//  if (!builder){
-//    sst_hg_abort_printf("invalid alltoall type requested: %s", allgather_type_.c_str());
-//  }
+  if (comm->smpComm() && comm->smpBalanced()){
+    int smpSize = comm->smpComm()->nproc();
+    void* intraDst = dst ? new char[nelems*type_size*smpSize] : nullptr;
+    int intra_tag = 1<<28 | tag;
 
-//  if (comm->smpComm() && comm->smpBalanced()){
-//    int smpSize = comm->smpComm()->nproc();
-//    void* intraDst = dst ? new char[nelems*type_size*smpSize] : nullptr;
-//    int intra_tag = 1<<28 | tag;
-
-//    BtreeGather* intra = new BtreeGather(this, 0, intraDst, src, smpSize*nelems,
-//                                         type_size, intra_tag, cq_id, comm->smpComm());
-//    DagCollective* prev;
-//    if (comm->ownerComm()){
-//      int inter_tag = 2<<28 | tag;
-//      AllToAllCollective* inter = builder->create(this, dst, intraDst, smpSize*nelems,
-//                                                  type_size, inter_tag, cq_id, comm->ownerComm());
-//      intra->setSubsequent(inter);
-//      prev = inter;
-//    } else {
-//      prev = intra;
-//    }
-//    int bcast_tag = 3<<28 | tag;
-//    auto* bcast = new BinaryTreeBcastCollective(this, 0, dst, comm->nproc()*nelems,
-//                                                type_size, bcast_tag, cq_id, comm->smpComm());
-//    prev->setSubsequent(bcast);
-//    auto* final = new DoNothingCollective(this, tag, cq_id, comm);
-//    bcast->setSubsequent(final);
-//    return startCollective(intra);
-//  } else {
-//    AllToAllCollective* coll = builder->create(this, dst, src, nelems, type_size, tag, cq_id, comm);
-//    return startCollective(coll);
-//  }
-  sst_hg_abort_printf("unimplemented\n");
+    BtreeGather* intra = new BtreeGather(this, 0, intraDst, src, smpSize*nelems,
+                                         type_size, intra_tag, cq_id, comm->smpComm());
+    DagCollective* prev;
+    if (comm->ownerComm()){
+      int inter_tag = 2<<28 | tag;
+      AllToAllCollective* inter;
+      if (alltoall_type_ == "bruck") {
+        inter = (AllToAllCollective*) new BruckAlltoallCollective(this, dst, intraDst,
+                                                             smpSize*nelems, type_size, inter_tag, cq_id, comm->ownerComm());
+      }
+      else if (alltoall_type_ == "direct") {
+        inter = (AllToAllCollective*) new DirectAlltoallCollective(this, dst, intraDst, smpSize*nelems,
+                                                              type_size, inter_tag, cq_id, comm->ownerComm());
+      }
+      else {
+        sst_hg_abort_printf("unrecognized alltoall type");
+      }
+      intra->setSubsequent(inter);
+      prev = inter;
+    } else {
+      std::cerr << "prev = intra = " << intra << std::endl;
+      prev = intra;
+    }
+    int bcast_tag = 3<<28 | tag;
+    auto* bcast = new BinaryTreeBcastCollective(this, 0, dst, comm->nproc()*nelems,
+                                                type_size, bcast_tag, cq_id, comm->smpComm());
+    prev->setSubsequent(bcast);
+    auto* final = new DoNothingCollective(this, tag, cq_id, comm);
+    bcast->setSubsequent(final);
+    return startCollective(intra);
+  } else {
+    AllToAllCollective* coll;
+    if (alltoall_type_ == "bruck") {
+      coll = (AllToAllCollective*) new BruckAlltoallCollective(this, dst, src, nelems, type_size, tag, cq_id, comm);
+    }
+    else if (alltoall_type_ == "direct") {
+      coll = (AllToAllCollective*) new DirectAlltoallCollective(this, dst, src, nelems,
+                                                            type_size, tag, cq_id, comm);
+    }
+    else {
+      sst_hg_abort_printf("unrecognized alltoall type");
+    }
+    return startCollective(coll);
+  }
   return nullptr;
 }
 
@@ -813,56 +831,71 @@ CollectiveDoneMessage*
 CollectiveEngine::allgather(void *dst, void *src, int nelems, int type_size, int tag,
                              int cq_id, Communicator* comm)
 {
-// auto* msg = skipCollective(Collective::allgather, cq_id, comm, dst, src, nelems, type_size, tag);
-// if (msg) return msg;
+  auto* msg = skipCollective(Collective::allgather, cq_id, comm, dst, src, nelems, type_size, tag);
+  if (msg) return msg;
 
-//  if (!comm) comm = global_domain_;
+  if (!comm) comm = global_domain_;
 
-//  //FIXME
-//  auto* fact = AllgatherCollective::getBuilderLibrary("macro");
-//  if (!fact){
-//    sst_hg_abort_printf("No allgather collective algorithms registered!");
-//  }
+  if (comm->smpComm() && comm->smpBalanced()){
+    int smpSize = comm->smpComm()->nproc();
+    void* intraDst = dst ? new char[nelems*type_size*smpSize] : nullptr;
 
-//  auto* builder = fact->getBuilder(allgather_type_);
-//  if (!builder){
-//    sst_hg_abort_printf("invalid allgather type requested: %s", allgather_type_.c_str());
-//  }
+    int intra_tag = 1<<28 | tag;
 
-//  if (comm->smpComm() && comm->smpBalanced()){
-//    int smpSize = comm->smpComm()->nproc();
-//    void* intraDst = dst ? new char[nelems*type_size*smpSize] : nullptr;
+    AllgatherCollective* intra;
+    if (allgather_type_ == "bruck") {
+      intra = (AllgatherCollective*) new BruckAllgatherCollective(this, intraDst, src, nelems, type_size,
+                                                                intra_tag, cq_id, comm->smpComm());
+    }
+    else if (allgather_type_ == "ring") {
+      intra = (AllgatherCollective*) new RingAllgatherCollective(this, intraDst, src, nelems, type_size,
+                                                                intra_tag, cq_id, comm->smpComm());
+    }
+    else {
+      sst_hg_abort_printf("unrecognized allgather type");
+    }
 
-//    int intra_tag = 1<<28 | tag;
-
-
-
-//    AllgatherCollective* intra = builder->create(this, intraDst, src, nelems,
-//                                                 type_size, intra_tag, cq_id, comm->smpComm());
-
-//    DagCollective* prev;
-//    if (comm->ownerComm()){
-//      int inter_tag = 2<<28 | tag;
-
-//      AllgatherCollective* inter = builder->create(this, dst, intraDst, smpSize*nelems, type_size,
-//                                                   inter_tag, cq_id, comm->ownerComm());
-//      intra->setSubsequent(inter);
-//      prev = inter;
-//    } else {
-//      prev = intra;
-//    }
-//    int bcast_tag = 3<<28 | tag;
-//    auto* bcast = new BinaryTreeBcastCollective(this, 0, dst, comm->nproc()*nelems,
-//                                                type_size, bcast_tag, cq_id, comm->smpComm());
-//    prev->setSubsequent(bcast);
-//    auto* final = new DoNothingCollective(this, tag, cq_id, comm);
-//    bcast->setSubsequent(final);
-//    return startCollective(intra);
-//  } else {
-//    AllgatherCollective* coll = builder->create(this, dst, src, nelems, type_size, tag, cq_id, comm);
-//    return startCollective(coll);
-//  }
-  sst_hg_abort_printf("unimplemented\n");
+    DagCollective* prev;
+    if (comm->ownerComm()){
+      int inter_tag = 2<<28 | tag;
+      AllgatherCollective* inter;
+      if (allgather_type_ == "bruck") {
+        intra = (AllgatherCollective*) new BruckAllgatherCollective(this, dst, intraDst, smpSize*nelems, type_size,
+                                                                  inter_tag, cq_id, comm->ownerComm());
+      }
+      else if (allgather_type_ == "ring") {
+        intra = (AllgatherCollective*) new RingAllgatherCollective(this, dst, intraDst, smpSize*nelems, type_size,
+                                                                 inter_tag, cq_id, comm->ownerComm());
+      }
+      else {
+        sst_hg_abort_printf("unrecognized allgather type");
+      }
+      intra->setSubsequent(inter);
+      prev = inter;
+    } else {
+      prev = intra;
+    }
+    int bcast_tag = 3<<28 | tag;
+    auto* bcast = new BinaryTreeBcastCollective(this, 0, dst, comm->nproc()*nelems,
+                                                type_size, bcast_tag, cq_id, comm->smpComm());
+    prev->setSubsequent(bcast);
+    auto* final = new DoNothingCollective(this, tag, cq_id, comm);
+    bcast->setSubsequent(final);
+    return startCollective(intra);
+  }
+  else {
+    AllgatherCollective* coll;
+    if (allgather_type_ == "bruck") {
+      coll = (AllgatherCollective*) new BruckAllgatherCollective(this, dst, src, nelems, type_size, tag, cq_id, comm);
+    }
+    else if (allgather_type_ == "ring") {
+      coll = (AllgatherCollective*) new RingAllgatherCollective(this, dst, src, nelems, type_size, tag, cq_id, comm);
+    }
+    else {
+      sst_hg_abort_printf("unrecognized allgather type");
+    }
+    return startCollective(coll);
+  }
   return nullptr;
 }
 

--- a/src/sst/elements/mask-mpi/Makefile.am
+++ b/src/sst/elements/mask-mpi/Makefile.am
@@ -2,7 +2,7 @@
 #
 #
 
-comp_LTLIBRARIES = libmask_mpi.la sendrecv.la alltoall.la reduce.la
+comp_LTLIBRARIES = libmask_mpi.la sendrecv.la reduce.la alltoall.la allgather.la
 
 compdir = $(pkglibdir)
 
@@ -80,22 +80,27 @@ library_include_HEADERS = \
   unusedvariablemacro.h
 
 sendrecv_la_SOURCES = tests/sendrecv.cc
-alltoall_la_SOURCES = tests/alltoall.cc
 reduce_la_SOURCES = tests/reduce.cc
+alltoall_la_SOURCES = tests/alltoall.cc
+allgather_la_SOURCES = tests/allgather.cc
 
 EXTRA_DIST = \
  tests/testsuite_default_mask_mpi.py \
  tests/platform_file_mask_mpi_test.py \
- tests/test_alltoall.py \
  tests/test_reduce.py \
  tests/test_sendrecv.py \
+ tests/test_alltoall.py \
+ tests/test_allgather.py \
  tests/refFiles/test_reduce.out \
- tests/refFiles/test_sendrecv.out
+ tests/refFiles/test_sendrecv.out \
+ tests/refFiles/test_alltoall.out \
+ tests/refFiles/test_allgather.out
 
 libmask_mpi_la_LDFLAGS = -module -avoid-version
 sendrecv_la_LDFLAGS = -module -avoid-version
-alltoall_la_LDFLAGS = -module -avoid-version
 reduce_la_LDFLAGS = -module -avoid-version
+alltoall_la_LDFLAGS = -module -avoid-version
+allgather_la_LDFLAGS = -module -avoid-version
 
 install-exec-hook: 
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     mask-mpi=$(abs_srcdir)

--- a/src/sst/elements/mask-mpi/tests/allgather.cc
+++ b/src/sst/elements/mask-mpi/tests/allgather.cc
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Questions? Contact sst-macro-help@sandia.gov
 */
 
-#define ssthg_app_name alltoall
+#define ssthg_app_name allgather
 
 #include <stddef.h>
 #include <stdio.h>
@@ -59,13 +59,8 @@ int main(int argc, char* argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    int* values = new int[size];
-    for(int i = 0; i < size; i++) {
-      values[i] = rank;
-    }
-
     int* recv_values = new int[size];
-    MPI_Alltoall(values, 1, MPI_INT, recv_values, 1, MPI_INT, MPI_COMM_WORLD);
+    MPI_Allgather(&rank, 1, MPI_INT, recv_values, size, MPI_INT, MPI_COMM_WORLD);
     if(rank == 0) {
       for(int i = 0; i < size; ++i) {
         printf("recv_values[%d]=%d\n",i, recv_values[i]);

--- a/src/sst/elements/mask-mpi/tests/refFiles/test_allgather.out
+++ b/src/sst/elements/mask-mpi/tests/refFiles/test_allgather.out
@@ -1,0 +1,9 @@
+recv_values[0]=0
+recv_values[1]=1
+recv_values[2]=2
+recv_values[3]=3
+recv_values[4]=4
+recv_values[5]=5
+recv_values[6]=6
+recv_values[7]=7
+Simulation is complete, simulated time: 970.267 ns

--- a/src/sst/elements/mask-mpi/tests/refFiles/test_alltoall.out
+++ b/src/sst/elements/mask-mpi/tests/refFiles/test_alltoall.out
@@ -1,0 +1,9 @@
+recv_values[0]=0
+recv_values[1]=1
+recv_values[2]=2
+recv_values[3]=3
+recv_values[4]=4
+recv_values[5]=5
+recv_values[6]=6
+recv_values[7]=7
+Simulation is complete, simulated time: 970.267 ns

--- a/src/sst/elements/mask-mpi/tests/test_allgather.py
+++ b/src/sst/elements/mask-mpi/tests/test_allgather.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Copyright 2009-2024 NTESS. Under the terms
+# of Contract DE-NA0003525 with NTESS, the U.S.
+# Government retains certain rights in this software.
+#
+# Copyright (c) 2009-2024, NTESS
+# All rights reserved.
+#
+# This file is part of the SST software package. For license
+# information, see the LICENSE file in the top level directory of the
+# distribution.
+
+import sst
+from sst.merlin.base import *
+from sst.merlin.endpoint import *
+from sst.merlin.interface import *
+from sst.merlin.topology import *
+from sst.hg import *
+
+if __name__ == "__main__":
+
+    PlatformDefinition.loadPlatformFile("platform_file_mask_mpi_test")
+    PlatformDefinition.setCurrentPlatform("platform_mask_mpi_test")
+    platform = PlatformDefinition.getCurrentPlatform()
+
+    platform.addParamSet("operating_system", {
+        "verbose" : "0",
+        "app1.name" : "allgather",
+        "app1.exe"  : "allgather.so",
+        "app1.apis" : ["systemAPI:libsystemapi.so", "SimTransport:libsumi.so", "MpiApi:libmask_mpi.so"],
+    })
+
+    topo = topoSingle()
+    topo.link_latency = "20ns"
+    topo.num_ports = 32
+
+    ep = HgJob(0,8)
+
+    system = System()
+    system.setTopology(topo)
+    system.allocateNodes(ep,"linear")
+
+    system.build()

--- a/src/sst/elements/mask-mpi/tests/testsuite_default_mask_mpi.py
+++ b/src/sst/elements/mask-mpi/tests/testsuite_default_mask_mpi.py
@@ -40,6 +40,26 @@ class testcase_mask_mpi(SSTTestCase):
             os.environ["SST_LIB_PATH"] = path + ":" + libdir
         self.mask_mpi_template("test_reduce")
 
+    def test_alltoall(self):
+        testdir = self.get_testsuite_dir()
+        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        path = os.environ.get("SST_LIB_PATH")
+        if path is None or path == "":
+            os.environ["SST_LIB_PATH"] = libdir
+        else:
+            os.environ["SST_LIB_PATH"] = path + ":" + libdir
+        self.mask_mpi_template("test_alltoall")
+
+    def test_allgather(self):
+        testdir = self.get_testsuite_dir()
+        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        path = os.environ.get("SST_LIB_PATH")
+        if path is None or path == "":
+            os.environ["SST_LIB_PATH"] = libdir
+        else:
+            os.environ["SST_LIB_PATH"] = path + ":" + libdir
+        self.mask_mpi_template("test_allgather")
+
 #####
 
     def mask_mpi_template(self, testcase, striptotail=0):


### PR DESCRIPTION
Remove unnecessary builder/factory for some collective implementations, which enables those collectives.
