### PR TITLE
Resolve some memorypool  undeleted events

### DIFF
--- a/src/sst/elements/kingsley/linkControl.cc
+++ b/src/sst/elements/kingsley/linkControl.cc
@@ -209,6 +209,7 @@ void LinkControl::init(unsigned int phase)
             in_ret_credits[i] = inbuf_size.getRoundedValue() /flit_size;
         }
 
+        delete ev;
         init_state = 2;
         break;
     }
@@ -218,6 +219,7 @@ void LinkControl::init(unsigned int phase)
         if ( NULL == ev ) break;
         init_ev = static_cast<NocInitEvent*>(ev);
         id = init_ev->int_value;
+	delete ev;
 
         // Send credit event to router
         credit_event* cr_ev = new credit_event(0,inbuf_size.getRoundedValue() / flit_size);

--- a/src/sst/elements/kingsley/noc_mesh.cc
+++ b/src/sst/elements/kingsley/noc_mesh.cc
@@ -1066,6 +1066,7 @@ noc_mesh::init(unsigned int phase)
             if ( ports[i] != NULL ) {
                 credit_event* cr_ev = static_cast<credit_event*>(ports[i]->recvUntimedData());
                 port_credits[i] += cr_ev->credits;
+		delete cr_ev;
             }
         }
         init_state = 11;

--- a/src/sst/elements/memHierarchy/cacheController.cc
+++ b/src/sst/elements/memHierarchy/cacheController.cc
@@ -173,11 +173,14 @@ bool Cache::clockTick(Cycle_t time) {
         if (accepted != maxRequestsPerCycle_ && processEvent(prefetchBuffer_.front(), false)) {
             accepted++;
             // Accepted prefetches are profiled in the coherence manager
+	    prefetchBuffer_.pop();
         } else {
             statPrefetchDrop->addData(1);
             coherenceMgr_->removeRequestRecord(prefetchBuffer_.front()->getID());
+	    MemEventBase* ev = prefetchBuffer_.front();
+	    prefetchBuffer_.pop();
+	    delete ev;
         }
-        prefetchBuffer_.pop();
     }
 
     // Push any events that need to be retried next cycle onto the retry buffer

--- a/src/sst/elements/memHierarchy/memNICBase.h
+++ b/src/sst/elements/memHierarchy/memNICBase.h
@@ -364,7 +364,10 @@ class MemNICBase : public MemLinkBase {
                         dbg.debug(_L10_, "\tInserting in initQueue\n");
                         mre->putEvent(ev); // If we did not delete the Event, give it back to the MemRtrEvent
                         initQueue.push(mre);
-                    }
+                    } else {
+			delete mre;
+			delete ev;
+		    }
                 }
                 delete req;
             }


### PR DESCRIPTION
Simulations using memHierarchy and kingsley components (e.g. memHierarchy/tests/testMemoryCache.py and testPrefetchParameters.py) sometimes have events that are never deleted. Many of these are in initialization, but some were during execution and caused the memory pool usage to grow during simulation execution.  This PR addresses undeleted events in the following:

- prefetch handling in cacheController.cc clock_tick()
- memNICBase.h nicInit
- credit events in kingsley noc_mesh.cc noc_mesh::init
- kingsley LinkControl::init

There are still some remaining undeleted events but many fewer and they mostly appear to be in initialization where they don't cause increasing memorypool usage with simulation time. 
