### PR TITLE
Fix iterator type mismatches caused by the std::map comparison functor being left out

### DIFF
--- a/src/sst/elements/messier/nvm_dimm.cc
+++ b/src/sst/elements/messier/nvm_dimm.cc
@@ -219,9 +219,8 @@ bool NVM_DIMM::tick()
 void NVM_DIMM::schedule_delivery()
 {
 
-    std::map<NVM_Request *, long long int>::iterator st_1, en_1;
-    st_1 = ready_at_NVM.begin();
-    en_1 = ready_at_NVM.end();
+    auto st_1 = ready_at_NVM.begin();
+    auto en_1 = ready_at_NVM.end();
 
     while (st_1 != en_1)
     {

--- a/src/sst/elements/samba/tlb_unit.cc
+++ b/src/sst/elements/samba/tlb_unit.cc
@@ -91,13 +91,13 @@ TLB::TLB(ComponentId_t id, int tlb_id, TLB * Next_level, int Level, SST::Params&
 
 
     // === Init Counters
-    
+
 	hits=misses=0;
 
 
     // === Per page-size params =======================================
-    
-    
+
+
     // params
 	size = new int[sizes];
 	assoc = new int[sizes];
@@ -163,7 +163,7 @@ void TLB::setPTW(PageTableWalker * Next_level) {
     PTW=Next_level;
 }
 
-// This is the most important function, which works like the heart of the TLBUnit, 
+// This is the most important function, which works like the heart of the TLBUnit,
 // called on every cycle to check if any completed requests or new requests at this cycle.
 bool TLB::tick(SST::Cycle_t x)
 {
@@ -180,7 +180,7 @@ bool TLB::tick(SST::Cycle_t x)
 
 
 		// Double checking that we actually still don't have it inserted
-		// Insert the translation into all structures with same or smaller size page support. 
+		// Insert the translation into all structures with same or smaller size page support.
         // Note that smaller page sizes will still have the same translation with offset derived from address
 		std::map<long long int, int>::iterator lu_st, lu_en;
 		lu_st=SIZE_LOOKUP.begin();
@@ -216,7 +216,7 @@ bool TLB::tick(SST::Cycle_t x)
 			st++;
 		}
 
-		// Note that here we are substituting for latency of checking the tag before proceeding 
+		// Note that here we are substituting for latency of checking the tag before proceeding
         // to the next level, we also add the upper link latency for the round trip
 		ready_by[ev]= x + latency + 2*upper_link_latency;
 
@@ -227,10 +227,9 @@ bool TLB::tick(SST::Cycle_t x)
 		// Check if there are other misses that were going to the same translation and waiting for the response of this miss
 		if((level==1) && (SAME_MISS.find(addr/4096)!=SAME_MISS.end()))
 		{
-		  std::map< MemHierarchy::MemEventBase*, int>::iterator same_st, same_en;
-		  same_st = SAME_MISS[addr/4096].begin();
-    		  same_en = SAME_MISS[addr/4096].end();
-   		   while(same_st!=same_en)
+		   auto same_st = SAME_MISS[addr/4096].begin();
+		   auto same_en = SAME_MISS[addr/4096].end();
+		   while(same_st!=same_en)
 		    {
 
 	    		ready_by[same_st->first] = x + latency + 2*upper_link_latency;
@@ -249,7 +248,7 @@ bool TLB::tick(SST::Cycle_t x)
 
 
 
-	// The actual dispatching process... here we take a request and place it 
+	// The actual dispatching process... here we take a request and place it
     // in the right queue based on being miss or hit and the number of pending misses
 	std::vector<MemHierarchy::MemEventBase*>::iterator st_1,en_1;
 	st_1 = not_serviced.begin();
@@ -357,9 +356,8 @@ bool TLB::tick(SST::Cycle_t x)
 	}
 
 
-	std::map<MemHierarchy::MemEventBase *, SST::Cycle_t>::iterator st, en;
-	st = ready_by.begin();
-	en = ready_by.end();
+	auto st = ready_by.begin();
+	auto en = ready_by.end();
 
 	// We iterate over the list of being serviced request to see if any has finished by this cycle
 	while(st!=en)
@@ -524,5 +522,3 @@ void TLB::update_lru(Address_t vaddr, int struct_id)
 
 
 }
-
-


### PR DESCRIPTION
This fixes a build error which was detected when compiling sst-elements with the STL debug option `-D_GLIBCXX_DEBUG`:
```
  CXX      nvm_dimm.lo
../../../../../src/sst/elements/messier/nvm_dimm.cc: In member function 'void SST::MessierComponent::NVM_DIMM::schedule_delivery()':
../../../../../src/sst/elements/messier/nvm_dimm.cc:223:31: error: no match for 'operator=' (operand types are 'std::__debug::map<SST::MessierComponent::NVM_Request*, long long int>::iterator' and 'std::__debug::map<SST::MessierComponent::NVM_Request*, long long int, SST::MessierComponent::NVM_DIMM::NVMReqPtrCompare>::iterator')
  223 |     st_1 = ready_at_NVM.begin();
      |                               ^

(similar error for en_1)

  CXX      tlb_unit.lo
../../../../../src/sst/elements/samba/tlb_unit.cc: In member function 'bool TLB::tick(SST::Cycle_t)':
../../../../../src/sst/elements/samba/tlb_unit.cc:231:56: error: no match for 'operator=' (operand types are 'std::__debug::map<SST::MemHierarchy::MemEventBase*, int>::iterator' and 'std::__debug::map<SST::MemHierarchy::MemEventBase*, int, SST::SambaComponent::MemEventPtrCompare>::iterator')
  231 |                   same_st = SAME_MISS[addr/4096].begin();
      |                                                        ^

(similar error for same_en)

../../../../../src/sst/elements/samba/tlb_unit.cc: In member function 'bool TLB::tick(SST::Cycle_t)':
../../../../../src/sst/elements/samba/tlb_unit.cc:360:29: error: no match for 'operator=' (operand types are 'std::__debug::map<SST::MemHierarchy::MemEventBase*, long unsigned int>::iterator' and 'std::__debug::map<SST::MemHierarchy::MemEventBase*, long unsigned int, SST::SambaComponent::MemEventPtrCompare>::iterator')
  360 |         st = ready_by.begin();
      |                             ^

(similar error for en)
```

The iterators are declared without the comparison functor being passed to the `std::map` container in the iterator declaration, causing a type mismatch in the assignments of the iterators.

It may be that  `-D_GLIBCXX_DEBUG`  causes the STL containers to use different default comparison functors, such as debugging wrappers, while the regular defaults match.

Re-declaring the iterators with `auto` ensures that they are the correct type, and fixes this error.

(Some trailing whitespace was removed in the edited files, which is my editor's default behavior.)


