### PR TITLE
remove unnecessary UNUSED() macros in declarations (not definitions)

### DIFF
--- a/src/sst/elements/memHierarchy/memLink.h
+++ b/src/sst/elements/memHierarchy/memLink.h
@@ -97,14 +97,14 @@ public:
     virtual void setup() override;
 
     /* Shutdown functions for parent */
-    virtual void complete(unsigned int UNUSED(phase)) override;
+    virtual void complete(unsigned int phase) override;
 
     /* Remote endpoint info management */
     virtual std::set<EndpointInfo>* getSources();
     virtual std::set<EndpointInfo>* getDests();
     virtual std::set<EndpointInfo>* getPeers();
-    virtual bool isDest(std::string UNUSED(str));
-    virtual bool isSource(std::string UNUSED(str));
+    virtual bool isDest(std::string str);
+    virtual bool isSource(std::string str);
     virtual bool isPeer(std::string str);
     virtual std::string findTargetDestination(Addr addr);
     virtual std::string getTargetDestination(Addr addr);
@@ -135,7 +135,7 @@ protected:
     std::set<EndpointInfo> endpoints_;          // Tracks endpoints in the system with info on how to get there
     std::set<std::string> reachable_names_;     // Tracks reachable names for faster lookup than iterating via remotes/peers
     std::set<std::string> peer_names_;          // Tracks peer names for faster lookup than iterating via peers
-    
+
     // For events that require destination names during init
     std::set<MemEventInit*> init_send_queue_;
 

--- a/src/sst/elements/memHierarchy/memLinkBase.h
+++ b/src/sst/elements/memHierarchy/memLinkBase.h
@@ -72,7 +72,7 @@ public:
             return str.str();
         }
     };
-    
+
     // Identifiers that can be attached to init messages to detect memory system topology
     enum class ReachableGroup{Source, Dest, Peer, Unknown};
 
@@ -164,10 +164,10 @@ public:
     /* Functions for managing communication according to address */
     virtual std::string findTargetDestination(Addr addr) =0;    /* Return destination and return "" if none found */
     virtual std::string getTargetDestination(Addr addr) =0;     /* Return destination and error if none found */
-    
+
     /* Check if a request address maps to our region */
     virtual bool isRequestAddressValid(Addr addr) { return info.region.contains(addr); }
-    
+
     /* Get a string-ized list of available destinations on this link */
     virtual std::string getAvailableDestinationsAsString() =0; // For debug
 
@@ -175,11 +175,10 @@ public:
     virtual std::set<EndpointInfo>* getSources() =0;
     virtual std::set<EndpointInfo>* getDests() =0;
     virtual std::set<EndpointInfo>* getPeers() =0; // If peers are reachable via this link, may be empty if no peers or not reachable
-
-    virtual bool isDest(std::string UNUSED(str)) =0;    /* Check whether a component is a destination on this link. May be slow (for init() only) */
-    virtual bool isSource(std::string UNUSED(str)) =0;  /* Check whether a component is a source on this link. May be slow (for init() only) */
-    virtual bool isPeer(std::string UNUSED(str)) =0;    /* Check whether a component is a peer on this link. May be slow (for init() only) */
-    virtual bool isReachable(std::string dst) =0;       /* Check whether a component is reachable on this link. Should be fast - used during simulation */
+    virtual bool isDest(std::string str) =0;       // Check whether a component is a destination on this link. May be slow (for init() only)
+    virtual bool isSource(std::string str) =0;     // Check whether a component is a source on this link. May be slow (for init() only)
+    virtual bool isPeer(std::string str) =0;       // Check whether a component is a peer on this link. May be slow (for init() only)
+    virtual bool isReachable(std::string dst) =0;  // Check whether a component is reachable on this link. Should be fast - used during simulation
 
     MemRegion getRegion() { return info.region; }
     void setRegion(MemRegion region) { info.region = region; }
@@ -188,7 +187,7 @@ public:
     void setEndpointInfo(EndpointInfo i) { info = i; }
 
     // Optional. This sets the name used for src/destination/requestor/etc.
-    // This should be set correctly by default but occasionally 
+    // This should be set correctly by default but occasionally
     // a specific implementation may require a different setting
     void setName(std::string name) { info.name = name; }
 

--- a/src/sst/elements/shogun/shogun_nic.h
+++ b/src/sst/elements/shogun/shogun_nic.h
@@ -83,8 +83,8 @@ namespace Shogun {
         virtual Request* recv(int vn) override;
 
         virtual void setup() override;
-        virtual void init(unsigned int UNUSED(phase)) override;
-        virtual void complete(unsigned int UNUSED(phase)) override;
+        virtual void init(unsigned int phase) override;
+        virtual void complete(unsigned int phase) override;
         virtual void finish() override;
 
         /**


### PR DESCRIPTION
`UNUSED()` macro has no effect in function declarations which aren't definitions.