### PR TITLE
Mercury: major code cleanup and debugging improvements

### DIFF
--- a/src/sst/elements/mask-mpi/tests/platform_file_mask_mpi_test.py
+++ b/src/sst/elements/mask-mpi/tests/platform_file_mask_mpi_test.py
@@ -4,6 +4,14 @@ from sst.merlin.base import *
 platdef = PlatformDefinition("platform_mask_mpi_test")
 PlatformDefinition.registerPlatformDefinition(platdef)
 
+platdef.addParamSet("node",{
+    "verbose" : "0",
+})
+
+platdef.addParamSet("nic",{
+    "verbose" : "0",
+})
+
 platdef.addParamSet("operating_system",{
     "verbose" : "0",
 })
@@ -19,7 +27,6 @@ platdef.addParamSet("network_interface",{
     "output_buf_size" : "16kB"
 })
 
-#platdef.addClassType("network_interface","sst.merlin.interface.LinkControl")
 platdef.addClassType("network_interface","sst.merlin.interface.ReorderLinkControl")
 
 platdef.addParamSet("router",{

--- a/src/sst/elements/mask-mpi/tests/test_sendrecv.py
+++ b/src/sst/elements/mask-mpi/tests/test_sendrecv.py
@@ -25,7 +25,6 @@ if __name__ == "__main__":
     platform = PlatformDefinition.getCurrentPlatform()
 
     platform.addParamSet("operating_system", {
-        "verbose" : "0",
         "app1.name" : "sendrecv",
         "app1.exe"  : "sendrecv.so",
         "app1.apis" : ["systemAPI:libsystemapi.so", "SimTransport:libsumi.so", "MpiApi:libmask_mpi.so"],

--- a/src/sst/elements/mask-mpi/tests/testsuite_default_mask_mpi.py
+++ b/src/sst/elements/mask-mpi/tests/testsuite_default_mask_mpi.py
@@ -22,7 +22,7 @@ class testcase_mask_mpi(SSTTestCase):
 
     def test_sendrecv(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR",str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir
@@ -32,7 +32,7 @@ class testcase_mask_mpi(SSTTestCase):
 
     def test_reduce(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR",str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir
@@ -42,7 +42,7 @@ class testcase_mask_mpi(SSTTestCase):
 
     def test_alltoall(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR",str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir
@@ -52,7 +52,7 @@ class testcase_mask_mpi(SSTTestCase):
 
     def test_allgather(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR",str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir
@@ -62,7 +62,7 @@ class testcase_mask_mpi(SSTTestCase):
 
     def test_halo3d26(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR",str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir

--- a/src/sst/elements/mercury/common/connection.cc
+++ b/src/sst/elements/mercury/common/connection.cc
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #include <mercury/common/component.h>
 #include <sst/core/params.h>

--- a/src/sst/elements/mercury/common/connection.h
+++ b/src/sst/elements/mercury/common/connection.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/connection_fwd.h
+++ b/src/sst/elements/mercury/common/connection_fwd.h
@@ -1,49 +1,19 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
-
-#ifndef CONNECTION_FWD_H
-#define CONNECTION_FWD_H
+#pragma once
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/common/event_handler.h
+++ b/src/sst/elements/mercury/common/event_handler.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/event_link.cc
+++ b/src/sst/elements/mercury/common/event_link.cc
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #include <mercury/common/event_link.h>
 

--- a/src/sst/elements/mercury/common/event_link.h
+++ b/src/sst/elements/mercury/common/event_link.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/events_fwd.h
+++ b/src/sst/elements/mercury/common/events_fwd.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/skeleton.h
+++ b/src/sst/elements/mercury/common/skeleton.h
@@ -13,6 +13,9 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
+// There's a reasonable chance that we'll want the globals/TLS support eventually,
+// so I'm leaving that sst-macro code here for now -- JPK
+
 #pragma once
 
 #define SSTPP_QUOTE(name) #name

--- a/src/sst/elements/mercury/common/stl_string.h
+++ b/src/sst/elements/mercury/common/stl_string.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/thread_safe_new.h
+++ b/src/sst/elements/mercury/common/thread_safe_new.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-//#include <sst_element_config.h>
 #include <vector>
 #include <set>
 

--- a/src/sst/elements/mercury/common/unusedvariablemacro.h
+++ b/src/sst/elements/mercury/common/unusedvariablemacro.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/common/util.cc
+++ b/src/sst/elements/mercury/common/util.cc
@@ -16,7 +16,6 @@
 #include <mercury/common/util.h>
 #include <mercury/components/operating_system.h>
 #include <mercury/operating_system/process/app.h>
-//#include <sstmac/null_buffer.h>
 
 #include <cstring>
 
@@ -25,52 +24,6 @@ extern template class  SST::Hg::HgBase<SST::SubComponent>;
 
 typedef int (*main_fxn)(int,char**);
 typedef int (*empty_main_fxn)();
-
-//extern "C" double
-//sst_hg_now(){
-//  return sstmac::sw::OperatingSystem::currentOs()->now().sec();
-//}
-
-//extern "C" void
-//sst_hg_sleep_precise(double secs){
-//  sstmac::sw::OperatingSystem::currentOs()->sleep(sstmac::TimeDelta(secs));
-//}
-
-// namespace sstmac {
-
-//SST::Params& appParams(){
-//  return sstmac::sw::OperatingSystem::currentThread()->parentApp()->params();
-//}
-
-//std::string getAppParam(const std::string& name){
-//  return appParams().find<std::string>(name);
-//}
-
-//bool appHasParam(const std::string& name){
-//  return appParams().contains(name);
-//}
-
-//void getAppUnitParam(const std::string& name, double& val){
-//  val = appParams().find<SST::UnitAlgebra>(name).getValue().toDouble();
-//}
-
-//void getAppUnitParam(const std::string& name, int& val){
-//  val = appParams().find<SST::UnitAlgebra>(name).getRoundedValue();
-//}
-
-//void getAppUnitParam(const std::string& name, const std::string& def, int& val){
-//  val = appParams().find<SST::UnitAlgebra>(name, def).getRoundedValue();
-//}
-
-//void getAppUnitParam(const std::string& name, const std::string& def, double& val){
-//  val = appParams().find<SST::UnitAlgebra>(name, def).getRoundedValue();
-//}
-
-//void getAppArrayParam(const std::string& name, std::vector<int>& vec){
-//  appParams().find_array(name, vec);
-//}
-
-//} // end namespace sstmac
 
 extern "C" void ssthg_exit(int code)
 {
@@ -96,50 +49,7 @@ extern "C" int ssthg_atexit(void (* /*fxn*/)(void))
   return 0;
 }
 
-//extern "C"
-//int sst_hg_gethostname(char* name, size_t len)
-//{
-//  std::string sst_name = sstmac::sw::OperatingSystem::currentOs()->hostname();
-//  if (sst_name.size() > len){
-//    return -1;
-//  } else {
-//    ::strcpy(name, sst_name.c_str());
-//    return 0;
-//  }
-//}
-
-//extern "C"
-//long sst_hg_gethostid()
-//{
-//  return sstmac::sw::OperatingSystem::currentOs()->addr();
-//}
-
-//extern "C"
-//void sst_hg_free(void* ptr){
-//#ifdef free
-//#error #sstmac free macro should not be defined in util.cc - refactor needed
-//#endif
-//  if (isNonNullBuffer(ptr)) free(ptr);
-//}
-
 #include <unordered_map>
-
-//extern "C"
-//void sst_hg_advance_time(const char* param_name)
-//{
-//  sstmac::sw::Thread* thr = sstmac::sw::OperatingSystem::currentThread();
-//  sstmac::sw::App* parent = thr->parentApp();
-//  using ValueCache = std::unordered_map<void*,sstmac::TimeDelta>;
-//  static std::map<sstmac::sw::AppId,ValueCache> cache;
-//  auto& subMap = cache[parent->aid()];
-//  auto iter = subMap.find((void*)param_name);
-//  if (iter == subMap.end()){
-//    subMap[(void*)param_name] =
-//        sstmac::TimeDelta(parent->params().find<SST::UnitAlgebra>(param_name).getValue().toDouble());
-//    iter = subMap.find((void*)param_name);
-//  }
-//  parent->compute(iter->second);
-//}
 
 int
 userSkeletonMainInitFxn(const char* name, main_fxn fxn)

--- a/src/sst/elements/mercury/common/util.h
+++ b/src/sst/elements/mercury/common/util.h
@@ -16,24 +16,8 @@
 #pragma once
 
 #ifdef __cplusplus
-
 #include <mercury/common/errors.h>
 #include <mercury/operating_system/process/task_id.h>
-//#include <sprockit/spkt_string.h>
-//#include <sprockit/debug.h>
-
-/** Automatically inherit the errors */
-//using sprockit::IllformedError;
-//using sprockit::InputError;
-//using sprockit::InvalidKeyError;
-//using sprockit::IOError;
-//using sprockit::IteratorError;
-//using sprockit::LibraryError;
-//using sprockit::MemoryError;
-//using sprockit::NullError;
-//using sprockit::OSError;
-//using sprockit::RangeError;
-//using sprockit::SpktError;
 #endif
 
 namespace SST::Hg {

--- a/src/sst/elements/mercury/components/nic.h
+++ b/src/sst/elements/mercury/components/nic.h
@@ -1,85 +1,41 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
+
+#include <mercury/common/component.h>
 
 #include <sst/core/event.h>
 #include <sst/core/eli/elementbuilder.h>
 #include <sst/core/interfaces/simpleNetwork.h>
 
-#include <mercury/common/component.h>
 #include <mercury/common/thread_safe_new.h>
 #include <mercury/common/node_address.h>
 #include <mercury/common/timestamp.h>
+#include <mercury/common/event_handler.h>
 #include <mercury/components/node_fwd.h>
-//#include <sstmac/hardware/common/failable.h>
+#include <mercury/components/operating_system_fwd.h>
 #include <mercury/common/connection.h>
 #include <mercury/hardware/common/packet_fwd.h>
 #include <mercury/hardware/common/recv_cq.h>
-#include <mercury/hardware/network/network_message_fwd.h>
-//#include <sstmac/hardware/logp/logp_switch_fwd.h>
-//#include <sstmac/common/stats/stat_spyplot_fwd.h>
-//#include <sstmac/common/stats/stat_histogram_fwd.h>
 #include <mercury/hardware/common/flow_fwd.h>
-#include <mercury/hardware/network/network_message_fwd.h>
-#include <mercury/components/operating_system_fwd.h>
-//#include <mercury/operating_system/process/progress_queue.h>
-//#include <sstmac/hardware/topology/topology_fwd.h>
-//#include <sprockit/debug.h>
-//#include <mercury/common/factory.h>
-#include <mercury/common/event_handler.h>
 #include <mercury/hardware/network/network_message.h>
 
 #include <vector>
 #include <queue>
 #include <functional>
-
-//DeclareDebugSlot(nic);
-
-//#define nic_debug(...) \
-//  debug_printf(sprockit::dbg::nic, "NIC on node %d: %s", \
-//    int(addr()), sprockit::sprintf(__VA_ARGS__).c_str())
 
 namespace SST {
 namespace Hg {
@@ -109,7 +65,6 @@ class NicEvent :
  * the process (ppid) involved.
  */
 class NIC : public SST::Hg::SubComponent
-//class NIC : public ConnectableComponent
 {
  public:
 
@@ -130,11 +85,6 @@ class NIC : public SST::Hg::SubComponent
     LogP
   } Port;
 
-  // struct MyRequest : public SST::Interfaces::SimpleNetwork::Request {
-  //   uint64_t flow_id;
-  //   Timestamp start;
-  // };
-
   class FlowTracker : public Event {
 private:
     uint64_t flow_id;
@@ -142,20 +92,6 @@ public:
     FlowTracker(uint64_t id) : flow_id(id) {}
     uint64_t id() const {return flow_id;}
   };
-
-//  struct MessageEvent : public Event {
-//    MessageEvent(NetworkMessage* msg) :
-//      msg_(msg)
-//    {
-//    }
-//
-//    NetworkMessage* msg() const {
-//      return msg_;
-//    }
-//
-//   private:
-//    NetworkMessage*  msg_;
-//  };
 
 private:
   struct Pending {
@@ -210,10 +146,6 @@ public:
   void set_link_control(SST::Interfaces::SimpleNetwork* link_control) {
       link_control_ = link_control;
   }
-
-//  Topology* topology() const {
-//    return top_;
-//  }
 
   /**
    * @brief injectSend Perform an operation on the NIC.
@@ -282,20 +214,9 @@ public:
 
  protected:
 
-  void configureLogPLinks();
-
-  void configureLinks();
-
   Node* parent() const {
     return parent_;
   }
-
-  /**
-    Start the message sending and inject it into the network
-    This performs all model-specific work
-    @param payload The network message to send
-  */
-  //virtual void doSend(NetworkMessage* payload) = 0;
 
   bool negligibleSize(int bytes) const {
     return bytes <= negligibleSize_;
@@ -306,13 +227,9 @@ protected:
   Node* parent_;
   NodeId my_addr_;
   EventLink::ptr logp_link_;
-  //Topology* top_;
 
  private:
 
-  //StatSpyplot<int,uint64_t>* spy_bytes_;
-  //Statistic<uint64_t>* xmit_flows_;
-  //sw::SingleProgressQueue<NetworkMessage> queue_;
   SST::Interfaces::SimpleNetwork* link_control_;
   std::vector<std::queue<Pending>> pending_;
   std::vector<std::queue<NetworkMessage*>> ack_queue_;
@@ -320,6 +237,7 @@ protected:
   RecvCQ cq_;
   int vns_;
   int test_size_;
+  std::unique_ptr<SST::Output> out_;
 
  protected:
   SST::Hg::OperatingSystem* os_;
@@ -336,49 +254,6 @@ protected:
 
   void finishMemcpy(NetworkMessage* msg);
 };
-
-//class NullNIC : public NIC
-//{
-// public:
-
-//  SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
-//    NullNIC,
-//    "hg",
-//    "null_nic",
-//    SST_ELI_ELEMENT_VERSION(1,0,0),
-//    "implements a nic that models nothing - stand-in only",
-//    SST::Hg::NIC
-//          )
-
-////  SST_ELI_REGISTER_SUBCOMPONENT_DERIVED(
-////    NullNIC,
-////    "hg",
-////    "nullnic",
-////    SST_ELI_ELEMENT_VERSION(0,0,1),
-////    "Mercury Null NIC",
-////    SST::Hg::NIC
-////  )
-
-//  NullNIC(uint32_t id, SST::Params& params, SST::Hg::SimpleNode* parent) :
-//      NIC(id, params, parent)
-//  {
-//  }
-
-//  std::string toString() const override { return "null nic"; }
-//  //std::string toString() const { return "null nic"; }
-
-////  void connectOutput(int, int, EventLink::ptr&&) override {}
-
-////  void connectInput(int, int, EventLink::ptr&&) override {}
-
-////  SST::Event::HandlerBase* payloadHandler(int) override { return nullptr; }
-
-////  SST::Event::HandlerBase* creditHandler(int) override { return nullptr; }
-
-//  SST::Event::HandlerBase* payloadHandler(int) { return nullptr; }
-
-//  SST::Event::HandlerBase* creditHandler(int) { return nullptr; }
-//};
 
 } // end of namespace Hg
 } // end of namespace SST

--- a/src/sst/elements/mercury/components/nic_fwd.h
+++ b/src/sst/elements/mercury/components/nic_fwd.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 

--- a/src/sst/elements/mercury/components/node.cc
+++ b/src/sst/elements/mercury/components/node.cc
@@ -26,7 +26,6 @@ extern template SST::TimeConverter* HgBase<SST::Component>::time_converter_;
 
 Node::Node(ComponentId_t id, Params &params)
     : SST::Hg::Component(id), nic_(0) {
-
   my_addr_ = params.find<unsigned int>("logicalID",-1);
   unsigned int verbose = params.find<unsigned int>("verbose",0);
   out_ = std::unique_ptr<SST::Output>(new SST::Output(sprintf("Node%d:",my_addr_), verbose, 0, Output::STDOUT));
@@ -55,7 +54,7 @@ Node::Node(ComponentId_t id, Params &params)
   int ncores_ = params.find<std::int32_t>("ncores", 1);
   int nsockets_ = params.find<std::int32_t>("nsockets",1);
 
-//  // Tell the simulation not to end until we're ready
+  // Tell the simulation not to end until we're ready
   registerAsPrimaryComponent();
   primaryComponentDoNotEndSim();
 }

--- a/src/sst/elements/mercury/components/node.h
+++ b/src/sst/elements/mercury/components/node.h
@@ -91,6 +91,8 @@ public:
 
   SST::Hg::NIC* nic() { return nic_; }
 
+  std::string toString() { return sprintf("HgNode%d:",my_addr_); }
+
 private:
 
   SST::Hg::NIC* nic_;

--- a/src/sst/elements/mercury/components/operating_system.h
+++ b/src/sst/elements/mercury/components/operating_system.h
@@ -19,7 +19,6 @@
 
 #include <sst/core/link.h>
 
-//#include <mercury/common/factory.h>
 #include <sst/core/eli/elementbuilder.h>
 #include <mercury/components/node_fwd.h>
 #include <mercury/common/unique_id.h>
@@ -42,8 +41,6 @@ namespace SST {
 namespace Hg {
 
 extern template SST::TimeConverter* HgBase<SST::SubComponent>::time_converter_;
-
-//static std::string _tick_spacing_string_("1ps");
 
 class OperatingSystem : public SST::Hg::SubComponent {
 
@@ -150,6 +147,7 @@ public:
   /// to this context on every context switch.
   ThreadContext *des_context_;
 
+  unsigned int verbose_;
   int nranks_;
   Node* node_;
   Thread* active_thread_;
@@ -188,8 +186,6 @@ public:
   static SST::TimeConverter* timeConverter() {
     return time_converter_;
   }
-// protected:
-//  static SST::TimeConverter* time_converter_;
 
  public:
 
@@ -240,10 +236,6 @@ public:
     compute_sched_->releaseCores(ncore,thr);
   }
 
-//  NodeId rankToNode(int rank) {
-//    return NodeId( rank_mapper_->mapRank(rank) );
-//  }
-
   void set_nranks(int32_t ranks) {
     nranks_ = ranks;
   }
@@ -251,8 +243,6 @@ public:
   int32_t nranks() {
     return nranks_;
   }
-
-//  SST::Ember::EmberRankMap*	rank_mapper_;
 
 //
 // LIBRARIES

--- a/src/sst/elements/mercury/components/operating_system_fwd.h
+++ b/src/sst/elements/mercury/components/operating_system_fwd.h
@@ -13,15 +13,12 @@
 // information, see the LICENSE file in the top level directory of the
 // distribution.
 
-#ifndef sst_hg_software_process_OPERATING_SYSTEM_FWD_H
-#define sst_hg_software_process_OPERATING_SYSTEM_FWD_H
+#pragma once
 
 namespace SST {
 namespace Hg {
 
 class OperatingSystem;
 
-}
-}
-
-#endif // OPERATING_SYSTEM_FWD_H
+} // namespace Hg
+} // namespace SST

--- a/src/sst/elements/mercury/hardware/common/packet.h
+++ b/src/sst/elements/mercury/hardware/common/packet.h
@@ -18,7 +18,6 @@
 #include <sst/core/event.h>
 #include <mercury/common/node_address.h>
 #include <mercury/hardware/common/flow_fwd.h>
-//# include <sprockit/printable.h>
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/hardware/common/recv_cq.cc
+++ b/src/sst/elements/mercury/hardware/common/recv_cq.cc
@@ -22,7 +22,6 @@
 #include <mercury/hardware/common/packet.h>
 #include <mercury/hardware/common/recv_cq.h>
 #include <mercury/hardware/common/flow.h>
-//#include <sprockit/output.h>
 
 namespace SST {
 namespace Hg {
@@ -47,7 +46,7 @@ RecvCQ::recv(uint64_t unique_id, uint32_t bytes, Flow* orig)
   incomingMsg& incoming  = bytes_recved_[unique_id];
 #if SST_HG_SANITY_CHECK
   if (incoming.msg && orig){
-    spkt_abort_printf(
+    sst_hg_abort_printf(
         "RecvCQ::recv: only one message chunk should carry the parent payload for %" PRIu64 ": %s",
         unique_id, incoming.msg->toString().c_str());
   }

--- a/src/sst/elements/mercury/libraries/compute/compute_event.h
+++ b/src/sst/elements/mercury/libraries/compute/compute_event.h
@@ -19,12 +19,8 @@
 #include <mercury/common/timestamp.h>
 #include <mercury/hardware/common/flow.h>
 #include <mercury/common/thread_safe_new.h>
-//#include <mercury/hardware/memory/memory_id.h>
-//#include <mercury/typedefs.h>
 #include <type_traits>
 #include <stdint.h>
-
-//DeclareDebugSlot(compute_intensity);
 
 namespace SST {
 namespace Hg {
@@ -106,5 +102,5 @@ struct basic_instructions_st
 typedef ComputeEvent_impl<TimeDelta> TimedComputeEvent;
 typedef ComputeEvent_impl<basic_instructions_st> BasicComputeEvent;
 
-}
-}  // end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/compute_event_fwd.h
+++ b/src/sst/elements/mercury/libraries/compute/compute_event_fwd.h
@@ -20,7 +20,5 @@ namespace Hg {
 
 class ComputeEvent;
 
-} }
-
-
-#endif // COMPUTE_MESSAGE_FWD_H
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute.cc
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute.cc
@@ -18,5 +18,5 @@
 namespace SST {
 namespace Hg {
 
-}
-}
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute.h
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute.h
@@ -47,5 +47,5 @@ class LibCompute :
 
 };
 
-}
-}
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_inst.cc
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_inst.cc
@@ -18,12 +18,6 @@
 #include <mercury/libraries/compute/lib_compute_inst.h>
 #include <mercury/libraries/compute/compute_event.h>
 #include <mercury/operating_system/process/thread.h>
-//#include <sstmac/software/process/backtrace.h>
-//#include <mercury/common/event_callback.h>
-//#include <sstmac/common/stats/ftq.h>
-//#include <sstmac/software/process/ftq_scope.h>
-
-//RegisterDebugSlot(lib_compute_inst);
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_inst.h
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_inst.h
@@ -19,11 +19,6 @@
 #include <mercury/libraries/compute/compute_event_fwd.h>
 #include <mercury/operating_system/process/software_id.h>
 #include <stdint.h>
-//#include <sstmac/common/stats/ftq_tag.h>
-
-//these are the default instruction labels
-
-//DeclareDebugSlot(lib_compute_inst);
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_memmove.cc
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_memmove.cc
@@ -20,8 +20,6 @@
 #include <mercury/libraries/compute/compute_event.h>
 #include <mercury/operating_system/process/thread.h>
 #include <mercury/libraries/compute/lib_compute_memmove.h>
-//#include <sstmac/common/event_callback.h>
-//#include <sstmac/software/process/backtrace.h>
 
 namespace SST {
 namespace Hg {
@@ -43,9 +41,6 @@ LibComputeMemmove::LibComputeMemmove(SST::Params& params,
 void
 LibComputeMemmove::doAccess(uint64_t bytes)
 {
-  //if (bytes == 0){
-  //  return;
-  //}
   uint64_t num_loops = bytes / access_width_bytes_;
   int nflops = 0;
   int nintops = 1; //memmove instruction
@@ -74,5 +69,5 @@ LibComputeMemmove::copy(uint64_t bytes)
 }
 
 
-}
-} //end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_memmove.h
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_memmove.h
@@ -55,5 +55,5 @@ class LibComputeMemmove :
 
 };
 
-}
-} //end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_time.cc
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_time.cc
@@ -19,7 +19,6 @@
 #include <mercury/libraries/compute/compute_event.h>
 #include <mercury/operating_system/process/thread.h>
 #include <mercury/libraries/compute/lib_compute_memmove.h>
-//#include <sstmac/software/process/backtrace.h>
 
 namespace SST {
 namespace Hg {
@@ -65,5 +64,5 @@ LibComputeTime::sleep(TimeDelta time)
   os_->sleep(time);
 }
 
-}
-} //end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_compute_time.h
+++ b/src/sst/elements/mercury/libraries/compute/lib_compute_time.h
@@ -50,5 +50,5 @@ class LibComputeTime :
 
 };
 
-}
-} //end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/libraries/compute/lib_hybrid_compute.h
+++ b/src/sst/elements/mercury/libraries/compute/lib_hybrid_compute.h
@@ -39,5 +39,5 @@ class lib_hybrid_compute :
 
 };
 
-}
-} //end of namespace
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/operating_system/launch/app_launcher.cc
+++ b/src/sst/elements/mercury/operating_system/launch/app_launcher.cc
@@ -35,73 +35,16 @@ AppLauncher::incomingRequest(AppLaunchRequest* req)
 {
   Params app_params = req->params();
   SoftwareId sid(req->aid(), os_->addr()-1);
-
   std::string app_name;
   if (app_params.count("label")) {
       app_name = app_params.find<std::string>("label","");
   }
   else app_name = app_params.find<std::string>("name","");
-  //std::cerr << "launching app_name " << app_name << std::endl;
   std::string exe = app_params.find<std::string>("exe","");
-  //std::cerr << "launching exe " << exe << std::endl;
-
   App::dlopenCheck(req->aid(), app_params);
-  //app_params.print_all_params(std::cerr);
   App* theapp = create<App>("hg", app_name, app_params, sid, os_);
-  //theapp->setUniqueName(lreq->uniqueName());
-  //int intranode_rank = num_apps_launched_[lreq->aid()]++;
-  //int core_affinity = lreq->coreAffinity(intranode_rank);
-  //if (core_affinity != Thread::no_core_affinity){
-  //    theapp->setAffinity(core_affinity);
-  //  }
-
   os_->startApp(theapp, "my unique name");
 }
 
-//void
-//AppLauncher::start()
-//{
-//  Service::start();
-//  if (!os_) {
-//    spkt_throw_printf(sprockit::ValueError,
-//                     "AppLauncher::start: OS hasn't been registered yet");
-//  }
-//}
-
-//hw::NetworkMessage*
-//LaunchRequest::cloneInjectionAck() const
-//{
-//  spkt_abort_printf("launch event should never be cloned for injection");
-//  return nullptr;
-//}
-
-//int
-//StartAppRequest::coreAffinity(int  /*intranode_rank*/) const
-//{
-//  return Thread::no_core_affinity;
-//}
-
-//void
-//StartAppRequest::serialize_order(serializer &ser)
-//{
-//  LaunchRequest::serialize_order(ser);
-//  ser & unique_name_;
-//  ser & app_params_;
-//  mapping_ = TaskMapping::serialize_order(aid(), ser);
-//}
-
-//std::string
-//StartAppRequest::toString() const
-//{
-//  return sprockit::sprintf("start_app_event: app=%d task=%d node=%d", aid(), tid(), toaddr());
-//}
-
-//std::string
-//JobStopRequest::toString() const
-//{
-//  return sprockit::sprintf("job_stop_event: app=%d task=%d node=%d", aid(), tid(), fromaddr());
-//}
-
-
-}
-}
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/operating_system/libraries/api.cc
+++ b/src/sst/elements/mercury/operating_system/libraries/api.cc
@@ -15,14 +15,11 @@
 
 #include <sst/core/params.h>
 #include <mercury/components/operating_system.h>
