### PR TITLE
merlin/hr_router: support user-defined portcontrol subcomponents

### DIFF
--- a/src/sst/elements/merlin/interfaces/portControl.cc
+++ b/src/sst/elements/merlin/interfaces/portControl.cc
@@ -286,7 +286,7 @@ PortControl::PortControl(ComponentId_t cid, Params& params,  Router* rif, int rt
                            "bits (b) or bytes (B): %s\n",flit_size.toStringBestSI().c_str());
     }
     if ( flit_size.hasUnits("B") ) {
-        flit_size *= UnitAlgebra("8b");
+        flit_size *= UnitAlgebra("8b/B");
     }
 
     std::string output_latency_timebase = params.find<std::string>("output_latency","0ns");


### PR DESCRIPTION
For my use-case, I wish to assign bandwidths to local ports different from router-to-router port bandwidths. Although a mechanism exists in hr_router to set heterogeneous port control parameters, it relies on topology logical groups, which is too coarse for assigning properties to local ports (and it's only really used by the dragonfly topology).

This patch checks for user-defined subcomponents on an hr_router's portcontrol slots during initialization and assigns them to the associated port. This is enough to override any port settings by setting the subcomponent on any router after building a topology in pymerlin.

Also includes a small unit-conversion fix for flit_size in portControl that turned up while testing.