### PR TITLE
In Merlin, use SST:RNG::MersenneRNG instead of bare MersenneRNG

### DIFF
--- a/src/sst/elements/merlin/target_generator/uniform.h
+++ b/src/sst/elements/merlin/target_generator/uniform.h
@@ -47,7 +47,7 @@ public:
         {"max",   "Maximum address to generate","numpeers - 1"}
    )
 
-    MersenneRNG* gen;
+    SST::RNG::MersenneRNG* gen;
     SSTUniformDistribution* dist;
 
     int min;
@@ -62,7 +62,7 @@ public:
         min = params.find<int>("min",0);
         max = params.find<int>("max",num_peers - 1);
 
-        gen = new MersenneRNG(id);
+        gen = new SST::RNG::MersenneRNG(id);
 
         int dist_size = std::max(1, max-min);
         dist = new SSTUniformDistribution(dist_size, gen);
@@ -75,7 +75,7 @@ public:
     }
 
     void initialize(int id, int num_peers) {
-        gen = new MersenneRNG(id);
+        gen = new SST::RNG::MersenneRNG(id);
 
         if ( min == -1 ) min = 0;
         if ( max == -1 ) max = num_peers;
@@ -92,7 +92,7 @@ public:
     void seed(uint32_t val) {
         delete dist;
         delete gen;
-        gen = new MersenneRNG((unsigned int) val);
+        gen = new SST::RNG::MersenneRNG((unsigned int) val);
         dist = new SSTUniformDistribution(std::max(1, max-min),gen);
     }
 };

--- a/src/sst/elements/merlin/trafficgen/trafficgen.h
+++ b/src/sst/elements/merlin/trafficgen/trafficgen.h
@@ -163,13 +163,13 @@ private:
     };
 
     class ExponentialDist : public Generator {
-        MersenneRNG* gen;
+        SST::RNG::MersenneRNG* gen;
         SSTExponentialDistribution* dist;
 
     public:
         ExponentialDist(int lambda)
         {
-            gen = new MersenneRNG();
+            gen = new SST::RNG::MersenneRNG();
 	    dist = new SSTExponentialDistribution((double) lambda);
         }
 
@@ -186,13 +186,13 @@ private:
         void seed(uint32_t val)
         {
             delete gen;
-            gen = new MersenneRNG((unsigned int) val);
+            gen = new SST::RNG::MersenneRNG((unsigned int) val);
         }
     };
 
 
     class UniformDist : public Generator {
-        MersenneRNG* gen;
+        SST::RNG::MersenneRNG* gen;
         SSTUniformDistribution* dist;
 
         int dist_size;
@@ -200,7 +200,7 @@ private:
     public:
         UniformDist(int min, int max)
         {
-		gen = new MersenneRNG();
+		gen = new SST::RNG::MersenneRNG();
 
 		dist_size = std::max(1, max-min);
 		dist = new SSTUniformDistribution(dist_size, gen);
@@ -220,14 +220,14 @@ private:
         {
             delete dist;
             delete gen;
-            gen = new MersenneRNG((unsigned int) val);
+            gen = new SST::RNG::MersenneRNG((unsigned int) val);
             dist = new SSTUniformDistribution(dist_size,gen);
         }
     };
 
 
     class DiscreteDist : public Generator {
-	MersenneRNG* gen;
+	SST::RNG::MersenneRNG* gen;
 	SSTDiscreteDistribution* dist;
         int minValue;
     public:
@@ -241,7 +241,7 @@ private:
             }
             probs[target] = targetProb;
 
-	    gen = new MersenneRNG();
+	    gen = new SST::RNG::MersenneRNG();
 	    dist = new SSTDiscreteDistribution(&probs[0], size, gen);
         }
 
@@ -257,20 +257,20 @@ private:
 
         void seed(uint32_t val)
         {
-            gen = new MersenneRNG((unsigned int) val);
+            gen = new SST::RNG::MersenneRNG((unsigned int) val);
         }
     };
 
     class NormalDist : public Generator {
 	SSTGaussianDistribution* dist;
-	MersenneRNG* gen;
+	SST::RNG::MersenneRNG* gen;
 
         int minValue;
         int maxValue;
     public:
         NormalDist(int min, int max, double mean, double stddev) : minValue(min), maxValue(max)
         {
-            gen = new MersenneRNG();
+            gen = new SST::RNG::MersenneRNG();
             dist = new SSTGaussianDistribution(mean, stddev);
         }
 
@@ -289,7 +289,7 @@ private:
 
         void seed(uint32_t val)
         {
-            gen = new MersenneRNG((unsigned int) val);
+            gen = new SST::RNG::MersenneRNG((unsigned int) val);
         }
     };
 


### PR DESCRIPTION
In Merlin, `MersenneRNG` is used without the `SST::RNG::` namespace specifier. This happened to work because of a bug in SST Core which imported all of `SST::RNG` into the global namespace.

Other parts of SST Elements use the correct full name `SST::RNG::MersenneRNG`.

If a SST name in global namespace is desired for `MersenneRNG`, such as `SSTMersenneRNG` (similar to `SSTGaussianDistribution` and `SSTUniformDistribution`), it can be added to SST Core.


