### PR TITLE
Add more patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/
 .\#*
 \#*\#
 .gdb_history
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tags
 *.inc
 *.so
 sst_test_outputs/
+build/
+.\#*
+\#*\#
+.gdb_history


### PR DESCRIPTION
Add more patterns to `.gitignore`, such as GDB history file, `build/` directory, Emacs `.#*` temporary files.