### PR TITLE
Subcomponent fix for checkpointing

### DIFF
--- a/src/sst/elements/simpleElementExample/basicSubComponent_subcomponent.h
+++ b/src/sst/elements/simpleElementExample/basicSubComponent_subcomponent.h
@@ -89,7 +89,11 @@ public:
 
     int compute( int num) override;
     std::string compute( std::string comp ) override;
+
+    // serialization
+    basicSubComponentIncrement();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::simpleElementExample::basicSubComponentIncrement);
 
 private:
     int amount;
@@ -119,7 +123,11 @@ public:
 
     int compute( int num) override;
     std::string compute( std::string comp ) override;
+
+    //  serialization
+    basicSubComponentDecrement();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::simpleElementExample::basicSubComponentDecrement);
 
 private:
     int amount;
@@ -147,7 +155,11 @@ public:
 
     int compute( int num) override;
     std::string compute( std::string comp ) override;
+
+    // Serialization
+    basicSubComponentMultiply();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::simpleElementExample::basicSubComponentMultiply);
 
 private:
     int amount;
@@ -175,7 +187,11 @@ public:
 
     int compute( int num) override;
     std::string compute( std::string comp ) override;
+
+    // Serialization
+    basicSubComponentDivide();
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
+    ImplementSerializable(SST::simpleElementExample::basicSubComponentDivide);
 
 private:
     int amount;

--- a/src/sst/elements/simpleElementExample/basicSubComponent_subcomponent.h
+++ b/src/sst/elements/simpleElementExample/basicSubComponent_subcomponent.h
@@ -60,7 +60,7 @@ public:
     virtual std::string compute( std::string comp) =0;
 
     // Serialization
-    basicSubComponentAPI();
+    basicSubComponentAPI() {};
     ImplementVirtualSerializable(SST::simpleElementExample::basicSubComponentAPI);
 };
 
@@ -91,7 +91,7 @@ public:
     std::string compute( std::string comp ) override;
 
     // serialization
-    basicSubComponentIncrement();
+    basicSubComponentIncrement() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::simpleElementExample::basicSubComponentIncrement);
 
@@ -125,7 +125,7 @@ public:
     std::string compute( std::string comp ) override;
 
     //  serialization
-    basicSubComponentDecrement();
+    basicSubComponentDecrement() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::simpleElementExample::basicSubComponentDecrement);
 
@@ -157,7 +157,7 @@ public:
     std::string compute( std::string comp ) override;
 
     // Serialization
-    basicSubComponentMultiply();
+    basicSubComponentMultiply() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::simpleElementExample::basicSubComponentMultiply);
 
@@ -189,7 +189,7 @@ public:
     std::string compute( std::string comp ) override;
 
     // Serialization
-    basicSubComponentDivide();
+    basicSubComponentDivide() : basicSubComponentAPI() {};
     void serialize_order(SST::Core::Serialization::serializer& ser) override;
     ImplementSerializable(SST::simpleElementExample::basicSubComponentDivide);
 


### PR DESCRIPTION
This fixes the subcomponent for issue [(sstsimulator/sst-core#1228)](https://github.com/sstsimulator/sst-core/issues/1228). It adds the required constructor and macro for each subcomponent so that the test can be run with checkpointing enabled. I went ahead with this PR so the code could be reviewed as I'm basing other subcomponent checkpointing models on this code.

