### PR TITLE
merlin/linkcontrol: fix memory leak on insufficient send credits

### DIFF
--- a/src/sst/elements/merlin/interfaces/linkControl.cc
+++ b/src/sst/elements/merlin/interfaces/linkControl.cc
@@ -443,7 +443,11 @@ bool LinkControl::send(SimpleNetwork::Request* req, int vn) {
     int flits = ev->getSizeInFlits();
 
     // Check to see if there are enough credits to send
-    if ( out_handle.credits < flits ) return false;
+    if ( out_handle.credits < flits ) {
+        ev->takeRequest();
+        delete ev;
+        return false;
+    }
 
     // Update the credits
     out_handle.credits -= flits;


### PR DESCRIPTION
LinkControl::send allocates a RtrEvent to first compute the number of flits needed to send a request. If there's not enough credits, the method returns early without deleting the RtrEvent object and leaks its memory. This patch deletes the object before returning to fix the leak.