### PR TITLE
Remove calls to deprecated Python test framework functions

### DIFF
--- a/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
@@ -36,12 +36,12 @@ class testcase_Ariel(SSTTestCase):
         self.ariel_Template("memHstream")
 
     @unittest.skipIf(not pin_loaded, "Ariel: Requires PIN, but Env Var 'INTEL_PIN_DIRECTORY' is not found or path does not exist.")
-    @unittest.skipIf(host_os_is_osx(), "Ariel: Open MP is not supported on OSX.")
+    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_OSX, "Ariel: Open MP is not supported on OSX.")
     def test_Ariel_test_ivb(self):
         self.ariel_Template("ariel_ivb")
 
     @unittest.skipIf(not pin_loaded, "Ariel: Requires PIN, but Env Var 'INTEL_PIN_DIRECTORY' is not found or path does not exist.")
-    @unittest.skipIf(host_os_is_osx(), "Ariel: Open MP is not supported on OSX.")
+    @unittest.skipIf(host_os_get_distribution_type() == OS_DIST_OSX, "Ariel: Open MP is not supported on OSX.")
     @unittest.skipIf(testing_check_get_num_ranks() > 1, "Ariel: test_Ariel_test_snb skipped if ranks > 1 - Sandy Bridge test is incompatible with Multi-Rank.")
     def test_Ariel_test_snb(self):
         self.ariel_Template("ariel_snb")
@@ -152,7 +152,7 @@ class testcase_Ariel(SSTTestCase):
         # It is set in the Makefile but we set it here as well
         # to support out-of-source builds
         #ArielApiDir = "{0}/api".format(self.ArielElementDir)
-        ElementsBuildDir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY", "SST_ELEMENT_LIBRARY_BUILDDIR")
+        ElementsBuildDir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY", "SST_ELEMENT_LIBRARY_BUILDDIR", str)
         ArielApiDir = "{0}/src/sst/elements/ariel/api".format(ElementsBuildDir)
         current_ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")
 

--- a/src/sst/elements/ariel/tests/testsuite_mpi_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_mpi_Ariel.py
@@ -80,7 +80,7 @@ class testcase_Ariel(SSTTestCase):
     multi_rank = testing_check_get_num_ranks() > 1
     multi_rank_error_msg = "Ariel: Ariel MPI tests are not compatible with multi-rank sst runs."
 
-    using_osx = host_os_is_osx()
+    using_osx = host_os_get_distribution_type() == OS_DIST_OSX
     osx_error_msg = "Ariel: OpenMP is not supported on macOS"
 
     # TODO: This is hacky. What is the correct way to get the test script location?

--- a/src/sst/elements/cramSim/tests/test_txntrace.py
+++ b/src/sst/elements/cramSim/tests/test_txntrace.py
@@ -39,11 +39,10 @@ def read_arguments():
 def setup_config_params(config_file_list, override_list):
     l_params = {}
     for l_configFileEntry in config_file_list:
-        l_configFile = open(l_configFileEntry, 'r')
-        for l_line in l_configFile:
-            l_tokens = l_line.split()
-            #print (l_tokens[0], ": ", l_tokens[1])
-            l_params[l_tokens[0]] = l_tokens[1]
+        with open(l_configFileEntry) as l_configFile:
+            for l_line in l_configFile:
+                l_tokens = l_line.split()
+                l_params[l_tokens[0]] = l_tokens[1]
 
     for override in override_list:
         l_tokens = override.split("=")

--- a/src/sst/elements/ember/test/generateNidListQOS.py
+++ b/src/sst/elements/ember/test/generateNidListQOS.py
@@ -30,7 +30,7 @@ def _random_linear( args ):
     global _nids
     size = int(args[0])
 
-    if len(args) is 2 :
+    if len(args) == 2:
         random.seed(int(args[1]))
     
     random.shuffle(_nids)
@@ -150,7 +150,7 @@ def generate( args ):
     global _apps
     _apps.append(app)
 
-    if len(_nids) is 0 :
+    if not len(_nids):
         _finalize_qos_config(total_nodes)
     
     return ','.join(str(num) for num in nid_list)

--- a/src/sst/elements/ember/test/generateNidListQOS.py
+++ b/src/sst/elements/ember/test/generateNidListQOS.py
@@ -16,7 +16,7 @@ def _random( args ):
     global _nids
     size = int(args[0])
 
-    if len(args) is 2 :
+    if len(args) == 2:
         random.seed(int(args[1]))
     
     random.shuffle(_nids)

--- a/src/sst/elements/ember/tests/testsuite_default_ember_otf2.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_otf2.py
@@ -8,7 +8,7 @@ import os
 
 class testcase_EmberOTF2(SSTTestCase):
 
-    otf2_support = sst_elements_config_include_file_get_value_int("HAVE_OTF2", 0, True) > 0
+    otf2_support = sst_elements_config_include_file_get_value("HAVE_OTF2", int, 0, True) > 0
 
     def setUp(self):
         super(type(self), self).setUp()

