### PR TITLE
Install libarielapi.so as part of installing sst-elements

### DIFF
--- a/src/sst/elements/ariel/Makefile.am
+++ b/src/sst/elements/ariel/Makefile.am
@@ -134,7 +134,8 @@ sstdir = $(includedir)/sst/elements/ariel
 nobase_sst_HEADERS = \
 	ariel_shmem.h \
 	arieltracegen.h \
-	arielmemmgr.h
+	arielmemmgr.h \
+	api/arielapi.h
 
 libexec_PROGRAMS =
 
@@ -245,6 +246,8 @@ endif
 install-exec-hook:
 	$(MKDIR_P) $(libexecdir)
 	$(INSTALL) fesimple.so $(libexecdir)/fesimple.so
+	$(MKDIR_P) $(pkglibdir)
+	$(INSTALL) api/libarielapi.so $(pkglibdir)/libarielapi.so
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     ariel=$(abs_srcdir)
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      ariel=$(abs_srcdir)/tests
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTSUITES ariel=$(abs_srcdir)/testsuites
@@ -281,6 +284,8 @@ fesimple.o : $(top_srcdir)/src/sst/elements/ariel/frontend/simple/fesimple.cc
 install-exec-hook:
 	$(MKDIR_P) $(libexecdir)
 	$(INSTALL) fesimple.so $(libexecdir)/fesimple.so
+	$(MKDIR_P) $(pkglibdir)
+	$(INSTALL) api/libarielapi.so $(pkglibdir)/libarielapi.so
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     ariel=$(abs_srcdir)
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      ariel=$(abs_srcdir)/tests
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTSUITES ariel=$(abs_srcdir)/testsuites

--- a/src/sst/elements/ariel/api/arielapi.c
+++ b/src/sst/elements/ariel/api/arielapi.c
@@ -70,7 +70,7 @@ void omp_parallel_region() {
 // This function only exists to get mapped by the frontend. It should only be called
 // from MPI_Init or MPI_Init_thread to allow the frontend to distinguish between our
 // custom versions of of those functions and the normal MPI library's versions.
-int _api_mpi_init() {
+void _api_mpi_init() {
     printf("notifying fesimple\n");
 }
 

--- a/src/sst/elements/ariel/configure.m4
+++ b/src/sst/elements/ariel/configure.m4
@@ -19,8 +19,12 @@ AC_DEFUN([SST_ariel_CONFIG], [
   AC_SUBST([ARIEL_MPI_CFLAGS])
   AC_SUBST([ARIEL_MPI_LIBS])
 
-  AC_CONFIG_LINKS([src/sst/elements/ariel/api/arielapi.c:src/sst/elements/ariel/api/arielapi.c])
-  AC_CONFIG_LINKS([src/sst/elements/ariel/api/arielapi.h:src/sst/elements/ariel/api/arielapi.h])
+  dnl Use autoconf to copy files. Because of the way api/Makefile.am and mpi/Makefle.am
+  dnl are written, these files are not automatically copied for out of source builds.
+  AC_CONFIG_FILES([src/sst/elements/ariel/api/arielapi.c:src/sst/elements/ariel/api/arielapi.c])
+  AC_CONFIG_FILES([src/sst/elements/ariel/api/arielapi.h:src/sst/elements/ariel/api/arielapi.h])
+  AC_CONFIG_FILES([src/sst/elements/ariel/mpi/mpilauncher.cc:src/sst/elements/ariel/mpi/mpilauncher.cc])
+  AC_CONFIG_FILES([src/sst/elements/ariel/mpi/fakepin.cc:src/sst/elements/ariel/mpi/fakepin.cc])
 
   AC_CONFIG_FILES([src/sst/elements/ariel/api/Makefile])
   AC_CONFIG_FILES([src/sst/elements/ariel/mpi/Makefile])

--- a/src/sst/elements/ariel/mpi/Makefile.am
+++ b/src/sst/elements/ariel/mpi/Makefile.am
@@ -5,5 +5,7 @@ mpilauncher: mpilauncher.cc
 fakepin: fakepin.cc
 	 $(ARIEL_MPICXX) fakepin.cc -o fakepin
 
+bin_SCRIPTS = mpilauncher
+
 clean-local:
 	rm -f mpilauncher fakepin


### PR DESCRIPTION
As part of building Ariel, `libarielapi.so` is built. This PR installs the library with the rest of SST, in the `$pkglibdir` directory. This will make it easier for external programs that depend on this library to find it. The header is also installed with the rest of the Ariel headers and a small bugfix for arielapi.c is included.