-//#include <libraries/compute/lib_compute_memmove.h>
 #include <mercury/operating_system/process/thread.h>
 #include <mercury/operating_system/process/app.h>
 #include <mercury/operating_system/libraries/api.h>
 #include <mercury/hardware/common/flow.h>
-//#include <sstmac/common/sstmac_env.h>
 #include <mercury/common/thread_lock.h>
-//#include <sprockit/keyword_registration.h>
 
 namespace SST {
 namespace Hg {
@@ -66,18 +63,11 @@ API::activeThread()
 void
 API::startAPICall()
 {
-//  if (host_timer_){
-//    host_timer_->start();
-//  }
   activeThread()->startAPICall();
 }
 void
 API::endAPICall()
 {
-//  if (host_timer_) {
-//    double time = host_timer_->stamp();
-//    api_parent_app_->compute(TimeDelta(time));
-//  }
   activeThread()->endAPICall();
 }
 

--- a/src/sst/elements/mercury/operating_system/libraries/api.h
+++ b/src/sst/elements/mercury/operating_system/libraries/api.h
@@ -17,7 +17,6 @@
 
 #include <sst/core/event.h>
 #include <sst/core/subcomponent.h>
-//#include <mercury/common/factory.h>
 #include <sst/core/eli/elementbuilder.h>
 #include <mercury/common/component.h>
 #include <mercury/common/events.h>

--- a/src/sst/elements/mercury/operating_system/process/app.h
+++ b/src/sst/elements/mercury/operating_system/process/app.h
@@ -18,7 +18,6 @@
 #include <sst/core/params.h>
 
 #include <mercury/common/component.h>
-//#include <mercury/common/factory.h>
 #include <sst/core/eli/elementbuilder.h>
 #include <mercury/components/operating_system.h>
 #include <mercury/operating_system/process/thread.h>
@@ -72,21 +71,6 @@ class App : public Thread
   void sleep(TimeDelta time);
 
   void compute(TimeDelta time);
-
-//  void computeInst(ComputeEvent* cmsg);
-
-//  void computeLoop(uint64_t num_loops,
-//    int nflops_per_loop,
-//    int nintops_per_loop,
-//    int bytes_per_loop);
-
-//  void computeBlockRead(uint64_t bytes);
-
-//  void computeBlockWrite(uint64_t bytes);
-
-//  void computeBlockMemcpy(uint64_t bytes);
-
-//  LibComputeMemmove* computeLib();
 
   ~App() override;
 
@@ -236,7 +220,6 @@ class App : public Thread
 
   void computeDetailed(uint64_t flops, uint64_t intops, uint64_t bytes, int nthread);
 
-//  LibComputeMemmove* compute_lib_;
   std::string unique_name_;
 
   int next_tls_key_;

--- a/src/sst/elements/mercury/operating_system/process/compute_scheduler.cc
+++ b/src/sst/elements/mercury/operating_system/process/compute_scheduler.cc
@@ -17,8 +17,6 @@
 #include <mercury/operating_system/process/compute_scheduler.h>
 #include <mercury/operating_system/process/thread.h>
 
-//RegisterDebugSlot(compute_scheduler, "Print all debug information related to the OS compute scheduler");
-
 namespace SST {
 namespace Hg {
 

--- a/src/sst/elements/mercury/operating_system/process/compute_scheduler.h
+++ b/src/sst/elements/mercury/operating_system/process/compute_scheduler.h
@@ -17,14 +17,10 @@
 
 #include <sst/core/params.h>
 #include <sst/core/eli/elementinfo.h>
-//#include <mercury/common/factory.h>
 #include <sst/core/eli/elementbuilder.h>
 #include <mercury/hardware/common/flow.h>
 #include <mercury/components/operating_system_fwd.h>
 #include <mercury/operating_system/process/thread_fwd.h>
-//#include <sprockit/debug.h>
-
-//DeclareDebugSlot(compute_scheduler)
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/operating_system/process/loadlib.cc
+++ b/src/sst/elements/mercury/operating_system/process/loadlib.cc
@@ -73,8 +73,6 @@ void* loadExternLibrary(const std::string& libname, const std::string& searchPat
                       libname.c_str(), searchPath.c_str());
   }
 
-  //std::cerr << "Loading external library " << fullpath << std::endl;
-
   // This is a little weird, but always try the last path - if we
   // didn't succeed in the stat, we'll get a file not found error
   // from dlopen, which is a useful error message for the user.

--- a/src/sst/elements/mercury/operating_system/process/progress_queue.cc
+++ b/src/sst/elements/mercury/operating_system/process/progress_queue.cc
@@ -1,46 +1,18 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
 #include <mercury/operating_system/process/progress_queue.h>
 #include <mercury/operating_system/libraries/unblock_event.h>
 #include <mercury/components/operating_system.h>
@@ -95,5 +67,5 @@ PollingQueue::unblock()
   ProgressQueue::unblock(pending_threads_);
 }
 
-}
-}
+} // end namespace Hg
+} // end namespace SST

