### PR TITLE
Install Ariel API Library

### DIFF
--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -245,6 +245,8 @@ endif
 install-exec-hook:
 	$(MKDIR_P) $(libexecdir)
 	$(INSTALL) fesimple.so $(libexecdir)/fesimple.so
+	$(MKDIR_P) $(libdir)
+	$(INSTALL) api/libarielapi.so $(libdir)/libarielapi.so
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     ariel=$(abs_srcdir)
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      ariel=$(abs_srcdir)/tests
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTSUITES ariel=$(abs_srcdir)/testsuites
@@ -281,6 +283,8 @@ fesimple.o : $(top_srcdir)/src/sst/elements/ariel/frontend/simple/fesimple.cc
 install-exec-hook:
 	$(MKDIR_P) $(libexecdir)
 	$(INSTALL) fesimple.so $(libexecdir)/fesimple.so
+	$(MKDIR_P) $(libdir)
+	$(INSTALL) api/libarielapi.so $(libdir)/libarielapi.so
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     ariel=$(abs_srcdir)
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      ariel=$(abs_srcdir)/tests
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTSUITES ariel=$(abs_srcdir)/testsuites

--- a/src/sst/elements/ariel/api/arielapi.c
+++ b/src/sst/elements/ariel/api/arielapi.c
@@ -70,7 +70,7 @@ void omp_parallel_region() {
 // This function only exists to get mapped by the frontend. It should only be called
 // from MPI_Init or MPI_Init_thread to allow the frontend to distinguish between our
 // custom versions of of those functions and the normal MPI library's versions.
-int _api_mpi_init() {
+void _api_mpi_init() {
     printf("notifying fesimple\n");
 }
 


### PR DESCRIPTION
As part of building Ariel, `libarielapi.so` is built. This PR installs the library with the rest of SST, in the `$install-prefix/lib` directory. This will make it easier for external programs that depend on this library to find it. 

Also includes a small bugfix in arielapi.c. 