### PR TITLE
Add #include <list> to a bunch of headers

### DIFF
--- a/src/sst/elements/firefly/nic.h
+++ b/src/sst/elements/firefly/nic.h
@@ -17,7 +17,8 @@
 #ifndef COMPONENTS_FIREFLY_NIC_H
 #define COMPONENTS_FIREFLY_NIC_H
 
-#include <math.h>
+#include <cmath>
+#include <list>
 #include <sstream>
 #include <queue>
 #include <sst/core/module.h>

--- a/src/sst/elements/iris/sumi/message.h
+++ b/src/sst/elements/iris/sumi/message.h
@@ -44,7 +44,9 @@ Questions? Contact sst-macro-help@sandia.gov
 
 #pragma once
 
+#include <list>
 #include <memory>
+#include <utility>
 #include <mercury/common/util.h>
 #include <mercury/common/printable.h>
 #include <mercury/common/serializable.h>

--- a/src/sst/elements/memHierarchy/membackend/timingTransaction.h
+++ b/src/sst/elements/memHierarchy/membackend/timingTransaction.h
@@ -13,6 +13,8 @@
 #ifndef _H_SST_MEMH_TIMING_TRANSACTION
 #define _H_SST_MEMH_TIMING_TRANSACTION
 
+#include <list>
+
 #include <sst/core/subcomponent.h>
 
 namespace SST {

--- a/src/sst/elements/memHierarchy/mshr.h
+++ b/src/sst/elements/memHierarchy/mshr.h
@@ -16,6 +16,7 @@
 #ifndef _MSHR_H_
 #define _MSHR_H_
 
+#include <list>
 #include <map>
 #include <string>
 #include <sstream>

--- a/src/sst/elements/rdmaNic/rdmaNic.h
+++ b/src/sst/elements/rdmaNic/rdmaNic.h
@@ -16,6 +16,7 @@
 #ifndef MEMHIERARCHY_SHMEM_NIC_H
 #define MEMHIERARCHY_SHMEM_NIC_H
 
+#include <list>
 #include <queue>
 #include <sst/core/sst_types.h>
 

--- a/src/sst/elements/serrano/serrano.h
+++ b/src/sst/elements/serrano/serrano.h
@@ -21,6 +21,8 @@
 #include <sst/core/output.h>
 
 #include <cstdio>
+#include <list>
+#include <map>
 
 #include "smsg.h"
 #include "scircq.h"


### PR DESCRIPTION
This adds `#include <list>` and a few other `#include`s which were missing in Elements because it depended on them being `#include`d by Core.

Core serialization is in the process of being refactored such that it does not explicitly depend on standard containers like `std::list` and instead works on any types with certain properties, like having a `value_type` defined, and having `begin()`, `end()` and `push_back()` methods available.

A thorough review of Elements (and Core) should be done at some point, to `#include` the necessary headers used in each subcomponent, and not rely on them being `#include`d somewhere else.

@kpgriesser 