--- a/src/sst/elements/mercury/operating_system/process/progress_queue.h
+++ b/src/sst/elements/mercury/operating_system/process/progress_queue.h
@@ -1,46 +1,17 @@
-/**
-Copyright 2009-2024 National Technology and Engineering Solutions of Sandia,
-LLC (NTESS).  Under the terms of Contract DE-NA-0003525, the U.S. Government
-retains certain rights in this software.
-
-Sandia National Laboratories is a multimission laboratory managed and operated
-by National Technology and Engineering Solutions of Sandia, LLC., a wholly
-owned subsidiary of Honeywell International, Inc., for the U.S. Department of
-Energy's National Nuclear Security Administration under contract DE-NA0003525.
-
-Copyright (c) 2009-2024, NTESS
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification, 
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-Questions? Contact sst-macro-help@sandia.gov
-*/
+// Copyright 2009-2024 NTESS. Under the terms
+// of Contract DE-NA0003525 with NTESS, the U.S.
+// Government retains certain rights in this software.
+//
+// Copyright (c) 2009-2024, NTESS
+// All rights reserved.
+//
+// Portions are copyright of other developers:
+// See the file CONTRIBUTORS.TXT in the top level directory
+// of the distribution for more information.
+//
+// This file is part of the SST software package. For license
+// information, see the LICENSE file in the top level directory of the
+// distribution.
 
 #pragma once
 
