### PR TITLE
miranda: check request operation instead of using dynamic_cast

### DIFF
--- a/src/sst/elements/miranda/mirandaCPU.cc
+++ b/src/sst/elements/miranda/mirandaCPU.cc
@@ -463,10 +463,10 @@ bool RequestGenCPU::clockTick(SST::Cycle_t cycle) {
             break;
     	}
 
-        MemoryOpRequest* memOpReq;
 	GeneratorRequest* nxtRq = pendingRequests.at(i);
+        ReqOperation op = nxtRq->getOperation();
 
-	if(nxtRq->getOperation() == REQ_FENCE) {
+	if(op == REQ_FENCE) {
             if(0 == requestsInFlight.size()) {
 		out->verbose(CALL_INFO, 4, 0, "Fence operation completed, no pending requests, will be retired.\n");
 
@@ -483,7 +483,7 @@ bool RequestGenCPU::clockTick(SST::Cycle_t cycle) {
 
             // Fence operations do now allow anything else to complete in this cycle
             break;
-        } else if (nxtRq->getOperation() == CUSTOM) {
+        } else if (op == CUSTOM) {
             if (requestsPending[CUSTOM] < maxRequestsPending[CUSTOM]) {
                 out->verbose(CALL_INFO, 4, 0, "Will attempt to issue as free slots in the load/store unit.\n");
 
@@ -501,9 +501,9 @@ bool RequestGenCPU::clockTick(SST::Cycle_t cycle) {
                     delete nxtRq;
                 }
             }
-        } else if ( ( memOpReq = dynamic_cast<MemoryOpRequest*>(nxtRq) ) ) {
-
-            if( requestsPending[memOpReq->getOperation()] < maxRequestsPending[memOpReq->getOperation()] ) {
+        } else if (op == READ || op == WRITE) {
+            if( requestsPending[op] < maxRequestsPending[op] ) {
+                auto memOpReq = static_cast<MemoryOpRequest*>(nxtRq);
                 out->verbose(CALL_INFO, 4, 0, "Will attempt to issue as free slots in the load/store unit.\n");
 
 

--- a/src/sst/elements/miranda/mirandaGenerator.h
+++ b/src/sst/elements/miranda/mirandaGenerator.h
@@ -180,12 +180,13 @@ public:
 		const uint64_t cLength,
 		const ReqOperation cOpType) :
 		GeneratorRequest(),
-		addr(cAddr), length(cLength), op(cOpType) {}
+		addr(cAddr), length(cLength), op(cOpType)
+	{ assert (op == READ || op == WRITE); }
+
 	~MemoryOpRequest() {}
 	ReqOperation getOperation() const { return op; }
 	bool isRead() const { return op == READ; }
 	bool isWrite() const { return op == WRITE; }
-        bool isCustom() const { return op == CUSTOM; }
 	uint64_t getAddress() const { return addr; }
 	uint64_t getLength() const { return length; }
 


### PR DESCRIPTION
For my simulation, approximately 15-20% of CPU time is spent resolving one dynamic_cast in miranda. This dynamic cast does not appear to be necessary because mirandaCPU dispatches GeneratorRequests based on the request's operation.

This patch replaces the dynamic_cast with an operation check and adds an assertion on the MemoryOpRequest's operation type. The assertion ensures a MemoryOpRequest is either READ or WRITE to avoid potential incorrect static_cast'ing into CustomOpRequests.