### PR TITLE
unittest: replace assertEquals with assertEqual

### DIFF
--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
@@ -106,7 +106,7 @@ class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "openMP dirnoncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "openMP dirnoncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -120,7 +120,7 @@ class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "openMP dirnoncacheable testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "openMP dirnoncacheable testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
@@ -110,7 +110,7 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "openMP diropenMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "openMP diropenMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -124,7 +124,7 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "openMP diropenMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "openMP diropenMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
@@ -108,7 +108,7 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "openMP noncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "openMP noncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -122,7 +122,7 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "openMP noncacheable testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "openMP noncacheable testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
@@ -110,7 +110,7 @@ class testcase_memH_openMP_openMP(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "openMP openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "openMP openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -124,7 +124,7 @@ class testcase_memH_openMP_openMP(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "openMP openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "openMP openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
@@ -236,7 +236,7 @@ class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "Sweep dir3LevelSweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "Sweep dir3LevelSweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -250,7 +250,7 @@ class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "Sweep dir3LevelSweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "Sweep dir3LevelSweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
@@ -207,7 +207,7 @@ class testcase_memH_sweep_dirsweep(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "Sweep dirsweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "Sweep dirsweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -221,7 +221,7 @@ class testcase_memH_sweep_dirsweep(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "Sweep dirsweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "Sweep dirsweep testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
@@ -207,7 +207,7 @@ class testcase_memH_sweep_dirsweepB(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "Sweep dirsweepB Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "Sweep dirsweepB Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -221,7 +221,7 @@ class testcase_memH_sweep_dirsweepB(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "Sweep dirsweepB testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "Sweep dirsweepB testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
@@ -219,7 +219,7 @@ class testcase_memH_sweep_dirsweepI(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "Sweep dirsweepI Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "Sweep dirsweepI Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -233,7 +233,7 @@ class testcase_memH_sweep_dirsweepI(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "Sweep dirsweepI testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "Sweep dirsweepI testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
@@ -207,7 +207,7 @@ class testcase_memH_sweep_openMP(SSTTestCase):
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
                     rtn = OSCommand(cmd).run()
-                    self.assertEquals(rtn.result(), 0, "Sweep openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
+                    self.assertEqual(rtn.result(), 0, "Sweep openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
@@ -221,7 +221,7 @@ class testcase_memH_sweep_openMP(SSTTestCase):
                     log_debug("Testline='{0}'; refcount={1}; outcount={2}".format(testline, refcount, outcount))
 
                     # Compare the count
-                    self.assertEquals(outcount, refcount, "Sweep openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
+                    self.assertEqual(outcount, refcount, "Sweep openMP testing line '{0}': outfile count = {1} does not match reffile count = {2}".format(testline, outcount, refcount))
 
 ###############################################
 


### PR DESCRIPTION
According to https://docs.python.org/3.9/library/unittest.html, `assertEquals` has been deprecated since at least Python 3.2, so this silences a lot of output in running these tests.