@@ -261,6 +232,6 @@ struct MultiProgressQueue : public ProgressQueue {
 
 };
 
-}
-}
+} // end namespace Hg
+} // end namespace SST
 

--- a/src/sst/elements/mercury/operating_system/process/simple_compute_scheduler.cc
+++ b/src/sst/elements/mercury/operating_system/process/simple_compute_scheduler.cc
@@ -16,7 +16,6 @@
 #include <mercury/components/operating_system.h>
 #include <mercury/operating_system/process/simple_compute_scheduler.h>
 #include <mercury/operating_system/process/thread.h>
-//#include <mercury/operating_system/process/sstmac_config.h>
 
 namespace SST {
 namespace Hg {

--- a/src/sst/elements/mercury/operating_system/process/thread.cc
+++ b/src/sst/elements/mercury/operating_system/process/thread.cc
@@ -18,14 +18,9 @@
 #include <mercury/common/output.h>
 #include <mercury/components/node.h>
 #include <mercury/components/operating_system.h>
-//#include <sstmac/common/stats/ftq.h>
 #include <mercury/operating_system/process/thread.h>
 #include <mercury/operating_system/process/thread_info.h>
 #include <mercury/operating_system/process/app.h>
-//#include <sstmac/software/libraries/library.h>
-//#include <sstmac/software/libraries/compute/compute_event.h>
-//#include <sstmac/software/api/api.h>
-//#include <sstmac/common/sst_event.h>
 
 #include <iostream>
 #include <exception>
@@ -35,10 +30,6 @@
 #include <stdlib.h>
 #include <cstdlib>
 #include <stdio.h>
-
-//#include <unusedvariablemacro.h>
-
-//MakeDebugSlot(host_compute)
 
 using namespace std;
 
@@ -170,11 +161,6 @@ Thread::Thread(SST::Params& params, SoftwareId sid, OperatingSystem* os) :
 {
   //make all cores possible active
   cpumask_ = ~(cpumask_);
-
-  //auto* ftq_stat = os->node()->registerMultiStatistic<int,uint64_t,uint64_t>(params, "ftq", subname);
-  //this will either be a null stat or an ftq stat
-  //the rest of the code will do null checks on the variable before dumping traces
-  //ftq_trace_ = dynamic_cast<FTQCalendar*>(ftq_stat)
 }
 
 void
@@ -199,8 +185,6 @@ Thread::endAPICall()
 uint32_t
 Thread::initId()
 {
-  //abort("aborting Thread::initID\n");
-  //thread id not yet initialized
   if (thread_id_ == Thread::main_thread)
     thread_id_ = THREAD_ID_CNT++;
   //I have not yet been assigned a process context (address space)
@@ -231,39 +215,10 @@ Thread::setTlsValue(long thekey, void *ptr)
   tls_values_[thekey] = ptr;
 }
 
-//void
-//Thread::appendBacktrace(int  /*id*/)
-//{
-//#if SST_HG_HAVE_CALL_GRAPH
-//  backtrace_[bt_nfxn_] = id;
-//  bt_nfxn_++;
-//#else
-//  sprockit::abort("did not compile with call graph support");
-//#endif
-//}
-
-//void
-//Thread::popBacktrace()
-//{
-//  --bt_nfxn_;
-//  last_bt_collect_nfxn_ = std::min(last_bt_collect_nfxn_, bt_nfxn_);
-//}
-
-//void
-//Thread::recordLastBacktrace(int nfxn)
-//{
-//  last_bt_collect_nfxn_ = nfxn;
-//}
-
 void
 Thread::spawn(Thread* thr)
 {
-//  abort("abort Thread::spawn\n");
   thr->parent_app_ = parentApp();
-//  if (host_timer_){
-//    thr->host_timer_ = new HostTimer;
-//    thr->host_timer_->start();
-//  }
   os_->startThread(thr);
 }
 
@@ -285,74 +240,12 @@ Thread::~Thread()
   //if (host_timer_) delete host_timer_;
 }
 
-//void
-//Thread::spawnOmpParallel()
-//{
-//  spkt_abort_printf("unimplemented: spawn_omp_parallel");
-//  omp_context& active = omp_contexts_.back();
-//  active.subthreads.resize(active.requested_num_subthreads);
-//  // App* parent = parentApp();
-//  // for (int i=1; i < active.requested_num_subthreads; ++i){
-//  //   thread* thr = new thread(params, parent->sid(), os_);
-//  //   thr->setOmpParentContext(active);
-//  //   startThread(thr);
-//  //   active.subthreads[i] = thr;
-//  // }
-//  //and finally have this thread enter the region as thread 0
-//  setOmpParentContext(0, active);
-//}
-
-//void
-//Thread::setOmpParentContext(int id, const omp_context& context)
-//{
-//  omp_contexts_.emplace_back();
-//  omp_context& active = omp_contexts_.back();
-//  active.level = context.level + 1;
-//  active.num_threads = context.requested_num_subthreads;
-//  active.max_num_subthreads = active.requested_num_subthreads =
-//      context.max_num_subthreads / context.requested_num_subthreads;
-//  active.id = id;
-//  active.parent_id = context.id;
-//}
-
-//void
-//Thread::computeDetailed(uint64_t flops, uint64_t nintops, uint64_t bytes, int nthread)
-//{
-//  omp_context& active = omp_contexts_.back();
-//  int used_nthread = nthread == use_omp_num_threads ? active.num_threads : nthread;
-//  parentApp()->computeDetailed(flops, nintops, bytes, used_nthread);
-//}
-
-//void
-//Thread::collectStats(
-//     Timestamp start,
-//     TimeDelta elapsed)
-//{
-//#if !SSTMAC_INTEGRATED_SST_CORE
-//#if SST_HG_HAVE_CALL_GRAPH
-//  if (callGraph_) {
-//    callGraph_->collect(elapsed.ticks(), this);
-//  }
-//#endif
-//  if (ftq_trace_){
-//    ftq_trace_->addData(ftag_.id(), start.time.ticks(), elapsed.ticks());
-//  }
-//#endif
-//}
-
 void
 Thread::startThread(Thread* thr)
 {
   thr->p_txt_ = p_txt_;
   os_->startThread(thr);
 }
-
-//void
-//Thread::setCpumask(uint64_t cpumask)
-//{
-//  cpumask_ = cpumask;
-//  os_->reassignCores(this);
-//}
 
 void
 Thread::join()
@@ -370,96 +263,3 @@ Thread::join()
 
 } // end namespace Hg
 } // end namespace SST
