### PR TITLE
Add include guard to sst_element_config.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,13 @@ AM_INIT_AUTOMAKE([1.9.6 foreign dist-bzip2 subdir-objects no-define tar-pax])
 # If Automake supports silent rules, enable them.
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+AH_TOP([
+#ifndef _SST_ELEMENT_CONFIG_H_
+#define _SST_ELEMENT_CONFIG_H_
+])
+AH_BOTTOM([
+#endif /* _SST_ELEMENT_CONFIG_H_ */
+])
 AC_CONFIG_HEADERS([src/sst_element_config.h])
 
 m4_include([config/sst_elements_include.m4])


### PR DESCRIPTION
Add include guard to sst_element_config.h.  Similar to sstsimulator/sst-core#1269
