### PR TITLE
Merlin: fix typo in pymerlin-topo-mesh script

### DIFF
--- a/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
@@ -77,9 +77,9 @@ class _topoMeshBase(Topology):
 
 
     def setShape(self,shape,width,local_ports):
-        this.shape = shape
-        this.width = width
-        this.local_ports = local_ports
+        self.shape = shape
+        self.width = width
+        self.local_ports = local_ports
         
     def _formatShape(self, arr):
         return 'x'.join([str(x) for x in arr])


### PR DESCRIPTION
A simple fix for an apparent typo in the merlin topology script.
See also: https://github.com/sstsimulator/sst-elements/issues/2446