-
-//#include <sstmac/software/process/std_thread.h>
-//#include <sstmac/software/process/std_mutex.h>
-
-//namespace sstmac {
-//namespace sw {
-
-//class stdThread : public Thread {
-// public:
-//  stdThread(std_thread_base* base,
-//            Thread* parent) :
-//    Thread(parent->parentApp()->params(),
-//           SoftwareId(parent->aid(), parent->tid(), -1),
-//           parent->os()),
-//    base_(base)
-//  {
-//    parent_app_ = parent->parentApp();
-//    //std threads need to be joinable
-//    setDetachState(JOINABLE);
-//  }
-
-//  void run() override {
-//    base_->run();
-//  }
-
-// private:
-//  std_thread_base* base_;
-//};
-
-//int start_std_thread(std_thread_base* base)
-//{
-//  Thread* parent = OperatingSystem::currentThread();
-//  stdThread* thr = new stdThread(base, parent);
-//  base->setOwner(thr);
-//  parent->os()->startThread(thr);
-//  return thr->threadId();
-//}
-
-//void join_std_thread(std_thread_base *thr)
-//{
-//  thr->owner()->join();
-//}
-
-
-//stdMutex::stdMutex()
-//{
-//  parent_app_ = OperatingSystem::currentThread()->parentApp();
-//  id_ = parent_app_->allocateMutex();
-//}
-
-//void stdMutex::lock()
-//{
-//  mutex_t* mut = parent_app_->getMutex(id_);
-//  if (mut == nullptr){
-//    spkt_abort_printf("error: bad mutex id for std::mutex: %d", id_);
-//  } else if (mut->locked) {
-//    mut->waiters.push_back(OperatingSystem::currentThread());
-//    parent_app_->os()->block();
-//  } else {
-//    mut->locked = true;
-//  }
-//}
-
-//stdMutex::~stdMutex()
-//{
-//  parent_app_->eraseMutex(id_);
-//}
-
-//void stdMutex::unlock()
-//{
-//  mutex_t* mut = parent_app_->getMutex(id_);
-//  if (mut == nullptr || !mut->locked){
-//    return;
-//  } else if (!mut->waiters.empty()){
-//    Thread* blocker = mut->waiters.front();
-//    mut->waiters.pop_front();
-//    parent_app_->os()->unblock(blocker);
-//  } else {
-//    mut->locked = false;
-//  }
-//}
-
-//bool stdMutex::try_lock()
-//{
-//  mutex_t* mut = parent_app_->getMutex(id_);
-//  if (mut == nullptr){
-//    return false;
-//  } else if (mut->locked){
-//    return false;
-//  } else {
-//    return true;
-//  }
-//}