--- a/src/sst/elements/gensa/tests/OutputParser.py
+++ b/src/sst/elements/gensa/tests/OutputParser.py
@@ -101,7 +101,8 @@ class OutputParser:
         self.rows         = 0
 
     def close(self):
-        if self.inFile: self.inFile.close()
+        if self.inFile is not None:
+            self.inFile.close()
         self.inFile = None
         self.columns = []
 
@@ -175,7 +176,9 @@ class OutputParser:
                 if c < count: column.values.append(column.value)
                 else:         column.values.append(defaultValue)  # Because the structure is not sparse, we must fill out every row.
                 c += 1
-        if len(self.columns) == 0: return  # failed to read any input, not even a header row
+        if len(self.columns) == 0:
+            self.close()
+            return  # failed to read any input, not even a header row
 
         # If there is a separate columns file, open and parse it.
         columnFileName = fileName + ".columns"

--- a/src/sst/elements/gensa/tests/testsuite_default_gensa.py
+++ b/src/sst/elements/gensa/tests/testsuite_default_gensa.py
@@ -69,6 +69,7 @@ class testcase_gensa_Component(SSTTestCase):
         if not self.checkColumn(o, "13", [1,1,1,0]): cmp_result = False
         if not self.checkColumn(o, "14", [1,1,0,0]): cmp_result = False
         self.assertTrue(cmp_result, "Output file {0}/out does not contain expected spike pattern".format(outdir))
+        o.close()
 
     def checkColumn(self, o, index, pattern):
         c = o.getColumn(index)

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
@@ -21,7 +21,7 @@ class testcase_memHierarchy_memHSieve(SSTTestCase):
 
 #####
     pin_compiled = testing_is_PIN_Compiled()
-    pin_version_valid = testing_is_PIN2_used() | testing_is_PIN3_used()
+    pin_version_valid = testing_is_PIN3_used()
     pin_loaded = testing_is_PIN_loaded()
 
     @unittest.skipIf(not pin_compiled, "memHSieve: Requires PIN, but PinTool is not compiled with Elements. In sst_element_config.h PINTOOL_EXECUTABLE={0}".format(pin_exec_path))
@@ -34,7 +34,6 @@ class testcase_memHierarchy_memHSieve(SSTTestCase):
 
     def memHSieve_Template(self, testcase, testtimeout=360):
 
-        pin2defined = testing_is_PIN2_used()
         pin3defined = testing_is_PIN3_used()
 
         # Get the path to the test files

--- a/src/sst/elements/mercury/tests/testsuite_default_hg.py
+++ b/src/sst/elements/mercury/tests/testsuite_default_hg.py
@@ -21,7 +21,7 @@ class testcase_hg(SSTTestCase):
 
     def test_testme(self):
         testdir = self.get_testsuite_dir()
-        libdir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR")
+        libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR", str)
         path = os.environ.get("SST_LIB_PATH")
         if path is None or path == "":
             os.environ["SST_LIB_PATH"] = libdir

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -27,7 +27,7 @@ class testcase_prospero(SSTTestCase):
 #####
     pin_loaded = testing_is_PIN_loaded()
     pin3_used = testing_is_PIN3_used()
-    libz_missing = not sst_elements_config_include_file_get_value_int("HAVE_LIBZ", default=0, disable_warning=True)
+    libz_missing = not sst_elements_config_include_file_get_value("HAVE_LIBZ", type=int, default=0, disable_warning=True)
 
     @unittest.skipIf(libz_missing, "test_prospero_compressed_using_TAR_traces test: Requires LIBZ, but LIBZ is not found in build configuration.")
     def test_prospero_compressed_using_TAR_traces(self):
@@ -225,7 +225,7 @@ class testcase_prospero(SSTTestCase):
         self.assertTrue(rtn.result() == 0, "array.c failed to compile")
 
         # Make sure we have access to the sst-prospero-trace binary
-        elem_bin_dir = sstsimulator_conf_get_value_str("SST_ELEMENT_LIBRARY", "SST_ELEMENT_LIBRARY_BINDIR", "BINDIR_UNDEFINED")
+        elem_bin_dir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY", "SST_ELEMENT_LIBRARY_BINDIR", str, "BINDIR_UNDEFINED")
         log_debug("Elements bin_dir = {0}".format(elem_bin_dir))
         filepath_sst_prospero_trace_app = "{0}/sst-prospero-trace".format(elem_bin_dir)
         if os.path.isfile(filepath_sst_prospero_trace_app):


### PR DESCRIPTION
This removes calls to test functions that were deprecated (https://github.com/sstsimulator/sst-core/pull/1136, https://github.com/sstsimulator/sst-core/pull/1137, https://github.com/sstsimulator/sst-core/pull/1145) and fixes a few other warnings, particularly about unclosed files.