### PR TITLE
Enable MPI time statistics in Ember

### DIFF
--- a/src/sst/elements/ember/emberengine.cc
+++ b/src/sst/elements/ember/emberengine.cc
@@ -27,23 +27,22 @@ using namespace std;
 using namespace SST::Ember;
 using namespace SST::Hermes;
 
-EmberEngine::EmberEngine(SST::ComponentId_t id, SST::Params& params) :
+EmberEngine::EmberEngine( SST::ComponentId_t id, SST::Params& params ) :
     Component( id ),
-	currentMotif(0),
-	m_motifDone(false),
-	m_detailedCompute(NULL)
+    m_currentMotif( 0 ),
+    m_motifDone( false ),
+    m_detailedCompute( nullptr )
 {
-	// Get the level of verbosity the user is asking to print out, default is 1
-	// which means don't print much.
-	uint32_t verbosity = (uint32_t) params.find("verbose", 1);
-	uint32_t mask = (uint32_t) params.find("verboseMask", 0);
-	m_jobId = params.find("jobId", -1);
+    // Get the level of verbosity the user is asking to print out, default is 1
+    // which means don't print much.
+    uint32_t verbosity = (uint32_t) params.find( "verbose", 1 );
+    uint32_t mask = (uint32_t) params.find( "verboseMask", 0 );
+    m_jobId = params.find( "jobId", -1 );
 
+    std::ostringstream prefix;
+    prefix << "@t:" << m_jobId << ":EmberEngine:@p:@l: ";
 
-	std::ostringstream prefix;
-	prefix << "@t:" << m_jobId << ":EmberEngine:@p:@l: ";
-
-	output.init( prefix.str(), verbosity, mask, Output::STDOUT);
+    output.init( prefix.str(), verbosity, mask, Output::STDOUT );
 
     std::ostringstream tmp;
     tmp << m_jobId;
@@ -55,61 +54,88 @@ EmberEngine::EmberEngine(SST::ComponentId_t id, SST::Params& params) :
     m_detailedCompute = m_os->getDetailedCompute();
     m_memHeapLink = m_os->getMemHeapLink();
 
-    std::string motifLogFile = params.find<std::string>("motifLog", "");
-    if("" != motifLogFile) {
-        m_motifLogger = loadComponentExtension<EmberMotifLog>(motifLogFile, m_jobId);
+    std::string motifLogFile = params.find<std::string>( "motifLog", "" );
+    if ( "" != motifLogFile ) {
+        m_motifLogger = loadComponentExtension<EmberMotifLog>( motifLogFile, m_jobId );
     } else {
         m_motifLogger = nullptr;
     }
-	output.verbose(CALL_INFO, 2, ENGINE_MASK, "\n");
+    output.verbose( CALL_INFO, 2, ENGINE_MASK, "\n" );
 
-	// create a map of all the available API's
-	m_apiMap = createApiMap( m_os, this, params );
-    assert( ! m_apiMap.empty() );
+    // create a map of all the available API's
+    m_apiMap = createApiMap( m_os, this, params );
+    assert( !m_apiMap.empty() );
 
-	motifParams.resize( params.find("motif_count", 1) );
-	output.verbose(CALL_INFO, 2, ENGINE_MASK, "Identified %ld motifs "
-                                    "to be simulated.\n", motifParams.size());
+    m_numMotifs = params.find( "motif_count", 1 );
+    output.verbose( CALL_INFO, 2, ENGINE_MASK, "Identified %u motifs "
+                    "to be simulated.\n", m_numMotifs );
 
-	for ( unsigned int i = 0;  i < motifParams.size(); i++ ) {
-		std::ostringstream tmp;
-    	tmp << i;
+    if ( m_numMotifs == 0 ) {
+        output.fatal( CALL_INFO, -1, "Error: need to specify at least one motif\n" );
+    }
 
+    for ( int i = 0;  i < m_numMotifs; i++ ) {
+        std::ostringstream tmp;
+        tmp << i;
         //NetworkSim: Add the rankmapper parameter as motif parameters and pass it.
-        params.insert("motif" + tmp.str() + ".rankmapper", params.find<string>("rankmapper", "ember.LinearMap"), true);
-
+        params.insert( "motif" + tmp.str() + ".rankmapper",
+                       params.find<string>( "rankmapper", "ember.LinearMap" ), true );
         //NetworkSim: Add the mapFile parameter as motif parameters and pass it.
-        params.insert("motif" + tmp.str() + ".rankmap.mapFile", params.find<string>("mapFile", "mapFile.txt"), true);
-        //NetworkSim->end
+        params.insert( "motif" + tmp.str() + ".rankmap.mapFile",
+                       params.find<string>("mapFile", "mapFile.txt"), true );
 
-		motifParams[i] = params.get_scoped_params( "motif" + tmp.str() );
-	}
+        SST::Params motifParams = params.get_scoped_params( "motif" + tmp.str() );
+
+        EmberGenerator* gen = createMotif( motifParams,
+                                           m_apiMap,
+                                           m_jobId,
+                                           i,
+                                           m_nodePerf );
+        assert( gen );
+        m_motifs.push_back( gen );
+    }
 
     registerAsPrimaryComponent();
 
     // Init the first Motif
-    m_generator = initMotif( motifParams[0], m_apiMap, m_jobId,
-                        currentMotif, m_nodePerf );
+    assert(m_currentMotif == 0);
+    m_generator = m_motifs[0];
     assert( m_generator );
+    m_generator->configure();
 
-	// Configure self link to handle event timing
-	selfEventLink = configureSelfLink("self", "1ps",
-		new Event::Handler<EmberEngine>(this, &EmberEngine::handleEvent));
-    assert(selfEventLink);
+    output.verbose( CALL_INFO, 4, MOTIF_START_STOP_MASK,
+                    "Starting motif: %s\n", m_generator->getMotifName().c_str() );
 
-	// Create a time converter for our compute events
-	nanoTimeConverter = getTimeConverter("1ns");
+    // Make sure we don't stop the simulation until we are ready
+    if ( m_generator->primary() ) {
+        primaryComponentDoNotEndSim();
+    }
+
+    // Configure self link to handle event timing
+    auto eventHandler = new Event::Handler<EmberEngine>( this, &EmberEngine::handleEvent );
+    selfEventLink = configureSelfLink( "self", "1ps", eventHandler );
+    assert( selfEventLink );
+
+    // Create a time converter for our compute events
+    nanoTimeConverter = getTimeConverter( "1ns" );
 }
 
 EmberEngine::~EmberEngine() {
-	ApiMap::iterator iter = m_apiMap.begin();
-	for ( ; iter != m_apiMap.end(); ++ iter ) {
-		delete iter->second;
-	}
+    ApiMap::iterator iter = m_apiMap.begin();
+    for ( ; iter != m_apiMap.end(); ++ iter ) {
+        delete iter->second;
+    }
 
-	if(NULL != m_motifLogger) {
-		delete m_motifLogger;
-	}
+    if (nullptr != m_motifLogger) {
+        delete m_motifLogger;
+    }
+
+    for ( size_t i = 0; i < m_motifs.size(); i++ ) {
+        if (m_motifs[i]) {
+            std::cout << "WARNING: Motif " << m_motifs[i]->getMotifName() << " has not completed\n";
+            delete m_motifs[i];
+        }
+    }
 }
 
 EmberEngine::ApiMap EmberEngine::createApiMap( OS* os,
@@ -166,43 +192,36 @@ EmberEngine::ApiMap EmberEngine::createApiMap( OS* os,
     return tmp;
 }
 
-EmberGenerator* EmberEngine::initMotif( SST::Params params,
+EmberGenerator* EmberEngine::createMotif( SST::Params params,
 	const ApiMap& apiMap, int jobId, int motifNum, NodePerf* nodePerf )
 {
     EmberGenerator* gen = NULL;
 
     // get the name of the motif
     std::string gentype = params.find<std::string>( "name" );
-	assert( !gentype.empty() );
 
     // if(NULL != m_motifLogger) {
     //     m_motifLogger->logMotifStart(gentype, motifNum);
     // }
 
-	output.verbose(CALL_INFO, 2, ENGINE_MASK, "motif=`%s`\n", gentype.c_str());
+    if( gentype.empty() ) {
+        output.fatal( CALL_INFO, -1, "Error: You did not specify a generator "
+                                     "or Ember to use\n" );
+    } else {
+	    output.verbose( CALL_INFO, 2, ENGINE_MASK, "motif=`%s`\n", gentype.c_str() );
 
-	if( gentype.empty()) {
-		output.fatal(CALL_INFO, -1, "Error: You did not specify a generator"
-                "or Ember to use\n");
-	} else {
-		params.insert("_jobId", std::to_string( jobId ), true);
-		params.insert("_motifNum", std::to_string( motifNum ), true);
-		assert( sizeof(this) == sizeof(uint64_t) );
-		params.insert("_enginePtr", std::to_string( reinterpret_cast<uint64_t>( this ) ), true);
+        params.insert( "_jobId", std::to_string( jobId ), true );
+        params.insert( "_motifNum", std::to_string( motifNum ), true );
+        assert( sizeof( this ) == sizeof( uint64_t ) );
+        params.insert( "_enginePtr", std::to_string( reinterpret_cast<uint64_t>( this ) ), true);
 
-		gen = loadAnonymousSubComponent<EmberGenerator>( gentype, "", 0, ComponentInfo::SHARE_NONE, params );
+        gen = loadAnonymousSubComponent<EmberGenerator>( gentype, "", 0, ComponentInfo::SHARE_NONE, params );
+        if ( !gen ) {
+            output.fatal( CALL_INFO, -1, "Error: Could not load the "
+                                         "generator %s for Ember\n", gentype.c_str() );
+        }
 
-		if(NULL == gen) {
-			output.fatal(CALL_INFO, -1, "Error: Could not load the "
-                    "generator %s for Ember\n", gentype.c_str());
-		}
-
-                gen->setup();
-	}
-
-	// Make sure we don't stop the simulation until we are ready
-    if ( gen->primary() ) {
-        primaryComponentDoNotEndSim();
+        gen->setup();
     }
 
     return gen;
@@ -251,37 +270,71 @@ void EmberEngine::issueNextEvent(uint64_t nanoDelay) {
 
     output.debug(CALL_INFO, 8, ENGINE_MASK, "Engine issuing next event with delay %" PRIu64 "\n", nanoDelay);
 
+    // This loop tries to generate at least one event.
+    // When the currently executed motif gets drained, continue with the next motif,
+    // until there are no more motifs to simulate.
     while ( evQueue.empty() ) {
 
-        if ( ! m_motifDone ) {
+        if ( !m_motifDone ) {
+            // Enque some new events
             m_motifDone = refillQueue();
         }
 
-        // if the event Queue is empty after a refill the motif is done
-        if (  evQueue.empty() ) {
-            if (NULL != m_motifLogger) {
-                m_motifLogger->logMotifEnd(m_generator->getMotifName(),currentMotif);
+        if ( evQueue.empty() ) {
+
+            // No more events in the current motif
+
+            // Finalize the current motif
+            if ( NULL != m_motifLogger ) {
+                m_motifLogger->logMotifEnd( m_generator->getMotifName(), m_currentMotif );
             }
-            // output.verbose(CALL_INFO, 1, MOTIF_START_STOP_MASK, "Motif finished: %s\n",m_generator->getMotifName().c_str());
+
+            output.verbose( CALL_INFO, 4, MOTIF_START_STOP_MASK,
+                            "Motif finished: %s\n", m_generator->getMotifName().c_str() );
+
             m_generator->completed( &output, getCurrentSimTimeNano() );
-            if ( m_generator->primary() ) {
-	            primaryComponentOKToEndSim();
-            }
+
+            const bool wasPrimary = m_generator->primary();
+
             delete m_generator;
+            m_motifs[m_currentMotif] = nullptr;
 
-            if ( ++currentMotif == motifParams.size() ) {
-                return;
-            } else {
-                m_generator = initMotif( motifParams[currentMotif],
-								m_apiMap, m_jobId, currentMotif, m_nodePerf );
-                assert( m_generator );
-                if (NULL != m_motifLogger) {
-                    m_motifLogger->logMotifStart(currentMotif);
+            m_currentMotif++;
+
+            // See if there are more motifs to simulate
+
+            if ( m_currentMotif == m_numMotifs ) {
+                output.verbose( CALL_INFO, 4, MOTIF_START_STOP_MASK,
+                            "All (%d) motifs have finished\n", m_numMotifs );
+                if ( wasPrimary ) {
+                    primaryComponentOKToEndSim();
                 }
-                // output.verbose(CALL_INFO, 1, MOTIF_START_STOP_MASK, "Motif starting: %s\n",m_generator->getMotifName().c_str());
 
-                m_motifDone = refillQueue();
+                return;
             }
+
+            m_generator = m_motifs[m_currentMotif];
+            assert( m_generator );
+            m_generator->configure();
+
+            const bool isPrimary = m_generator->primary();
+            if ( wasPrimary != isPrimary ) {
+                if ( isPrimary ) {
+                    primaryComponentDoNotEndSim();
+                }
+                else {
+                    primaryComponentOKToEndSim();
+                }
+            }
+
+            if ( NULL != m_motifLogger ) {
+                m_motifLogger->logMotifStart( m_currentMotif );
+            }
+
+            output.verbose( CALL_INFO, 4, MOTIF_START_STOP_MASK,
+                            "Motif starting: %s\n", m_generator->getMotifName().c_str());
+
+            m_motifDone = refillQueue();
         }
     }
 

--- a/src/sst/elements/ember/emberengine.h
+++ b/src/sst/elements/ember/emberengine.h
@@ -54,7 +54,8 @@ public:
         { "motif_count", "Sets the number of motifs which will be run in this simulation, default is 1", "1"},
         { "rankmapper", "Sets the rank mapping SST module to load to rank translations, default is linear mapping", "ember.LinearMap" },
         { "mapFile", "Sets the name of the input file for custom map", "mapFile.txt" },
-
+        { "enableMpiStatsPerMotif", "Creates separate MPI time stats for each MPI motif. "
+                                    "Set to 0 to make all MPI motifs within an EmberEngine use the same time stats.", "1"},
         { "motif%(motif_count)d", "Sets the event generator or motif for the engine", "ember.EmberPingPongGenerator" },
     )
 	/* PARAMS
@@ -133,7 +134,8 @@ private:
     ApiMap createApiMap( Hermes::OS* os, SST::Component*, SST::Params );
 
     EmberGenerator* createMotif( SST::Params, const ApiMap&, int jobId,
-                                 int motifNum, Hermes::NodePerf* nodePerf );
+                                 int motifNum, Hermes::NodePerf* nodePerf,
+                                 bool statsPerMotif );
 
     int         m_jobId;
     int         m_currentMotif;

--- a/src/sst/elements/ember/emberengine.h
+++ b/src/sst/elements/ember/emberengine.h
@@ -131,31 +131,33 @@ private:
     typedef std::map< std::string, ApiInfo* > ApiMap;
 
     ApiMap createApiMap( Hermes::OS* os, SST::Component*, SST::Params );
-    EmberGenerator* initMotif( SST::Params, const ApiMap&,
-					int jobId, int motifNum, Hermes::NodePerf* nodePerf );
 
-	int         m_jobId;
-	uint32_t    currentMotif;
+    EmberGenerator* createMotif( SST::Params, const ApiMap&, int jobId,
+                                 int motifNum, Hermes::NodePerf* nodePerf );
+
+    int         m_jobId;
+    int         m_currentMotif;
+    int         m_numMotifs;
     bool        m_motifDone;
     ApiMap      m_apiMap;
-	Output      output;
+    Output      output;
 
-	std::queue<EmberEvent*> evQueue;
+    std::queue<EmberEvent*> evQueue;
 
     Hermes::NodePerf*   m_nodePerf;
-	EmberGenerator*     m_generator;
-	SST::Link*          selfEventLink;
-	SST::TimeConverter* nanoTimeConverter;
-	EmberMotifLog*      m_motifLogger;
+    EmberGenerator*     m_generator;
+    SST::Link*          selfEventLink;
+    SST::TimeConverter* nanoTimeConverter;
+    EmberMotifLog*      m_motifLogger;
 
-	std::vector<SST::Params> motifParams;
-	Thornhill::DetailedCompute* m_detailedCompute;
-	Thornhill::MemoryHeapLink*  m_memHeapLink;
+    std::vector<EmberGenerator*> m_motifs;
 
-	EmberEngine();			    		// For serialization
-	EmberEngine(const EmberEngine&);    // Do not implement
-	void operator=(const EmberEngine&); // Do not implement
+    Thornhill::DetailedCompute* m_detailedCompute;
+    Thornhill::MemoryHeapLink*  m_memHeapLink;
 
+    EmberEngine();			    		// For serialization
+    EmberEngine(const EmberEngine&);    // Do not implement
+    void operator=(const EmberEngine&); // Do not implement
 };
 
 }

--- a/src/sst/elements/ember/embergen.h
+++ b/src/sst/elements/ember/embergen.h
@@ -70,8 +70,11 @@ class EmberGenerator : public SubComponent {
 
 	~EmberGenerator(){ };
 
-    virtual void generate( const SST::Output* output, const uint32_t phase,
-        std::queue<EmberEvent*>* evQ ) {
+    virtual void configure() = 0;
+
+    virtual void generate( const SST::Output* output,
+                           const uint32_t phase,
+                           std::queue<EmberEvent*>* evQ ) {
         assert(0);
     }
 
@@ -85,9 +88,8 @@ class EmberGenerator : public SubComponent {
 
     virtual bool primary( ) { return m_primary; }
 
-    virtual std::string getComputeModelName() {
-        return "";
-    }
+    virtual std::string getComputeModelName() { return ""; }
+
     EmberLib* getLib(std::string name );
 
 

--- a/src/sst/elements/ember/libs/emberMpiLib.h
+++ b/src/sst/elements/ember/libs/emberMpiLib.h
@@ -63,36 +63,6 @@ namespace Ember {
 
 static SST::Output abort_output("EmberMpiLib: ", 5, -1, Output::STDERR);
 
-#undef FOREACH_ENUM
-#define FOREACH_ENUM(NAME) \
-    NAME( Init ) \
-    NAME( Finalize ) \
-    NAME( Rank ) \
-    NAME( Size ) \
-    NAME( Send ) \
-    NAME( Recv ) \
-    NAME( Irecv ) \
-    NAME( Isend ) \
-    NAME( Wait ) \
-    NAME( Waitall ) \
-    NAME( Waitany ) \
-    NAME( Compute ) \
-    NAME( Barrier ) \
-    NAME( Alltoallv ) \
-    NAME( Alltoall ) \
-    NAME( Allreduce ) \
-    NAME( Reduce ) \
-    NAME( Bcast) \
-    NAME( Scatter) \
-    NAME( Scatterv) \
-    NAME( Gettime ) \
-    NAME( Commsplit ) \
-    NAME( Commcreate ) \
-    NAME( NUM_EVENTS ) \
-
-#define GENERATE_ENUM(ENUM) ENUM,
-#define GENERATE_STRING(STRING) #STRING,
-
 class EmberSpyInfo {
   public:
     EmberSpyInfo(const int32_t rank)
@@ -115,10 +85,6 @@ const uint32_t EMBER_SPYPLOT_SEND_COUNT = 1;
 const uint32_t EMBER_SPYPLOT_SEND_BYTES = 2;
 
 class EmberMpiLib : public EmberLib {
-
-    enum Events {
-        FOREACH_ENUM(GENERATE_ENUM)
-    };
 
   public:
 
@@ -384,11 +350,12 @@ class EmberMpiLib : public EmberLib {
 		m_backed = true;
 	}
 
-        void setNotBacked() {
-                m_backed = false;
-        }
+    void setNotBacked() {
+        m_backed = false;
+    }
 
-	void completed(const SST::Output* output, uint64_t time, std::string motifName, int motifNum );
+    void setEventStatistics(std::vector<Statistic<uint32_t>*>& stats);
+	void completed( const SST::Output* output, uint64_t time, std::string motifName, int motifNum );
 
   private:
     virtual void* memAddr( void * addr ) {
@@ -396,8 +363,7 @@ class EmberMpiLib : public EmberLib {
     }
 
 	MP::Interface& api() { return *static_cast<MP::Interface*>(m_api); }
-	std::vector< Statistic<uint32_t>* > m_Stats;
-	static const char*  m_eventName[];
+	std::vector< EventTimeStat* > m_Stats;
 
 	bool m_backed;
 	int m_size;

--- a/src/sst/elements/ember/libs/mpi/emberMPIEvent.h
+++ b/src/sst/elements/ember/libs/mpi/emberMPIEvent.h
@@ -26,7 +26,44 @@ using namespace Hermes::MP;
 namespace SST {
 namespace Ember {
 
-typedef Statistic<uint32_t> EmberEventTimeStatistic;
+using TimeStatDataType = uint32_t;
+using EventTimeStat = Statistic<TimeStatDataType>;
+
+#define FOREACH_MPI_EVENT(NAME) \
+    NAME( Init ) \
+    NAME( Finalize ) \
+    NAME( Rank ) \
+    NAME( Size ) \
+    NAME( Send ) \
+    NAME( Recv ) \
+    NAME( Irecv ) \
+    NAME( Isend ) \
+    NAME( Wait ) \
+    NAME( Waitall ) \
+    NAME( Waitany ) \
+    NAME( Compute ) \
+    NAME( Barrier ) \
+    NAME( Alltoallv ) \
+    NAME( Alltoall ) \
+    NAME( Allreduce ) \
+    NAME( Reduce ) \
+    NAME( Bcast) \
+    NAME( Scatter) \
+    NAME( Scatterv) \
+    NAME( Gettime ) \
+    NAME( Commsplit ) \
+    NAME( Commcreate ) \
+    NAME( NUM_MPI_EVENTS ) \
+
+#define GENERATE_ENUM(ENUM) ENUM,
+
+enum MPIEvents {
+    FOREACH_MPI_EVENT(GENERATE_ENUM)
+};
+
+#undef GENERATE_ENUM
+
+extern const char* MPIEventNames[];
 
 class EmberMPIEvent : public EmberEvent {
 

--- a/src/sst/elements/ember/mpi/embermpigen.cc
+++ b/src/sst/elements/ember/mpi/embermpigen.cc
@@ -16,6 +16,7 @@
 #include <sst_config.h>
 
 #include "embermpigen.h"
+#include "libs/mpi/emberMPIEvent.h"
 
 using namespace SST;
 using namespace SST::Ember;
@@ -33,12 +34,26 @@ EmberMessagePassingGenerator::EmberMessagePassingGenerator(
     }
     //end->NetworkSim
 
-    m_rankMap = loadModule<EmberRankMap>(rankMapModule,mapParams);
+    m_rankMap = loadModule<EmberRankMap>( rankMapModule, mapParams );
 
     if(NULL == m_rankMap) {
         std::cerr << "Error: Unable to load rank map scheme: \'"
 								 << rankMapModule << "\'" << std::endl;
         exit(-1);
+    }
+
+    const bool perMotifStats = params.find<bool>("mpiStatsPerMotif", true);
+
+    // Register statistics
+    const std::string namePrefix( "time-" );
+    for (int i = 0; i < NUM_MPI_EVENTS; i++) {
+        std::string statName = namePrefix + std::string( MPIEventNames[i] );
+        std::string subId("");
+        if ( perMotifStats ) {
+            subId = name + "Motif";
+        }
+        EventTimeStat* stat = registerStatistic<TimeStatDataType>( statName, subId );
+        m_mpiTimeStats.push_back( stat );
     }
 
 	m_mpi = static_cast<EmberMpiLib*>( getLib("mpi") );
@@ -49,5 +64,5 @@ EmberMessagePassingGenerator::EmberMessagePassingGenerator(
 
 EmberMessagePassingGenerator::~EmberMessagePassingGenerator()
 {
-    verbose(CALL_INFO, 2, 0, "\n");
+    verbose( CALL_INFO, 2, 0, "\n" );
 }

--- a/src/sst/elements/ember/mpi/embermpigen.cc
+++ b/src/sst/elements/ember/mpi/embermpigen.cc
@@ -50,7 +50,7 @@ EmberMessagePassingGenerator::EmberMessagePassingGenerator(
         std::string statName = namePrefix + std::string( MPIEventNames[i] );
         std::string subId("");
         if ( perMotifStats ) {
-            subId = name + "Motif";
+            subId = name + "Motif_" + std::to_string(getMotifNum());
         }
         EventTimeStat* stat = registerStatistic<TimeStatDataType>( statName, subId );
         m_mpiTimeStats.push_back( stat );

--- a/src/sst/elements/ember/mpi/embermpigen.h
+++ b/src/sst/elements/ember/mpi/embermpigen.h
@@ -71,7 +71,11 @@ public:
 	EmberMessagePassingGenerator( ComponentId_t id, Params& params, std::string name = "" );
 	~EmberMessagePassingGenerator();
 
-    virtual void completed( const SST::Output* output, uint64_t time ) {
+    virtual void configure() override
+    { }
+
+    virtual void completed( const SST::Output* output, uint64_t time ) override
+    {
 		mpi().completed(output,time,getMotifName(),getMotifNum());
 	};
 

--- a/src/sst/elements/ember/mpi/embermpigen.h
+++ b/src/sst/elements/ember/mpi/embermpigen.h
@@ -68,15 +68,43 @@ public:
 		rankmap.*
 	*/
 
+	SST_ELI_DOCUMENT_STATISTICS(
+        { "time-Init", "Time spent in Init event",          "ns", 1 },
+        { "time-Finalize", "Time spent in Finalize event",  "ns", 1 },
+        { "time-Rank", "Time spent in Rank event",          "ns", 1 },
+        { "time-Size", "Time spent in Size event",          "ns", 1 },
+        { "time-Send", "Time spent in Recv event",          "ns", 1 },
+        { "time-Recv", "Time spent in Recv event",          "ns", 1 },
+        { "time-Irecv", "Time spent in Irecv event",        "ns", 1 },
+        { "time-Isend", "Time spent in Isend event",        "ns", 1 },
+        { "time-Wait", "Time spent in Wait event",          "ns", 1 },
+        { "time-Waitall", "Time spent in Waitall event",    "ns", 1 },
+        { "time-Waitany", "Time spent in Waitany event",    "ns", 1 },
+        { "time-Compute", "Time spent in Compute event",    "ns", 1 },
+        { "time-Barrier", "Time spent in Barrier event",    "ns", 1 },
+        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 1 },
+        { "time-Alltoall", "Time spent in Alltoall event",   "ns", 1 },
+        { "time-Allreduce", "Time spent in Allreduce event", "ns", 1 },
+        { "time-Reduce", "Time spent in Reduce event",       "ns", 1 },
+        { "time-Bcast", "Time spent in Bcast event",         "ns", 1 },
+        { "time-Scatter", "Time spent in Scatter event",     "ns", 1 },
+        { "time-Scatterv", "Time spent in Scatter event",    "ns", 1 },
+        { "time-Gettime", "Time spent in Gettime event",     "ns", 1 },
+        { "time-Commsplit", "Time spent in Commsplit event", "ns", 1 },
+        { "time-Commcreate", "Time spent in Commcreate event", "ns", 1 },
+    )
+
 	EmberMessagePassingGenerator( ComponentId_t id, Params& params, std::string name = "" );
 	~EmberMessagePassingGenerator();
 
     virtual void configure() override
-    { }
+    {
+        mpi().setEventStatistics( m_mpiTimeStats );
+    }
 
     virtual void completed( const SST::Output* output, uint64_t time ) override
     {
-		mpi().completed(output,time,getMotifName(),getMotifNum());
+		mpi().completed(output, time, getMotifName(), getMotifNum());
 	};
 
 protected:
@@ -116,33 +144,34 @@ protected:
 		return mpi().sizeofDataType( type );
 	}
 
-	int get_count( MessageResponse* resp, PayloadDataType datatype, int* count ) {
-		uint32_t nbytes = resp->count * resp->dtypeSize;
-		int dtypesize = sizeofDataType(datatype);
-		if ( nbytes % dtypesize ) {
-			*count = 0;
-			return -1;
-		}
-		*count = nbytes / dtypesize;
-
-		return 0;
-	}
-
-	EmberRankMap* getRankMap() { return m_rankMap; }
-
-	void memSetBacked() {
-		EmberGenerator::memSetBacked();
-		mpi().setBacked();
-	}
-
-        void memSetNotBacked() {
-                EmberGenerator::memSetNotBacked();
-                mpi().setNotBacked();
+    int get_count( MessageResponse* resp, PayloadDataType datatype, int* count ) {
+        uint32_t nbytes = resp->count * resp->dtypeSize;
+        int dtypesize = sizeofDataType(datatype);
+        if ( nbytes % dtypesize ) {
+            *count = 0;
+            return -1;
         }
+        *count = nbytes / dtypesize;
+        return 0;
+    }
+
+    EmberRankMap* getRankMap() { return m_rankMap; }
+
+    void memSetBacked() {
+        EmberGenerator::memSetBacked();
+        mpi().setBacked();
+    }
+
+    void memSetNotBacked() {
+        EmberGenerator::memSetNotBacked();
+        mpi().setNotBacked();
+    }
 
 private:
-	EmberMpiLib*	m_mpi;
-	EmberRankMap*	m_rankMap;
+    EmberMpiLib*	m_mpi;
+    EmberRankMap*	m_rankMap;
+
+    std::vector< EventTimeStat* > m_mpiTimeStats;
 };
 
 

--- a/src/sst/elements/ember/mpi/embermpigen.h
+++ b/src/sst/elements/ember/mpi/embermpigen.h
@@ -157,12 +157,12 @@ protected:
 
     EmberRankMap* getRankMap() { return m_rankMap; }
 
-    void memSetBacked() {
+    void memSetBacked() override {
         EmberGenerator::memSetBacked();
         mpi().setBacked();
     }
 
-    void memSetNotBacked() {
+    void memSetNotBacked() override {
         EmberGenerator::memSetNotBacked();
         mpi().setNotBacked();
     }

--- a/src/sst/elements/ember/mpi/motifs/ember3damr.cc
+++ b/src/sst/elements/ember/mpi/motifs/ember3damr.cc
@@ -74,7 +74,6 @@ Ember3DAMRGenerator::Ember3DAMRGenerator(SST::ComponentId_t id, Params& params) 
 
 	// We are complete, let the user know
 	out->verbose(CALL_INFO, 2, 0, "AMR Motif constructor completed.\n");
-	configure();
 }
 
 void Ember3DAMRGenerator::loadBlocks() {

--- a/src/sst/elements/ember/mpi/motifs/ember3damr.cc
+++ b/src/sst/elements/ember/mpi/motifs/ember3damr.cc
@@ -798,6 +798,8 @@ void Ember3DAMRGenerator::configure()
 {
 	out->verbose(CALL_INFO, 2, 0, "Configuring AMR motif...\n");
 
+    EmberMessagePassingGenerator::configure();
+
 	char* newPrefix = (char*) malloc(sizeof(char) * 64);
 
 	if(out->getVerboseLevel() > 8) {

--- a/src/sst/elements/ember/mpi/motifs/ember3damr.h
+++ b/src/sst/elements/ember/mpi/motifs/ember3damr.h
@@ -79,22 +79,37 @@ public:
 
 
 public:
-	Ember3DAMRGenerator(SST::ComponentId_t, Params& params);
-	~Ember3DAMRGenerator();
-	void configure();
-        bool generate( std::queue<EmberEvent*>& evQ );
-	int32_t power3(const uint32_t expon);
+    Ember3DAMRGenerator( SST::ComponentId_t, Params& params );
 
-	uint32_t power2(uint32_t exponent) const;
-        void loadBlocks();
+    ~Ember3DAMRGenerator();
 
-	uint32_t calcBlockID(const uint32_t posX, const uint32_t posY, const uint32_t posZ, const uint32_t level);
-        void calcBlockLocation(const uint32_t blockID, const uint32_t blockLevel, uint32_t* posX, uint32_t* posY, uint32_t* posZ);
-        bool isBlockLocal(const uint32_t bID) const;
-	void postBlockCommunication(std::queue<EmberEvent*>& evQ, int32_t* blockComm, uint32_t* nextReq, const uint32_t faceSize, const uint32_t msgTag,
-		const Ember3DAMRBlock* theBlock);
-	void aggregateBlockCommunication(const std::vector<Ember3DAMRBlock*>& blocks, std::map<int32_t, uint32_t>& blockToMessageSize);
-	void aggregateCommBytes(Ember3DAMRBlock* curBlock, std::map<int32_t, uint32_t>& blockToMessageSize);
+    void configure() override;
+
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
+
+    int32_t power3( const uint32_t expon );
+
+    uint32_t power2( uint32_t exponent ) const;
+
+    void loadBlocks();
+
+    uint32_t calcBlockID( const uint32_t posX, const uint32_t posY, const uint32_t posZ,
+                          const uint32_t level );
+
+    void calcBlockLocation( const uint32_t blockID, const uint32_t blockLevel,
+                            uint32_t* posX, uint32_t* posY, uint32_t* posZ );
+
+    bool isBlockLocal( const uint32_t bID ) const;
+
+    void postBlockCommunication( std::queue<EmberEvent*>& evQ, int32_t* blockComm,
+                                 uint32_t* nextReq, const uint32_t faceSize,
+                                 const uint32_t msgTag, const Ember3DAMRBlock* theBlock );
+
+    void aggregateBlockCommunication( const std::vector<Ember3DAMRBlock*>& blocks,
+                                      std::map<int32_t, uint32_t>& blockToMessageSize );
+
+    void aggregateCommBytes( Ember3DAMRBlock* curBlock,
+                             std::map<int32_t, uint32_t>& blockToMessageSize);
 
 private:
 	void printBlockMap();

--- a/src/sst/elements/ember/mpi/motifs/ember3damr.h
+++ b/src/sst/elements/ember/mpi/motifs/ember3damr.h
@@ -53,31 +53,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
 public:
     Ember3DAMRGenerator( SST::ComponentId_t, Params& params );
 

--- a/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.cc
+++ b/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.cc
@@ -35,17 +35,15 @@ Ember3DCommDoublingGenerator::Ember3DCommDoublingGenerator(SST::ComponentId_t id
 	computeBetweenSteps = (uint32_t) params.find("arg.compute_at_step", 2000);
 
 	requests = (MessageRequest*) malloc(sizeof(MessageRequest) * 52);
-
-	configure();
 }
 
 void Ember3DCommDoublingGenerator::configure()
 {
-	if((peX * peY * peZ) != (unsigned) size()) {
-		fatal(CALL_INFO, -1, "Processor decomposition of %" PRIu32 "x%" PRIu32 "x%" PRIu32 " != rank count of %" PRIu32 "\n",
-			peX, peY, peZ, size());
+    if ( ( peX * peY * peZ ) != (unsigned)size() ) {
+        fatal( CALL_INFO, -1, "Processor decomposition of %" PRIu32 "x%" PRIu32 "x%" PRIu32 ""
+                              " != rank count of %" PRIu32 "\n",
+                              peX, peY, peZ, size() );
 	}
-
 }
 
 int32_t Ember3DCommDoublingGenerator::power3(const uint32_t expon) {

--- a/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.cc
+++ b/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.cc
@@ -39,6 +39,8 @@ Ember3DCommDoublingGenerator::Ember3DCommDoublingGenerator(SST::ComponentId_t id
 
 void Ember3DCommDoublingGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
     if ( ( peX * peY * peZ ) != (unsigned)size() ) {
         fatal( CALL_INFO, -1, "Processor decomposition of %" PRIu32 "x%" PRIu32 "x%" PRIu32 ""
                               " != rank count of %" PRIu32 "\n",

--- a/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.h
+++ b/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.h
@@ -68,11 +68,11 @@ public:
     )
 
 public:
-	Ember3DCommDoublingGenerator(SST::ComponentId_t, Params& params);
-	~Ember3DCommDoublingGenerator() {}
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ );
-	int32_t power3(const uint32_t expon);
+    Ember3DCommDoublingGenerator( SST::ComponentId_t, Params& params );
+    ~Ember3DCommDoublingGenerator() {}
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
+    int32_t power3( const uint32_t expon );
 
 private:
 	uint32_t phase;

--- a/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.h
+++ b/src/sst/elements/ember/mpi/motifs/ember3dcommdbl.h
@@ -43,30 +43,6 @@ public:
         {   "compute_at_step",  "Sets the computation time in between each communication phase in nanoseconds", "1000"  },
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
 public:
     Ember3DCommDoublingGenerator( SST::ComponentId_t, Params& params );
     ~Ember3DCommDoublingGenerator() {}

--- a/src/sst/elements/ember/mpi/motifs/emberBFS.h
+++ b/src/sst/elements/ember/mpi/motifs/emberBFS.h
@@ -346,30 +346,6 @@ public:
         {   "arg.exec_model",  "Computation timing model file",    "exec.model"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-                                { "time-Init", "Time spent in Init event",          "ns",  0},
-                                { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-                                { "time-Rank", "Time spent in Rank event",          "ns", 0},
-                                { "time-Size", "Time spent in Size event",          "ns", 0},
-                                { "time-Send", "Time spent in Recv event",          "ns", 0},
-                                { "time-Recv", "Time spent in Recv event",          "ns", 0},
-                                { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-                                { "time-Isend", "Time spent in Isend event",        "ns", 0},
-                                { "time-Wait", "Time spent in Wait event",          "ns", 0},
-                                { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-                                { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-                                { "time-Compute", "Time spent in Compute event",    "ns", 0},
-                                { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-                                { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-                                { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-                                { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-                                { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-                                { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-                                { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-                                { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-                                { "time-Commcreate", "Time spent in Commcreate event", "ns", 0}
-                                )
-
 public:
     EmberBFSGenerator(SST::ComponentId_t, Params& params);
     ~EmberBFSGenerator();

--- a/src/sst/elements/ember/mpi/motifs/emberNtoM.h
+++ b/src/sst/elements/ember/mpi/motifs/emberNtoM.h
@@ -40,29 +40,6 @@ public:
         {   "arg.numRecvBufs",      "Sets the number of preposted recv buffers",   "1"},
         {   "arg.targetRankList",   "Sets the targer ranks", "0"},
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
 public:
 	EmberNtoMGenerator(SST::ComponentId_t, Params& params);

--- a/src/sst/elements/ember/mpi/motifs/emberTrafficGen.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberTrafficGen.cc
@@ -77,6 +77,8 @@ void EmberTrafficGenGenerator::configure()
         return;
     }
 
+    EmberMessagePassingGenerator::configure();
+
     m_rank = rank();
 
     m_distMessageSize = new SSTGaussianDistribution(

--- a/src/sst/elements/ember/mpi/motifs/emberTrafficGen.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberTrafficGen.cc
@@ -68,8 +68,6 @@ EmberTrafficGenGenerator::EmberTrafficGenGenerator(SST::ComponentId_t id,
             m_iterations = 1000;
         }
     }
-
-    configure();
 }
 
 void EmberTrafficGenGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/emberTrafficGen.h
+++ b/src/sst/elements/ember/mpi/motifs/emberTrafficGen.h
@@ -70,19 +70,20 @@ public:
 
 
 public:
-	EmberTrafficGenGenerator(SST::ComponentId_t, Params& params);
-    bool generate( std::queue<EmberEvent*>& evQ);
-    bool generate_plusOne( std::queue<EmberEvent*>& evQ);
-    bool primary( ) {
+	EmberTrafficGenGenerator( SST::ComponentId_t, Params& params );
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
+    bool generate_plusOne( std::queue<EmberEvent*>& evQ );
+    bool primary() override
+    {
         if (m_pattern == "plusOne")
             return false;
         return true;
     }
-    void configure();
+    void configure() override;
     void configure_plusOne();
 
     // extended patterns
-    bool generate_random( std::queue<EmberEvent*>& evQ);
+    bool generate_random( std::queue<EmberEvent*>& evQ );
     void recv_data();
     void send_data();
     void wait_for_any();

--- a/src/sst/elements/ember/mpi/motifs/emberTrafficGen.h
+++ b/src/sst/elements/ember/mpi/motifs/emberTrafficGen.h
@@ -44,31 +44,6 @@ public:
         { "arg.startDelay", "Sets the stddev of time between exchange",     "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
 public:
 	EmberTrafficGenGenerator( SST::ComponentId_t, Params& params );
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/emberallgather.h
+++ b/src/sst/elements/ember/mpi/motifs/emberallgather.h
@@ -41,31 +41,6 @@ public:
         {   "arg.verify",        "Verify the data transfer",    "true" },
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allgather", "Time spent in Allgather event", "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
 public:
 	EmberAllgatherGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);

--- a/src/sst/elements/ember/mpi/motifs/emberallgatherv.h
+++ b/src/sst/elements/ember/mpi/motifs/emberallgatherv.h
@@ -40,31 +40,6 @@ public:
         {   "arg.verify",      "Verify data transfer",        "true"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberAllgathervGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberallpingpong.h
+++ b/src/sst/elements/ember/mpi/motifs/emberallpingpong.h
@@ -40,32 +40,7 @@ public:
         {   "arg.computetime",      "Sets the time spent computing some values",        "1000"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
-	EmberAllPingPongGenerator(SST::ComponentId_t, Params& params);
+	EmberAllPingPongGenerator( SST::ComponentId_t, Params& params );
     bool generate( std::queue<EmberEvent*>& evQ);
 
 private:

--- a/src/sst/elements/ember/mpi/motifs/emberallreduce.h
+++ b/src/sst/elements/ember/mpi/motifs/emberallreduce.h
@@ -41,31 +41,6 @@ public:
         {   "arg.doUserFunc",   "Test reduce operation",        "false"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberAllreduceGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberalltoall.h
+++ b/src/sst/elements/ember/mpi/motifs/emberalltoall.h
@@ -40,30 +40,6 @@ public:
         {   "arg.bytes",        "Sets the number of bytes per rank",        "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
 public:
 	EmberAlltoallGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);

--- a/src/sst/elements/ember/mpi/motifs/emberalltoallv.h
+++ b/src/sst/elements/ember/mpi/motifs/emberalltoallv.h
@@ -39,30 +39,6 @@ public:
         {   "arg.count",        "Sets the number of data items",        "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
 public:
 	EmberAlltoallvGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);

--- a/src/sst/elements/ember/mpi/motifs/emberbarrier.h
+++ b/src/sst/elements/ember/mpi/motifs/emberbarrier.h
@@ -39,31 +39,6 @@ public:
         {   "arg.compute",      "Sets the time spent computing",        "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberBarrierGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ );
 

--- a/src/sst/elements/ember/mpi/motifs/emberbcast.h
+++ b/src/sst/elements/ember/mpi/motifs/emberbcast.h
@@ -41,31 +41,6 @@ public:
         {   "arg.root",         "Sets the root of the reduction",           "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberBcastGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberbipingpong.h
+++ b/src/sst/elements/ember/mpi/motifs/emberbipingpong.h
@@ -39,31 +39,6 @@ public:
         {   "arg.iterations",       "Sets the number of operations to perform",     "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberBiPingPongGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/embercmt1d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt1d.cc
@@ -58,19 +58,20 @@ EmberCMT1DGenerator::EmberCMT1DGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberCMT1DGenerator::configure()
 {
-        myID = rank();
+    EmberMessagePassingGenerator::configure();
 
-        // Initialize Marsaglia RNG for compute time
-        m_random = new SSTGaussianDistribution( m_mean, m_stddev,
-                                    new RNG::MarsagliaRNG( 7+myID, getJobId() ) );
+    myID = rank();
+    // Initialize Marsaglia RNG for compute time
+    auto rng = new RNG::MarsagliaRNG( 7 + myID, getJobId() );
+    m_random = new SSTGaussianDistribution( m_mean, m_stddev, rng );
 
-
-    	if(rank() == 0) {
-            output("CMT1D (Pairwise Exchange) Motif \n"
-                "element_size = %" PRIu32 ", elements_per_proc = %" PRIu32 ", total processes = %" PRIu32 \
-    			"\ncompute time: mean = %fns ,stddev = %fns \nxfersize: %" PRIu64 "\n",
-    			eltSize, nelt, size(), m_mean, m_stddev, xferSize);
-    	}
+    if (rank() == 0) {
+        output( "CMT1D (Pairwise Exchange) Motif \n"
+                "element_size = %" PRIu32 ", elements_per_proc = %" PRIu32 ", "
+                "total processes = %" PRIu32 "\ncompute time: mean = "
+                "%fns ,stddev = %fns \nxfersize: %" PRIu64 "\n",
+                eltSize, nelt, size(), m_mean, m_stddev, xferSize );
+    }
 }
 
 

--- a/src/sst/elements/ember/mpi/motifs/embercmt1d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt1d.cc
@@ -54,10 +54,7 @@ EmberCMT1DGenerator::EmberCMT1DGenerator(SST::ComponentId_t id, Params& params) 
         m_stddev = params.find("arg.nsComputeStddev", (m_mean*0.05));
 
     	xferSize = eltSize*eltSize;
-
-    	configure();
 }
-
 
 void EmberCMT1DGenerator::configure()
 {

--- a/src/sst/elements/ember/mpi/motifs/embercmt1d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt1d.h
@@ -47,32 +47,6 @@ public:
         {   "arg.nsComputeStddev",  "Sets the stddev in compute time per processor", "50"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberCMT1DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT1DGenerator();
     void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/embercmt1d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt1d.h
@@ -73,10 +73,10 @@ public:
 
 
 public:
-	EmberCMT1DGenerator(SST::ComponentId_t, Params& params);
+    EmberCMT1DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT1DGenerator();
-    void configure();
-	bool generate( std::queue<EmberEvent*>& evQ);
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 

--- a/src/sst/elements/ember/mpi/motifs/embercmt2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt2d.cc
@@ -63,10 +63,7 @@ EmberCMT2DGenerator::EmberCMT2DGenerator(SST::ComponentId_t id, Params& params) 
 
     	x_xferSize = eltSize*eltSize*my*mz;
     	y_xferSize = eltSize*eltSize*mx*mz;
-
-        configure();
 }
-
 
 void EmberCMT2DGenerator::configure()
 {
@@ -124,10 +121,7 @@ void EmberCMT2DGenerator::configure()
     		(sendx_neg ? "Y" : "N"), x_neg,
     		(sendy_pos ? "Y" : "N"), y_pos,
     		(sendy_neg ? "Y" : "N"), y_neg  );
-
 }
-
-
 
 bool EmberCMT2DGenerator::generate( std::queue<EmberEvent*>& evQ)
 {

--- a/src/sst/elements/ember/mpi/motifs/embercmt2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt2d.cc
@@ -67,60 +67,61 @@ EmberCMT2DGenerator::EmberCMT2DGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberCMT2DGenerator::configure()
 {
-    	// Check that we are using all the processors or else lock up will happen :(.
-    	if( (px * py) != (signed)size() ) {
-    		fatal(CALL_INFO, -1, "Error: CMT2D motif checked processor decomposition: %" PRIu32 \
-    		    "x%" PRIu32 " != MPI World %" PRIu32 "\n",
-    			px, py, size());
-    	}
+    EmberMessagePassingGenerator::configure();
 
-    	if(rank() == 0) {
-    	    output(" CMT2D Motif \n" \
-    	        "element_size = %" PRIu32 ", elements_per_proc = %" PRIu32 ", total processes = %" PRIu32 \
-    			"\ncompute time: mean = %fns ,stddev = %fns \
-    			\nx_xfer: %" PRIu64 " ,y_xfer: %" PRIu64 \
-    			"\npx: %" PRIu32 " ,py: %" PRIu32 "\n",
-    			eltSize, nelt, size(), m_mean, m_stddev,
-    			x_xferSize, y_xferSize, px, py );
+    // Check that we are using all the processors or else lock up will happen :(.
+    if ( (px * py) != (signed)size() ) {
+        fatal(CALL_INFO, -1, "Error: CMT2D motif checked processor decomposition: %" PRIu32 \
+            "x%" PRIu32 " != MPI World %" PRIu32 "\n",
+            px, py, size());
+    }
 
-    	}
+    if ( rank() == 0 ) {
+        output(" CMT2D Motif \n" \
+            "element_size = %" PRIu32 ", elements_per_proc = %" PRIu32 ", total processes = %" PRIu32 \
+            "\ncompute time: mean = %fns ,stddev = %fns \
+            \nx_xfer: %" PRIu64 " ,y_xfer: %" PRIu64 \
+            "\npx: %" PRIu32 " ,py: %" PRIu32 "\n",
+            eltSize, nelt, size(), m_mean, m_stddev,
+            x_xferSize, y_xferSize, px, py );
+    }
 
-    	// Get our (x,y) position and neighboring ranks in a 3D decomposition
-    	myX=-1; myY=-1;
-    	myID = rank();
-    	getPosition(rank(), px, py, &myX, &myY);
+    // Get our (x,y) position and neighboring ranks in a 3D decomposition
+    myX=-1; myY=-1;
+    myID = rank();
+    getPosition(rank(), px, py, &myX, &myY);
 
-        // Initialize Marsaglia RNG for compute time
-        m_random = new SSTGaussianDistribution( m_mean, m_stddev,
-                                    new RNG::MarsagliaRNG( 7+myID, getJobId() ) );
+    // Initialize Marsaglia RNG for compute time
+    m_random = new SSTGaussianDistribution( m_mean, m_stddev,
+                                new RNG::MarsagliaRNG( 7+myID, getJobId() ) );
 
-    	// Set which direction to transfer and the neighbors in that direction
-    	if( myY > 0 ) {
-    		x_neg = convertPositionToRank(px, py, myX-1, myY);
-    		sendx_neg = true;
-    	}
-    	if( myY < px-1 ) {
-    		x_pos = convertPositionToRank(px, py, myX+1, myY);
-    		sendx_pos = true;
-    	}
-    	if( myX > 0 ) {
-    		y_neg = convertPositionToRank(px, py, myX, myY-1);
-    		sendy_neg = true;
-    	}
-    	if( myX < py-1 ) {
-    		y_pos = convertPositionToRank(px, py, myX, myY+1);
-    		sendy_pos = true;
-    	}
+    // Set which direction to transfer and the neighbors in that direction
+    if( myY > 0 ) {
+        x_neg = convertPositionToRank(px, py, myX-1, myY);
+        sendx_neg = true;
+    }
+    if( myY < px-1 ) {
+        x_pos = convertPositionToRank(px, py, myX+1, myY);
+        sendx_pos = true;
+    }
+    if( myX > 0 ) {
+        y_neg = convertPositionToRank(px, py, myX, myY-1);
+        sendy_neg = true;
+    }
+    if( myX < py-1 ) {
+        y_pos = convertPositionToRank(px, py, myX, myY+1);
+        sendy_pos = true;
+    }
 
-    	verbose(CALL_INFO, 2, 0, "Rank: %" PRIu64 " is located at coordinates \
-    		(%" PRId32 ", %" PRId32 ") in the 2D mesh, \
-    		X+:%s %" PRId32 ",X-:%s %" PRId32 ", Y+:%s %" PRId32 ",Y-:%s %" PRId32 "\n",
-    		myID,
-    		myX, myY,
-    		(sendx_pos ? "Y" : "N"), x_pos,
-    		(sendx_neg ? "Y" : "N"), x_neg,
-    		(sendy_pos ? "Y" : "N"), y_pos,
-    		(sendy_neg ? "Y" : "N"), y_neg  );
+    verbose(CALL_INFO, 2, 0, "Rank: %" PRIu64 " is located at coordinates \
+        (%" PRId32 ", %" PRId32 ") in the 2D mesh, \
+        X+:%s %" PRId32 ",X-:%s %" PRId32 ", Y+:%s %" PRId32 ",Y-:%s %" PRId32 "\n",
+        myID,
+        myX, myY,
+        (sendx_pos ? "Y" : "N"), x_pos,
+        (sendx_neg ? "Y" : "N"), x_neg,
+        (sendy_pos ? "Y" : "N"), y_pos,
+        (sendy_neg ? "Y" : "N"), y_neg  );
 }
 
 bool EmberCMT2DGenerator::generate( std::queue<EmberEvent*>& evQ)

--- a/src/sst/elements/ember/mpi/motifs/embercmt2d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt2d.h
@@ -51,31 +51,6 @@ public:
         {   "arg.nsComputeStddev",  "Sets the stddev in compute time per processor", "50"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
 public:
 	EmberCMT2DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT2DGenerator();

--- a/src/sst/elements/ember/mpi/motifs/embercmt2d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt2d.h
@@ -79,8 +79,8 @@ public:
 public:
 	EmberCMT2DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT2DGenerator();
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ);
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 // User parameters - application

--- a/src/sst/elements/ember/mpi/motifs/embercmt3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt3d.cc
@@ -68,10 +68,7 @@ EmberCMT3DGenerator::EmberCMT3DGenerator(SST::ComponentId_t id, Params& params) 
     	x_xferSize = eltSize*eltSize*my*mz;
     	y_xferSize = eltSize*eltSize*mx*mz;
     	z_xferSize = eltSize*eltSize*mx*my;
-
-        configure();
 }
-
 
 void EmberCMT3DGenerator::configure()
 {

--- a/src/sst/elements/ember/mpi/motifs/embercmt3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmt3d.cc
@@ -72,87 +72,84 @@ EmberCMT3DGenerator::EmberCMT3DGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberCMT3DGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
 
-    	// Check that we are using all the processors or else lock up will happen :(.
-//    	if( (px * py *pz *threads) != (signed)size() ) {
-    	if( (px * py *pz *threads) != (signed)size() ) {
-    		fatal(CALL_INFO, -1, "Error: CMT3D motif checked processor decomposition: %" \
-    			PRId32 "x%" PRId32 "x%" PRId32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",
-    			px, py, pz, threads, size());
-    	}
+    // Check that we are using all the processors or else lock up will happen :(.
+    if( (px * py *pz *threads) != (signed)size() ) {
+        fatal(CALL_INFO, -1, "Error: CMT3D motif checked processor decomposition: %" \
+            PRId32 "x%" PRId32 "x%" PRId32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",
+            px, py, pz, threads, size());
+    }
 
-    	if(rank() == 0) {
-    		output( "CMT3D (Pairwise Exchange) Motif \n" \
-    		    "nx1 (elt_size) = %" PRIu32 ", nelt (elts/proc) = %" PRIu32 ", np (total processes) = %" PRIu32 \
-    		    ", elements (total) = %" PRIu32 \
-     			"\npx: %" PRIu32 " ,py: %" PRIu32 " ,pz: %" PRIu32 " ,threads/proc: %" PRIu32 \
-     			"\nmx: %" PRIu32 " ,my: %" PRIu32 " ,mz: %" PRIu32 \
-    			"\ncompute time: mean = %fns ,stddev = %fns \
-    			\nx_xfer: %" PRIu64 " ,y_xfer: %" PRIu64 " ,z_xfer: %" PRIu64 "\n",
-    			eltSize, nelt, size(), nelt*size(),
-    			px, py, pz, threads,
-    			mx, my, mz,
-                m_mean, m_stddev,
-    			x_xferSize, y_xferSize, z_xferSize );
-    	}
+    if(rank() == 0) {
+        output( "CMT3D (Pairwise Exchange) Motif \n" \
+            "nx1 (elt_size) = %" PRIu32 ", nelt (elts/proc) = %" PRIu32 ", np (total processes) = %" PRIu32 \
+            ", elements (total) = %" PRIu32 \
+            "\npx: %" PRIu32 " ,py: %" PRIu32 " ,pz: %" PRIu32 " ,threads/proc: %" PRIu32 \
+            "\nmx: %" PRIu32 " ,my: %" PRIu32 " ,mz: %" PRIu32 \
+            "\ncompute time: mean = %fns ,stddev = %fns \
+            \nx_xfer: %" PRIu64 " ,y_xfer: %" PRIu64 " ,z_xfer: %" PRIu64 "\n",
+            eltSize, nelt, size(), nelt*size(),
+            px, py, pz, threads,
+            mx, my, mz,
+            m_mean, m_stddev,
+            x_xferSize, y_xferSize, z_xferSize );
+    }
 
-    	// Get our (x,y,z) position and neighboring ranks in a 3D decomposition
-    	myX=-1; myY=-1; myZ=-1;
-    	myID = rank();
-    	getPosition(myID, px, py, pz, &myX, &myY, &myZ);
+    // Get our (x,y,z) position and neighboring ranks in a 3D decomposition
+    myX=-1; myY=-1; myZ=-1;
+    myID = rank();
+    getPosition(myID, px, py, pz, &myX, &myY, &myZ);
 
-        // Initialize Marsaglia RNG for compute time
-        m_random = new SSTGaussianDistribution( m_mean, m_stddev,
-                                    new RNG::MarsagliaRNG( 7+myID, getJobId() ) );
+    // Initialize Marsaglia RNG for compute time
+    m_random = new SSTGaussianDistribution( m_mean, m_stddev,
+                                new RNG::MarsagliaRNG( 7+myID, getJobId() ) );
 
-    	// Set which direction to transfer and the neighbors in that direction
-    	if( myX > 0 ) {
-    		sendx_neg = true;
-    		x_neg	= convertPositionToRank(px, py, pz, myX-1, myY, myZ);
-    	}
+    // Set which direction to transfer and the neighbors in that direction
+    if( myX > 0 ) {
+        sendx_neg = true;
+        x_neg	= convertPositionToRank(px, py, pz, myX-1, myY, myZ);
+    }
 
-    	if( myX < px-1 ) {
-    		sendx_pos = true;
-    		x_pos	= convertPositionToRank(px, py, pz, myX+1, myY, myZ);
-    	}
+    if( myX < px-1 ) {
+        sendx_pos = true;
+        x_pos	= convertPositionToRank(px, py, pz, myX+1, myY, myZ);
+    }
 
-    	if( myY > 0 ) {
-    		sendy_neg = true;
-    		y_neg 	= convertPositionToRank(px, py, pz, myX, myY-1, myZ);
-    	}
+    if( myY > 0 ) {
+        sendy_neg = true;
+        y_neg 	= convertPositionToRank(px, py, pz, myX, myY-1, myZ);
+    }
 
-    	if( myY < py-1 ) {
-    		sendy_pos = true;
-    		y_pos	= convertPositionToRank(px, py, pz, myX, myY+1, myZ);
-    	}
+    if( myY < py-1 ) {
+        sendy_pos = true;
+        y_pos	= convertPositionToRank(px, py, pz, myX, myY+1, myZ);
+    }
 
-    	if( myZ > 0 ) {
-    		sendz_neg = true;
-    		z_neg 	= convertPositionToRank(px, py, pz, myX, myY, myZ-1);
-    	}
+    if( myZ > 0 ) {
+        sendz_neg = true;
+        z_neg 	= convertPositionToRank(px, py, pz, myX, myY, myZ-1);
+    }
 
-    	if( myZ < pz-1 ) {
-    		sendz_pos = true;
-    		z_pos	= convertPositionToRank(px, py, pz, myX, myY, myZ+1);
-    	}
+    if( myZ < pz-1 ) {
+        sendz_pos = true;
+        z_pos	= convertPositionToRank(px, py, pz, myX, myY, myZ+1);
+    }
 
-    	verbose(CALL_INFO, 2, 0, "Rank: %" PRIu64 " is located at coordinates \
-    		(%" PRId32 ", %" PRId32 ", %" PRId32") in the 3D grid,\
-    		X+:%s %" PRId32 ", X-:%s %" PRId32 ", \
-    		Y+:%s %" PRId32 ", Y-:%s %" PRId32 ", \
-    		Z+:%s %" PRId32 ", Z-:%s %" PRId32 "\n",
-    		myID,
-    		myX, myY, myZ,
-    		(sendx_pos ? "Y" : "N"), x_pos,
-    		(sendx_neg ? "Y" : "N"), x_neg,
-    		(sendy_pos ? "Y" : "N"), y_pos,
-    		(sendy_neg ? "Y" : "N"), y_neg,
-    		(sendz_pos ? "Y" : "N"), z_pos,
-    		(sendz_neg ? "Y" : "N"), z_neg);
-
+    verbose(CALL_INFO, 2, 0, "Rank: %" PRIu64 " is located at coordinates \
+        (%" PRId32 ", %" PRId32 ", %" PRId32") in the 3D grid,\
+        X+:%s %" PRId32 ", X-:%s %" PRId32 ", \
+        Y+:%s %" PRId32 ", Y-:%s %" PRId32 ", \
+        Z+:%s %" PRId32 ", Z-:%s %" PRId32 "\n",
+        myID,
+        myX, myY, myZ,
+        (sendx_pos ? "Y" : "N"), x_pos,
+        (sendx_neg ? "Y" : "N"), x_neg,
+        (sendy_pos ? "Y" : "N"), y_pos,
+        (sendy_neg ? "Y" : "N"), y_neg,
+        (sendz_pos ? "Y" : "N"), z_pos,
+        (sendz_neg ? "Y" : "N"), z_neg);
 }
-
-
 
 bool EmberCMT3DGenerator::generate( std::queue<EmberEvent*>& evQ)
 {

--- a/src/sst/elements/ember/mpi/motifs/embercmt3d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt3d.h
@@ -52,31 +52,6 @@ public:
         {   "arg.nsComputeStddev",  "Sets the stddev in compute time per processor", "50"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberCMT3DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT3DGenerator();
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/embercmt3d.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmt3d.h
@@ -79,8 +79,8 @@ public:
 public:
 	EmberCMT3DGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT3DGenerator();
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ);
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 

--- a/src/sst/elements/ember/mpi/motifs/embercmtcr.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmtcr.cc
@@ -63,6 +63,8 @@ EmberCMTCRGenerator::EmberCMTCRGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberCMTCRGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
 	if( (px * py *pz) != (signed)size() ) {
 		fatal(CALL_INFO, -1, "Error: CMTCR motif checked processor decomposition: %" \
 			PRIu32 "x%" PRIu32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",
@@ -91,10 +93,7 @@ void EmberCMTCRGenerator::configure()
 	verbose(CALL_INFO, 2, 0, "Rank: %" PRIu64 " is located at coordinates \
 		(%" PRId32 ", %" PRId32 ", %" PRId32") in the 3D grid, \n",
 		myID, myX, myY, myZ );
-
 }
-
-
 
 bool EmberCMTCRGenerator::generate( std::queue<EmberEvent*>& evQ)
 {
@@ -137,17 +136,4 @@ bool EmberCMTCRGenerator::generate( std::queue<EmberEvent*>& evQ)
         } else {
             return false;
         }
-
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/sst/elements/ember/mpi/motifs/embercmtcr.cc
+++ b/src/sst/elements/ember/mpi/motifs/embercmtcr.cc
@@ -59,15 +59,10 @@ EmberCMTCRGenerator::EmberCMTCRGenerator(SST::ComponentId_t id, Params& params) 
     m_stddev = params.find("arg.nsComputeStddev", (m_mean*0.05));
 
 	xferSize = eltSize*eltSize*nelt;
-
-	configure();
 }
-
-
 
 void EmberCMTCRGenerator::configure()
 {
-
 	if( (px * py *pz) != (signed)size() ) {
 		fatal(CALL_INFO, -1, "Error: CMTCR motif checked processor decomposition: %" \
 			PRIu32 "x%" PRIu32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",

--- a/src/sst/elements/ember/mpi/motifs/embercmtcr.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmtcr.h
@@ -52,31 +52,6 @@ public:
         {   "arg.nsComputeStddev",  "Sets the stddev in compute time per processor", "50"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberCMTCRGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT3DGenerator();
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/embercmtcr.h
+++ b/src/sst/elements/ember/mpi/motifs/embercmtcr.h
@@ -79,8 +79,8 @@ public:
 public:
 	EmberCMTCRGenerator(SST::ComponentId_t, Params& params);
 //	~EmberCMT3DGenerator();
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ);
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 // User parameters - application

--- a/src/sst/elements/ember/mpi/motifs/embercomm.h
+++ b/src/sst/elements/ember/mpi/motifs/embercomm.h
@@ -39,31 +39,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberCommGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberdetailedring.h
+++ b/src/sst/elements/ember/mpi/motifs/emberdetailedring.h
@@ -44,31 +44,6 @@ public:
         {   "arg.computeWindow",   "Sets the maximum compute time",   "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberDetailedRingGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 	std::string getComputeModelName();

--- a/src/sst/elements/ember/mpi/motifs/emberdetailedstream.h
+++ b/src/sst/elements/ember/mpi/motifs/emberdetailedstream.h
@@ -42,30 +42,6 @@ public:
        {   "arg.n_loops",          "Sets the number of loops",   "2"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
 public:
 	EmberDetailedStreamGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);

--- a/src/sst/elements/ember/mpi/motifs/emberfft3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberfft3d.cc
@@ -58,6 +58,8 @@ EmberFFT3DGenerator::EmberFFT3DGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberFFT3DGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
     m_data.npcol = size() / m_data.nprow;
 
     assert( 0 == (size() % m_data.nprow) );

--- a/src/sst/elements/ember/mpi/motifs/emberfft3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberfft3d.cc
@@ -54,8 +54,6 @@ EmberFFT3DGenerator::EmberFFT3DGenerator(SST::ComponentId_t id, Params& params) 
     m_transCostPer[3] = params.find<float>("arg.bwd_fft1",1);
     m_transCostPer[4] = params.find<float>("arg.bwd_fft2",1);
     m_transCostPer[5] = params.find<float>("arg.bwd_fft3",1);
-
-	configure();
 }
 
 void EmberFFT3DGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/emberfft3d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberfft3d.h
@@ -76,8 +76,8 @@ public:
 public:
 	EmberFFT3DGenerator(SST::ComponentId_t, Params& params);
 	~EmberFFT3DGenerator() {}
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ );
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 

--- a/src/sst/elements/ember/mpi/motifs/emberfft3d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberfft3d.h
@@ -49,31 +49,6 @@ public:
         { "arg.bwd_fft3",  "", "" },
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberFFT3DGenerator(SST::ComponentId_t, Params& params);
 	~EmberFFT3DGenerator() {}
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/emberfini.h
+++ b/src/sst/elements/ember/mpi/motifs/emberfini.h
@@ -37,31 +37,6 @@ public:
     SST_ELI_DOCUMENT_PARAMS(
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
     EmberFiniGenerator(SST::ComponentId_t id, Params& params) :
         EmberMessagePassingGenerator(id, params, "Fini")
     { }

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2d.cc
@@ -53,6 +53,8 @@ EmberHalo2DGenerator::EmberHalo2DGenerator(SST::ComponentId_t id, Params& params
 
 void EmberHalo2DGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
 	// Do we need to auto-size the 2D processor array?
 	if(0 == sizeX || 0 == sizeY) {
 		uint32_t localX = SST::Math::square_root(size());

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2d.cc
@@ -49,8 +49,6 @@ EmberHalo2DGenerator::EmberHalo2DGenerator(SST::ComponentId_t id, Params& params
 	sendSouth = false;
 
 	messageCount = 0;
-
-	configure();
 }
 
 void EmberHalo2DGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2d.h
@@ -44,32 +44,6 @@ public:
         {   "arg.sizey",        "Sets the processor decomposition in X", "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberHalo2DGenerator( SST::ComponentId_t id, Params& params );
     void configure() override;
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2d.h
@@ -70,10 +70,10 @@ public:
 
 
 public:
-	EmberHalo2DGenerator(SST::ComponentId_t id, Params& params);
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ);
-	void completed(const SST::Output* output, uint64_t );
+    EmberHalo2DGenerator( SST::ComponentId_t id, Params& params );
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
+    void completed( const SST::Output* output, uint64_t ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.cc
@@ -47,8 +47,6 @@ EmberHalo2DNBRGenerator::EmberHalo2DNBRGenerator(SST::ComponentId_t id, Params& 
 	sendSouth = false;
 
 	messageCount = 0;
-
-	configure();
 }
 
 void EmberHalo2DNBRGenerator::completed(const SST::Output* output, uint64_t) {

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.cc
@@ -55,6 +55,8 @@ void EmberHalo2DNBRGenerator::completed(const SST::Output* output, uint64_t) {
 
 void EmberHalo2DNBRGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
     if(0 == rank()) {
         output("PingPong, size=%d msgSizeX=%d msgSizeY=%d"
             " iter=%d nsCompute=%d\n",

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.h
@@ -43,31 +43,6 @@ public:
         {   "arg.sizey",        "Sets the processor decomposition in X", "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
     EmberHalo2DNBRGenerator( SST::ComponentId_t, Params& params );
     void configure() override;
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo2dNBR.h
@@ -68,10 +68,10 @@ public:
     )
 
 public:
-	EmberHalo2DNBRGenerator(SST::ComponentId_t, Params& params);
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ);
-    void completed(const SST::Output* output, uint64_t );
+    EmberHalo2DNBRGenerator( SST::ComponentId_t, Params& params );
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
+    void completed( const SST::Output* output, uint64_t ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3d.cc
@@ -55,11 +55,8 @@ EmberHalo3DGenerator::EmberHalo3DGenerator(SST::ComponentId_t id, Params& params
 	z_down = -1;
 	z_up   = -1;
 
-    jobId        = params.find<int>("_jobId"); //NetworkSim
-
-	configure();
+    jobId = params.find<int>("_jobId"); //NetworkSim
 }
-
 
 void EmberHalo3DGenerator::configure()
 {

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3d.cc
@@ -60,6 +60,8 @@ EmberHalo3DGenerator::EmberHalo3DGenerator(SST::ComponentId_t id, Params& params
 
 void EmberHalo3DGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
 	unsigned worldSize = size();
 
 	if(peX == 0 || peY == 0 || peZ == 0) {

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3d.h
@@ -77,10 +77,10 @@ public:
 
 
 public:
-	EmberHalo3DGenerator(SST::ComponentId_t, Params& params);
+	EmberHalo3DGenerator( SST::ComponentId_t, Params& params );
 	~EmberHalo3DGenerator() {}
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ );
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3d.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3d.h
@@ -51,32 +51,6 @@ public:
         {   "arg.iterations",       "Sets the number of halo3d operations to perform",  "10"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
 	EmberHalo3DGenerator( SST::ComponentId_t, Params& params );
 	~EmberHalo3DGenerator() {}
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3d26.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3d26.h
@@ -51,32 +51,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "10"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
 	EmberHalo3D26Generator(SST::ComponentId_t, Params& params);
 	~EmberHalo3D26Generator() {}
     bool generate( std::queue<EmberEvent*>& evQ);

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.cc
@@ -59,8 +59,6 @@ EmberHalo3DSVGenerator::EmberHalo3DSVGenerator(SST::ComponentId_t id, Params& pa
 	y_up   = -1;
 	z_down = -1;
 	z_up   = -1;
-
-	configure();
 }
 
 void EmberHalo3DSVGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.cc
@@ -63,6 +63,8 @@ EmberHalo3DSVGenerator::EmberHalo3DSVGenerator(SST::ComponentId_t id, Params& pa
 
 void EmberHalo3DSVGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
 	if(peX == 0 || peY == 0 || peZ == 0) {
 		peX = size();
                 peY = 1;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.h
@@ -78,10 +78,10 @@ public:
 
 
 public:
-	EmberHalo3DSVGenerator(SST::ComponentId_t, Params& params);
-	~EmberHalo3DSVGenerator() {}
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ );
+    EmberHalo3DSVGenerator( SST::ComponentId_t, Params& params );
+    ~EmberHalo3DSVGenerator() {}
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhalo3dsv.h
@@ -52,32 +52,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "10"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberHalo3DSVGenerator( SST::ComponentId_t, Params& params );
     ~EmberHalo3DSVGenerator() {}
     void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/emberhotspots.h
+++ b/src/sst/elements/ember/mpi/motifs/emberhotspots.h
@@ -44,32 +44,6 @@ public:
         { "arg.startDelay", "Sets the stddev of time between exchange",     "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberHotSpotsGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
     bool primary( ) {

--- a/src/sst/elements/ember/mpi/motifs/emberincast.h
+++ b/src/sst/elements/ember/mpi/motifs/emberincast.h
@@ -39,31 +39,7 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "1"},
         {   "arg.incasttarget",     "Sets the incast target for communications",    "0"},
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
-public:
 	EmberIncastGenerator(SST::ComponentId_t, Params& params);
     	bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberinit.h
+++ b/src/sst/elements/ember/mpi/motifs/emberinit.h
@@ -37,32 +37,6 @@ public:
     SST_ELI_DOCUMENT_PARAMS(
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
-
     EmberInitGenerator(SST::ComponentId_t id, Params& params) :
             EmberMessagePassingGenerator(id, params, "Init" ),
 			m_rank(-1),

--- a/src/sst/elements/ember/mpi/motifs/emberlqcd.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberlqcd.cc
@@ -253,6 +253,8 @@ int EmberLQCDGenerator::node_number(int x, int y, int z, int t) {
 
 void EmberLQCDGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
     //determine the problem size given to each node
     //code from MILC setup_hyper_prime()
     setup_hyper_prime();

--- a/src/sst/elements/ember/mpi/motifs/emberlqcd.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberlqcd.cc
@@ -109,8 +109,6 @@ EmberLQCDGenerator::EmberLQCDGenerator(SST::ComponentId_t id, Params& params) :
 	n_ranks[ZUP]   = -1;
 	n_ranks[TDOWN] = -1;
 	n_ranks[TUP]   = -1;
-
-	configure();
 }
 
 
@@ -255,7 +253,6 @@ int EmberLQCDGenerator::node_number(int x, int y, int z, int t) {
 
 void EmberLQCDGenerator::configure()
 {
-
     //determine the problem size given to each node
     //code from MILC setup_hyper_prime()
     setup_hyper_prime();

--- a/src/sst/elements/ember/mpi/motifs/emberlqcd.h
+++ b/src/sst/elements/ember/mpi/motifs/emberlqcd.h
@@ -76,31 +76,6 @@ public:
         { "arg.iterations",	"Sets the number of ping pong operations to perform", 	"1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberLQCDGenerator( SST::ComponentId_t, Params& params );
 	~EmberLQCDGenerator() {}
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/emberlqcd.h
+++ b/src/sst/elements/ember/mpi/motifs/emberlqcd.h
@@ -101,10 +101,10 @@ public:
     )
 
 public:
-	EmberLQCDGenerator(SST::ComponentId_t, Params& params);
+	EmberLQCDGenerator( SST::ComponentId_t, Params& params );
 	~EmberLQCDGenerator() {}
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ );
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
     int get_node_index(int x, int y, int z, int t);

--- a/src/sst/elements/ember/mpi/motifs/embermsgrate.h
+++ b/src/sst/elements/ember/mpi/motifs/embermsgrate.h
@@ -40,31 +40,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberMsgRateGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/embernaslu.cc
+++ b/src/sst/elements/ember/mpi/motifs/embernaslu.cc
@@ -45,32 +45,39 @@ EmberNASLUGenerator::EmberNASLUGenerator(SST::ComponentId_t id, Params& params) 
 
 void EmberNASLUGenerator::configure()
 {
-	// Check that we are using all the processors or else lock up will happen :(.
-	if( (px * py) != (signed)size() ) {
-		fatal(CALL_INFO, -1, "Error: NAS-LU motif checked processor decomposition: %" PRIu32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",
-			px, py, size());
-	}
+    EmberMessagePassingGenerator::configure();
 
-	int32_t myX = 0;
-	int32_t myY = 0;
+    // Check that we are using all the processors or else lock up will happen :(.
+    if( (px * py) != (signed)size() ) {
+        fatal(CALL_INFO, -1, "Error: NAS-LU motif checked processor decomposition: "
+                             "%" PRIu32 "x%" PRIu32 " != MPI World %" PRIu32 "\n",
+                             px, py, size());
+    }
 
-	// Get our position in a 2D processor array
-	getPosition(rank(), px, py, &myX, &myY);
+    int32_t myX = 0;
+    int32_t myY = 0;
 
-	x_up   = (myX != (px - 1)) ? rank() + 1 : -1;
-	x_down = (myX != 0) ? rank() - 1 : -1;
+    // Get our position in a 2D processor array
+    getPosition(rank(), px, py, &myX, &myY);
 
-	y_up   = (myY != (py - 1)) ? rank() + px : -1;
-	y_down = (myY != 0) ? rank() - px : -1;
+    x_up   = (myX != (px - 1)) ? rank() + 1 : -1;
+    x_down = (myX != 0) ? rank() - 1 : -1;
 
-	if(0 == rank()) {
-		verbose(CALL_INFO, 1, 0, " NAS-LU Motif\n");
-		verbose(CALL_INFO, 1, 0, " nx = %" PRIu32 ", ny = %" PRIu32 ", nz = %" PRIu32 ", nzblock=%" PRIu32 ", (nx/nzblock)=%" PRIu32 "\n",
-			nx, ny, nz, nzblock, (nz / nzblock));
-	}
+    y_up   = (myY != (py - 1)) ? rank() + px : -1;
+    y_down = (myY != 0) ? rank() - px : -1;
 
-	verbose(CALL_INFO, 1, 0, " Rank: %" PRIu32 " is located at coordinations of (%" PRId32 ", %" PRId32 ") in the 2D decomposition, X+: %" PRId32 ",X-:%" PRId32 ",Y+:%" PRId32 ",Y-:%" PRId32 "\n",
-		rank(), myX, myY, x_up, x_down, y_up, y_down);
+    if ( 0 == rank() ) {
+        verbose(CALL_INFO, 1, 0, " NAS-LU Motif\n");
+        verbose(CALL_INFO, 1, 0, " nx = %" PRIu32 ", ny = %" PRIu32 ","
+                                 " nz = %" PRIu32 ", nzblock=%" PRIu32 ","
+                                 " (nx/nzblock)=%" PRIu32 "\n",
+                                 nx, ny, nz, nzblock, (nz / nzblock));
+    }
+
+    verbose(CALL_INFO, 1, 0, " Rank: %" PRIu32 " is located at coordinations of "
+                             "(%" PRId32 ", %" PRId32 ") in the 2D decomposition, X+: "
+                             "%" PRId32 ",X-:%" PRId32 ",Y+:%" PRId32 ",Y-:%" PRId32 "\n",
+                             rank(), myX, myY, x_up, x_down, y_up, y_down);
 }
 
 bool EmberNASLUGenerator::generate( std::queue<EmberEvent*>& evQ)

--- a/src/sst/elements/ember/mpi/motifs/embernaslu.cc
+++ b/src/sst/elements/ember/mpi/motifs/embernaslu.cc
@@ -41,8 +41,6 @@ EmberNASLUGenerator::EmberNASLUGenerator(SST::ComponentId_t id, Params& params) 
 
 	// Check K-blocking factor is acceptable for dividing the Nz dimension
 	assert(nz % nzblock == 0);
-
-	configure();
 }
 
 void EmberNASLUGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/embernaslu.h
+++ b/src/sst/elements/ember/mpi/motifs/embernaslu.h
@@ -71,9 +71,9 @@ public:
 
 
 public:
-	EmberNASLUGenerator(SST::ComponentId_t, Params& params);
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ );
+    EmberNASLUGenerator( SST::ComponentId_t, Params& params );
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/embernaslu.h
+++ b/src/sst/elements/ember/mpi/motifs/embernaslu.h
@@ -45,32 +45,6 @@ public:
         {   "arg.nzblock",      "Sets the Z-dimensional block size (Nz % Nzblock == 0, default is 1)", "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberNASLUGenerator( SST::ComponentId_t, Params& params );
     void configure() override;
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/embernull.h
+++ b/src/sst/elements/ember/mpi/motifs/embernull.h
@@ -37,31 +37,6 @@ public:
     SST_ELI_DOCUMENT_PARAMS(
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberNullGenerator(SST::ComponentId_t id, Params& params) :
 		EmberMessagePassingGenerator(id, params, "Null" )
 	{ }

--- a/src/sst/elements/ember/mpi/motifs/emberotf2.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberotf2.cc
@@ -444,6 +444,8 @@ EmberOTF2Generator::EmberOTF2Generator(SST::ComponentId_t id, Params& params) :
 
 void EmberOTF2Generator::configure() {
 
+    EmberMessagePassingGenerator::configure();
+
     m_size = size();
 
     OTF2_Reader_SetSerialCollectiveCallbacks( traceReader );

--- a/src/sst/elements/ember/mpi/motifs/emberotf2.h
+++ b/src/sst/elements/ember/mpi/motifs/emberotf2.h
@@ -30,9 +30,13 @@ using TraceStringDefinitions = std::unordered_map<uint64_t, std::string>;
 class EmberOTF2Generator : public EmberMessagePassingGenerator {
 
 public:
-	EmberOTF2Generator(SST::ComponentId_t, Params& params);
-	~EmberOTF2Generator();
-    	bool generate( std::queue<EmberEvent*>& evQ );
+    EmberOTF2Generator(SST::ComponentId_t, Params& params);
+
+    ~EmberOTF2Generator();
+
+    void configure() override;
+
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 	SST_ELI_REGISTER_SUBCOMPONENT(
         	EmberOTF2Generator,

--- a/src/sst/elements/ember/mpi/motifs/emberotf2.h
+++ b/src/sst/elements/ember/mpi/motifs/emberotf2.h
@@ -52,30 +52,6 @@ public:
         	{   "arg.addCompute",        "Add compute time to try to match trace timestamps",  "false" }
 	)
 
-	SST_ELI_DOCUMENT_STATISTICS(
-	        { "time-Init", "Time spent in Init event",          "ns",  0},
-	        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-	        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-	        { "time-Size", "Time spent in Size event",          "ns", 0},
-	        { "time-Send", "Time spent in Recv event",          "ns", 0},
-	        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-	        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-	        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-	        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-	        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-	        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-	        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-	        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-	        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-	        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-	        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-	        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-	        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-	        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        	{ "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-	        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    	)
-
 	void setTimerResolution(uint64_t timerResolution) {
 		m_timerResolution = timerResolution;
 	}

--- a/src/sst/elements/ember/mpi/motifs/emberpingpong.h
+++ b/src/sst/elements/ember/mpi/motifs/emberpingpong.h
@@ -42,31 +42,7 @@ public:
         {   "arg.blockingRecv",     "Sets the recv mode",   "1"},
         {   "arg.waitall",          "Sets the wait mode",   "1"},
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
-public:
 	EmberPingPongGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberrandomgen.h
+++ b/src/sst/elements/ember/mpi/motifs/emberrandomgen.h
@@ -39,30 +39,6 @@ public:
         {   "arg.iterations",       "Sets the number of iterations to perform",     "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-public:
 	EmberRandomTrafficGenerator(SST::ComponentId_t, Params& params);
     	bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberreduce.h
+++ b/src/sst/elements/ember/mpi/motifs/emberreduce.h
@@ -40,31 +40,6 @@ public:
         {   "arg.root",         "Sets the root of the reduction",           "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberReduceGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberring.h
+++ b/src/sst/elements/ember/mpi/motifs/emberring.h
@@ -39,32 +39,6 @@ public:
         {   "arg.iterations",       "Sets the number of ping pong operations to perform",   "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
 	EmberRingGenerator(SST::ComponentId_t id, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberscatter.h
+++ b/src/sst/elements/ember/mpi/motifs/emberscatter.h
@@ -41,31 +41,6 @@ public:
         {   "arg.root",         "Sets the root of the reduction",           "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberScatterGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/emberscatterv.h
+++ b/src/sst/elements/ember/mpi/motifs/emberscatterv.h
@@ -41,31 +41,6 @@ public:
         {   "arg.root",         "Sets the root of the reduction",           "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberScattervGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ);
 

--- a/src/sst/elements/ember/mpi/motifs/embersendrecv.h
+++ b/src/sst/elements/ember/mpi/motifs/embersendrecv.h
@@ -36,32 +36,7 @@ public:
         "Performs a Sendrecv Motif",
         SST::Ember::EmberGenerator
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Sendrecv", "Time spent in Sendrecv event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
-public:
 	EmberSendrecvGenerator(SST::ComponentId_t id, Params& params):
         EmberMessagePassingGenerator(id, params, "Null" ), m_phase(Init)
 	{

--- a/src/sst/elements/ember/mpi/motifs/embersiriustrace.h
+++ b/src/sst/elements/ember/mpi/motifs/embersiriustrace.h
@@ -41,31 +41,6 @@ public:
         {       "arg.traceprefix",              "Sets the trace prefix for loading SIRIUS files", "" },
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 	EmberSIRIUSTraceGenerator(SST::ComponentId_t, Params& params);
 	~EmberSIRIUSTraceGenerator();
     	bool generate( std::queue<EmberEvent*>& evQ );

--- a/src/sst/elements/ember/mpi/motifs/emberstop.h
+++ b/src/sst/elements/ember/mpi/motifs/emberstop.h
@@ -40,32 +40,6 @@ public:
         {   "arg.compute",      "Sets the time spent computing",        "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
 	EmberStopGenerator(SST::ComponentId_t, Params& params);
     bool generate( std::queue<EmberEvent*>& evQ );
 

--- a/src/sst/elements/ember/mpi/motifs/embersweep2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embersweep2d.cc
@@ -36,8 +36,6 @@ EmberSweep2DGenerator::EmberSweep2DGenerator(SST::ComponentId_t id, Params& para
 
 	// Check K-blocking factor is acceptable for dividing the Nz dimension
 	assert(ny % y_block == 0);
-
-	configure();
 }
 
 void EmberSweep2DGenerator::configure()

--- a/src/sst/elements/ember/mpi/motifs/embersweep2d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embersweep2d.cc
@@ -40,18 +40,20 @@ EmberSweep2DGenerator::EmberSweep2DGenerator(SST::ComponentId_t id, Params& para
 
 void EmberSweep2DGenerator::configure()
 {
-	if(0 == rank()) {
-		verbose(CALL_INFO, 1, 0, " 2D Sweep Motif\n");
-		verbose(CALL_INFO, 1, 0, " nx = %" PRIu32 ", ny = %"
-			PRIu32 ", y_block=%" PRIu32 ", (ny/yblock)=%" PRIu32 "\n",
-			nx, ny, y_block, (ny/y_block));
-	}
+    EmberMessagePassingGenerator::configure();
 
-	x_up   = (rank() < (size() - 1)) ? rank() + 1 : -1;
-	x_down = (rank() > 0) ? rank() - 1 : -1;
+    if ( 0 == rank() ) {
+        verbose( CALL_INFO, 1, 0, " 2D Sweep Motif\n" );
+        verbose( CALL_INFO, 1, 0, " nx = %" PRIu32 ", ny = %"
+                 PRIu32 ", y_block=%" PRIu32 ", (ny/yblock)=%" PRIu32 "\n",
+                 nx, ny, y_block, (ny/y_block));
+    }
 
-	verbose(CALL_INFO, 1, 0, "Rank: %" PRId32 ", X+:%" PRId32
-					",X-:%" PRId32 "\n", rank(), x_up, x_down);
+    x_up   = (rank() < (size() - 1)) ? rank() + 1 : -1;
+    x_down = (rank() > 0) ? rank() - 1 : -1;
+
+    verbose( CALL_INFO, 1, 0, "Rank: %" PRId32 ", X+:%" PRId32
+             ",X-:%" PRId32 "\n", rank(), x_up, x_down );
 }
 
 bool EmberSweep2DGenerator::generate( std::queue<EmberEvent*>& evQ )

--- a/src/sst/elements/ember/mpi/motifs/embersweep2d.h
+++ b/src/sst/elements/ember/mpi/motifs/embersweep2d.h
@@ -41,31 +41,6 @@ public:
         {   "arg.y_block",      "Sets the Y-blocking factor (must be Ny % y_block == 0, default is 1 (no blocking))", "1"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
     EmberSweep2DGenerator( SST::ComponentId_t, Params& params );
     void configure() override;
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/embersweep2d.h
+++ b/src/sst/elements/ember/mpi/motifs/embersweep2d.h
@@ -66,9 +66,9 @@ public:
     )
 
 public:
-	EmberSweep2DGenerator(SST::ComponentId_t, Params& params);
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ );
+    EmberSweep2DGenerator( SST::ComponentId_t, Params& params );
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 	uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/embersweep3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embersweep3d.cc
@@ -60,6 +60,8 @@ EmberSweep3DGenerator::EmberSweep3DGenerator(SST::ComponentId_t id, Params& para
 
 void EmberSweep3DGenerator::configure()
 {
+    EmberMessagePassingGenerator::configure();
+
 	// Check that we are using all the processors or else lock up will happen :(.
 	if( (px * py) != (signed) size() ) {
 		fatal(CALL_INFO, -1, "Error: Sweep 3D motif checked "

--- a/src/sst/elements/ember/mpi/motifs/embersweep3d.cc
+++ b/src/sst/elements/ember/mpi/motifs/embersweep3d.cc
@@ -96,7 +96,6 @@ void EmberSweep3DGenerator::configure()
 bool EmberSweep3DGenerator::generate( std::queue<EmberEvent*>& evQ) {
 
 	if( 0 == m_loopIndex && 0 == m_InnerLoopIndex ) {
-		configure();
 		verbose(CALL_INFO, 2, MOTIF_MASK, "rank=%d size=%d\n", rank(), size());
 	}
 

--- a/src/sst/elements/ember/mpi/motifs/embersweep3d.h
+++ b/src/sst/elements/ember/mpi/motifs/embersweep3d.h
@@ -75,9 +75,9 @@ public:
 
 
 public:
-	EmberSweep3DGenerator(SST::ComponentId_t id, Params& params);
-	void configure();
-    bool generate( std::queue<EmberEvent*>& evQ );
+    EmberSweep3DGenerator( SST::ComponentId_t id, Params& params );
+    void configure() override;
+    bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
     uint32_t m_loopIndex;

--- a/src/sst/elements/ember/mpi/motifs/embersweep3d.h
+++ b/src/sst/elements/ember/mpi/motifs/embersweep3d.h
@@ -49,32 +49,6 @@ public:
         {   "arg.computetime",      "Sets the compute time per nx * ny block in picoseconds", "1000"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
     EmberSweep3DGenerator( SST::ComponentId_t id, Params& params );
     void configure() override;
     bool generate( std::queue<EmberEvent*>& evQ ) override;

--- a/src/sst/elements/ember/mpi/motifs/embertest.h
+++ b/src/sst/elements/ember/mpi/motifs/embertest.h
@@ -34,32 +34,6 @@ public:
         "Performs a Test Motif",
         SST::Ember::EmberGenerator
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Test", "Time spent in Test event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-public:
 
 	EmberTestGenerator(SST::ComponentId_t id, Params& params):
         EmberMessagePassingGenerator(id, params, "Null" ), m_phase(Init)

--- a/src/sst/elements/ember/mpi/motifs/embertestany.h
+++ b/src/sst/elements/ember/mpi/motifs/embertestany.h
@@ -34,33 +34,7 @@ public:
         "Performs a Testany Motif",
         SST::Ember::EmberGenerator
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Test", "Time spent in Test event",    "ns", 0},
-        { "time-Testany", "Time spent in Testany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
-public:
 	EmberTestanyGenerator(SST::ComponentId_t id, Params& params):
         EmberMessagePassingGenerator(id, params, "Null" ), m_phase(Init)
 	{

--- a/src/sst/elements/ember/mpi/motifs/emberunstructured.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberunstructured.cc
@@ -28,12 +28,10 @@ EmberUnstructuredGenerator::EmberUnstructuredGenerator(SST::ComponentId_t id, Pa
 	items_per_cell = (uint32_t) params.find<uint32_t>("arg.fields_per_cell", 1);
 	sizeof_cell = (uint32_t) params.find<uint32_t>("arg.datatype_width", 8);
 	iterations = (uint32_t) params.find<uint32_t>("arg.iterations", 1);
-	nsCompute  = (uint64_t) params.find<uint64_t>("arg.computetime", 0);
+	nsCompute = (uint64_t) params.find<uint64_t>("arg.computetime", 0);
 
-    jobId        = (int) params.find<int>("_jobId"); //NetworkSim
-	configure();
+    jobId = (int) params.find<int>("_jobId"); //NetworkSim
 }
-
 
 void EmberUnstructuredGenerator::configure()
 {

--- a/src/sst/elements/ember/mpi/motifs/emberunstructured.cc
+++ b/src/sst/elements/ember/mpi/motifs/emberunstructured.cc
@@ -35,25 +35,27 @@ EmberUnstructuredGenerator::EmberUnstructuredGenerator(SST::ComponentId_t id, Pa
 
 void EmberUnstructuredGenerator::configure()
 {
-	//Check the type of the rankmapper: CustomMap or LinearMap
-	bool use_CustomRankMap;
-	EmberCustomRankMap* cm = dynamic_cast<EmberCustomRankMap*>(getRankMap());
-	if(cm == NULL)
-		use_CustomRankMap = false;
-	else
-		use_CustomRankMap = true;
+    EmberMessagePassingGenerator::configure();
+
+    // Check the type of the rankmapper: CustomMap or LinearMap
+    bool use_CustomRankMap;
+    EmberCustomRankMap* cm = dynamic_cast<EmberCustomRankMap*>(getRankMap());
+    if(cm == NULL)
+        use_CustomRankMap = false;
+    else
+        use_CustomRankMap = true;
 
     if(0 == rank()) {
-		output("Unstructured motif problem size: %" PRIu32 "\n", p_size);
-		output("Unstructured motif compute time: %" PRIu32 " ns\n", nsCompute);
-		output("Unstructured motif iterations: %" PRIu32 "\n", iterations);
-		output("Unstructured motif iterms/cell: %" PRIu32 "\n", items_per_cell);
-		output("Unstructured motif communication graph file: %s \n", graphFile.c_str());
-		if(use_CustomRankMap)
-			output("Unstructured motif rankmap: CustomRankMap\n");
-		else
-			output("Unstructured motif rankmap: LinearRankMap\n");
-	}
+        output("Unstructured motif problem size: %" PRIu32 "\n", p_size);
+        output("Unstructured motif compute time: %" PRIu32 " ns\n", nsCompute);
+        output("Unstructured motif iterations: %" PRIu32 "\n", iterations);
+        output("Unstructured motif iterms/cell: %" PRIu32 "\n", items_per_cell);
+        output("Unstructured motif communication graph file: %s \n", graphFile.c_str());
+        if(use_CustomRankMap)
+            output("Unstructured motif rankmap: CustomRankMap\n");
+        else
+            output("Unstructured motif rankmap: LinearRankMap\n");
+    }
 
 	//Read raw communication from the graph file
 	rawCommMap = readCommFile(graphFile, size());

--- a/src/sst/elements/ember/mpi/motifs/emberunstructured.h
+++ b/src/sst/elements/ember/mpi/motifs/emberunstructured.h
@@ -66,10 +66,10 @@ public:
 
 
 public:
-	EmberUnstructuredGenerator(SST::ComponentId_t, Params& params);
+	EmberUnstructuredGenerator( SST::ComponentId_t, Params& params );
 	~EmberUnstructuredGenerator() {}
-	void configure();
-	bool generate( std::queue<EmberEvent*>& evQ );
+	void configure() override;
+	bool generate( std::queue<EmberEvent*>& evQ ) override;
 
 private:
 	std::string graphFile;

--- a/src/sst/elements/ember/mpi/motifs/emberunstructured.h
+++ b/src/sst/elements/ember/mpi/motifs/emberunstructured.h
@@ -40,32 +40,6 @@ public:
         {   "arg.computetime",      "Sets the number of nanoseconds to compute for",    "0"},
     )
 
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
-
-
-public:
 	EmberUnstructuredGenerator( SST::ComponentId_t, Params& params );
 	~EmberUnstructuredGenerator() {}
 	void configure() override;

--- a/src/sst/elements/ember/mpi/motifs/emberwaitany.h
+++ b/src/sst/elements/ember/mpi/motifs/emberwaitany.h
@@ -34,36 +34,13 @@ public:
         "Performs a Waitany Motif",
         SST::Ember::EmberGenerator
     )
-    SST_ELI_DOCUMENT_STATISTICS(
-        { "time-Init", "Time spent in Init event",          "ns",  0},
-        { "time-Finalize", "Time spent in Finalize event",  "ns", 0},
-        { "time-Rank", "Time spent in Rank event",          "ns", 0},
-        { "time-Size", "Time spent in Size event",          "ns", 0},
-        { "time-Send", "Time spent in Recv event",          "ns", 0},
-        { "time-Recv", "Time spent in Recv event",          "ns", 0},
-        { "time-Irecv", "Time spent in Irecv event",        "ns", 0},
-        { "time-Isend", "Time spent in Isend event",        "ns", 0},
-        { "time-Wait", "Time spent in Wait event",          "ns", 0},
-        { "time-Waitall", "Time spent in Waitall event",    "ns", 0},
-        { "time-Waitany", "Time spent in Waitany event",    "ns", 0},
-        { "time-Compute", "Time spent in Compute event",    "ns", 0},
-        { "time-Barrier", "Time spent in Barrier event",    "ns", 0},
-        { "time-Alltoallv", "Time spent in Alltoallv event", "ns", 0},
-        { "time-Alltoall", "Time spent in Alltoall event",  "ns", 0},
-        { "time-Allreduce", "Time spent in Allreduce event", "ns", 0},
-        { "time-Reduce", "Time spent in Reduce event",      "ns", 0},
-        { "time-Bcast", "Time spent in Bcast event",        "ns", 0},
-        { "time-Gettime", "Time spent in Gettime event",    "ns", 0},
-        { "time-Commsplit", "Time spent in Commsplit event", "ns", 0},
-        { "time-Commcreate", "Time spent in Commcreate event", "ns", 0},
-    )
 
-public:
 	EmberWaitanyGenerator(SST::ComponentId_t id , Params& params):
         EmberMessagePassingGenerator(id, params, "Null" ), m_phase(Init)
 	{
 		m_rng = new SST::RNG::XORShiftRNG();
 	}
+
     bool generate( std::queue<EmberEvent*>& evQ){
 		switch ( m_phase ) {
 			case Init:

--- a/src/sst/elements/ember/pyember.py
+++ b/src/sst/elements/ember/pyember.py
@@ -33,6 +33,7 @@ class EmberJob(Job):
         # Not sure what to do with this yet
         #x = self._createPrefixedParams("ember")
         self._declareParamsWithUserPrefix("ember","ember",["verbose"])
+        self._declareParamsWithUserPrefix("ember","ember",["verboseMask"])
         #x._subscribeToPlatformParamSet("ember")
 
         # Not clear what to do with this yet. Don't think we need it
@@ -190,6 +191,8 @@ class EmberMPIJob(EmberJob):
         apis = { 'api.0.module':'firefly.hadesMP'}
 
         EmberJob.__init__(self,job_id,num_nodes,apis,numCores,nicsPerNode)
+
+        self._declareParamsWithUserPrefix("ember","ember",["enableMpiStatsPerMotif"])
 
         self.nic = BasicNicConfiguration()
         self._lockVariable("nic")

--- a/src/sst/elements/ember/shmem/emberShmemGen.h
+++ b/src/sst/elements/ember/shmem/emberShmemGen.h
@@ -107,19 +107,29 @@ namespace Ember {
 class EmberShmemGenerator : public EmberGenerator {
 
 public:
+    EmberShmemGenerator( ComponentId_t, Params& params, std::string name = "" );
 
-	EmberShmemGenerator( ComponentId_t, Params& params, std::string name ="");
-	~EmberShmemGenerator() {}
-    virtual void completed( const SST::Output*, uint64_t time ) {}
-	virtual void setup();
+    ~EmberShmemGenerator()
+    { }
+
+    virtual void completed( const SST::Output*, uint64_t time )
+    { }
+
+    virtual void setup();
+
+    virtual void configure()
+    { }
 
 protected:
-	EmberShmemLib& shmem() { return *m_shmem; };
+    EmberShmemLib& shmem()
+    {
+        return *m_shmem;
+    };
 
-	EmberMiscLib* m_miscLib;
+    EmberMiscLib* m_miscLib;
 
 private:
-	EmberShmemLib* m_shmem;
+    EmberShmemLib* m_shmem;
 };
 
 }


### PR DESCRIPTION
This PR aims to bring back to Ember its capability of measuring and reporting as statistics the time being spent in different MPI events, by different MPI motifs.
Link to the related issue: https://github.com/sstsimulator/sst-elements/issues/2043

In the current design of Ember, motifs are created as anonymous subcomponents during simulation runtime. I.e., once the simulation of a particular motif completes, the next motif as specified in the config file gets loaded as an anonymous subcomponent. See the calls to initMotif() in ember/emberengine.cc.
One of the consequences of the dynamic motif loading is that registering any statistics defined by the motifs requires the StatisticOutput SST object to support the dynamic statistic registration (c.f., supportsDynamicRegistration() in statapi/statoutput.h). It seems that none of the currently available statistic output formats support dynamic statistics registration.

The first commit in this PR (Ember: create all motifs during simulation startup) addresses this issue by constructing all defined motifs in advance, i.e., in EmberEngine constructor.
Note that some of the Ember motifs to be fully initialized require another motif to be executed first. One example is the OTF2 motif, which requires the Init motif to initialize the EmberMpiLib object. To facilitate this, a virtual configure() method has been added to the base EmberGenerator class. Some of the motifs (e.g., Ember3DAMRGenerator) already had a configure() function, called in either their constructor or the generate() function. The configure() function is now called explicitly by the EmberEngine, notably in the places where the initMotif() has been previously called.

The second commit (Ember: Enable the MPI time statistics) enables the MPI time statistics in the motifs. The SST_ELI declarations of the MPI event stats are removed from all the derived motif classes and are now part only of the EmberMessagePassingGenerator. The enumeration of the MPI events has been moved from emberMpiLib.h to emberMPIEvent.h. Motifs use their name (e.g., InitMotif) as a statistic subId, so that different motifs may create separate sets of stats.
The EmberMpiLib object has been extended to hold a copy of the pointers to statistics created by the currently simulated motif. See setEventStatistics() in ember/libs/emberMpiLib.cc. Each MPI motif calls setEventStatistics() in its configure() function. The copy of stat pointers in EmberMpiLib is cleared after completion of each motif.
A new Ember config parameter 'enableMpiStatsPerMotif' has been added, enabled by default, which allows to create only one set of statistics (per EmberGenerator), by specifying enableMpiStatsPerMotif=0 in the config file.

For example:

ep = EmberMPIJob(0, topo.getNumNodes())
ep.addMotif("Init")
ep.addMotif("Fini")
ep.ember.enableMpiStatsPerMotif=0

With enableMpiStatsPerMotif=0
nic0core0_EmberEP, time-Init, , Accumulator, 298688773, 0, 60, 3600, 1, 60, 60

Default:
nic0core0_EmberEP, time-Init, InitMotif, Accumulator, 298688773, 0, 60, 3600, 1, 60, 60