--- a/src/sst/elements/mercury/operating_system/process/thread.h
+++ b/src/sst/elements/mercury/operating_system/process/thread.h
@@ -168,12 +168,6 @@ class Thread
     return os_;
   }
 
-//  void collectStats(Timestamp start, TimeDelta elapsed);
-
-//  const int* backtrace() const {
-//    return backtrace_;
-//  }
-
   virtual bool isMainThread() const {
     return false;
   }
@@ -201,12 +195,6 @@ class Thread
   void incrementBlockCounter() {
     ++block_counter_;
   }
-
-//  void appendBacktrace(int fxnId);
-
-//  void popBacktrace();
-
-//  void recordLastBacktrace(int nfxn);
 
   void initThread(const SST::Params& params, int phyiscal_thread_id,
     ThreadContext* tocopy, void *stack, int stacksize,
@@ -281,46 +269,6 @@ class Thread
   void computeDetailed(uint64_t flops, uint64_t intops,
                         uint64_t bytes, int nthread=use_omp_num_threads);
 
-//  int ompGetThreadNum() const {
-//    auto& active = omp_contexts_.back();
-//    return active.id;
-//  }
-
-//  int ompGetNumThreads() const {
-//    auto& active = omp_contexts_.back();
-//    return active.num_threads;
-//  }
-
-//  int ompGetMaxThreads() const {
-//    auto& active = omp_contexts_.back();
-//    return active.max_num_subthreads;
-//  }
-
-//  int ompGetAncestorThreadNum() const {
-//    auto& active = omp_contexts_.back();
-//    return active.parent_id;
-//  }
-
-//  void ompSetNumThreads(int thr) {
-//    auto& active = omp_contexts_.back();
-//    active.requested_num_subthreads = thr;
-//  }
-
-//  int ompGetLevel() const {
-//    auto& active = omp_contexts_.back();
-//    return active.level;
-//  }
-
-//  int ompInParallel() {
-//    auto& active = omp_contexts_.back();
-//    bool parallel = active.level > 0;
-//    return parallel ? 1 : 0;
-//  }
-
-//  template <class T> static T* getCurrentApi(){
-//    return current()->getApi<T>();
-//  }
-
   void* getTlsValue(long thekey) const;
 
   void setTlsValue(long thekey, void* ptr);
@@ -330,20 +278,6 @@ class Thread
   void startAPICall();
 
   void endAPICall();
-
-//  void setTag(const FTQTag& t){
-//    ftag_ = t;
-//  }
-
-//  const FTQTag& tag() const {
-//    return ftag_;
-//  }
-
-//  void spawnOmpParallel();
-
-//  CallGraph* callGraph() const {
-//    return callGraph_;
-//  }
 
  protected:
   Thread(SST::Params& params,
@@ -389,16 +323,12 @@ class Thread
 
   ProcessContext p_txt_;
 
-//  FTQTag ftag_;
-
   SoftwareId sid_;
 
 //  HostTimer* host_timer_;
 
  private:
   API* getAppApi(const std::string& name) const;
-
-//  CallGraphTrace backtrace_; //each function is labeled by unique integer
 
   int last_bt_collect_nfxn_;
 
@@ -429,11 +359,6 @@ class Thread
   detach_t detach_state_;
 
   std::list<omp_context> omp_contexts_;
-
-//  CallGraph* callGraph_;
-
-//  FTQCalendar* ftq_trace_;
-
 };
 
 } // end namespace Hg

--- a/src/sst/elements/mercury/operating_system/process/thread_info.cc
+++ b/src/sst/elements/mercury/operating_system/process/thread_info.cc
@@ -19,10 +19,6 @@
 #include <mercury/operating_system/process/tls.h>
 #include <mercury/operating_system/threading/thread_lock.h>
 #include <mercury/operating_system/threading/stack_alloc.h>
-//#include <process/global.h>
-//#include <mercury/common/sstmac_config.h>
-//#include <sprockit/thread_safe_new.h>
-//#include <sstmac/skeleton_tls.h>
 
 #include <iostream>
 #include <string.h>


### PR DESCRIPTION
Major cleanup of Mercury environment.

- Removed much of the currently unused sst/macro code, but left some code commented out when it was deemed likely to be useful in the near future (or it would be burdensome to reincorporate it).
- Debugging now works using core output objects and verbosity params gets propagated, including to Hg::App.
- Switched to a single consistent copyright statement.
- Many miscellaneous code improvements.

