### PR TITLE
Fix use_after_move

### DIFF
--- a/src/sst/elements/iris/sumi/sim_transport.cc
+++ b/src/sst/elements/iris/sumi/sim_transport.cc
@@ -232,7 +232,7 @@ SimTransport::allocateCq(int id, std::function<void(Message*)>&& f)
   if (iter != held_.end()){
     auto& list = iter->second;
     for (Message* m : list){
-      f(m);
+      completion_queues_[id](m);
     }
     held_.erase(iter);
   }


### PR DESCRIPTION
We `std::move(f)` on line 230.  According to the spec this leaves `f` in a valid but unspecified state.  On line 235 we call `f` which we should not be doing.
