### PR TITLE
Initialize sumi return values

### DIFF
--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cm.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cm.cc
@@ -112,7 +112,7 @@ EXTERN_C DIRECT_FN STATIC  int sumi_getname(fid_t fid, void *addr, size_t *addrl
   }
 
 	int ret;
-	size_t len = 0, cpylen;
+	size_t len = 0, cpylen = 0;
 #if 0
   struct sumi_fid_ep *ep = NULL;
   struct sumi_fid_sep *sep = NULL;
@@ -306,7 +306,7 @@ EXTERN_C DIRECT_FN STATIC  int sumi_getpeer(struct fid_ep *ep, void *addr,
 EXTERN_C DIRECT_FN STATIC  int sumi_connect(struct fid_ep *ep, const void *addr,
 				  const void *param, size_t paramlen)
 {
-	int ret, errno_keep;
+	int ret = 0, errno_keep;
 #if 0
   struct sumi_fid_ep *ep_priv;
 	struct sockaddr_in saddr;
@@ -460,7 +460,7 @@ err_unlock:
 EXTERN_C DIRECT_FN STATIC  int sumi_accept(struct fid_ep *ep, const void *param,
 				 size_t paramlen)
 {
-	int ret, errno_keep;
+	int ret = 0, errno_keep;
 #if 0
   struct sumi_vc *vc;
   struct sumi_fid_ep *ep_priv;
@@ -589,7 +589,7 @@ err_unlock:
 
 DIRECT_FN STATIC int sumi_shutdown(struct fid_ep *ep, uint64_t flags)
 {
-	int ret;
+	int ret = 0;
 #if 0
   struct sumi_fid_ep *ep_priv;
 	struct fi_eq_cm_entry eq_entry = {0};
@@ -709,7 +709,7 @@ extern "C" DIRECT_FN  int sumi_pep_bind(struct fid *fid, struct fid *bfid, uint6
 
 extern "C" DIRECT_FN  int sumi_pep_listen(struct fid_pep *pep)
 {
-	int ret, errno_keep;
+	int ret = 0, errno_keep;
 #if 0
   struct sumi_fid_pep *pep_priv;
 	struct sockaddr_in saddr;

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cntr.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cntr.cc
@@ -130,7 +130,7 @@ static int sumi_cntr_close(fid_t fid)
 
 DIRECT_FN STATIC uint64_t sumi_cntr_readerr(struct fid_cntr *cntr)
 {
-	int v, ret;
+	int v = 0, ret = 0;
   struct sumi_fid_cntr *cntr_priv;
 #if 0
 
@@ -150,7 +150,7 @@ DIRECT_FN STATIC uint64_t sumi_cntr_readerr(struct fid_cntr *cntr)
 
 DIRECT_FN STATIC uint64_t sumi_cntr_read(struct fid_cntr *cntr)
 {
-	int v, ret;
+	int v = 0, ret = 0;
 #if 0
   struct sumi_fid_cntr *cntr_priv;
 

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_sep.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_sep.cc
@@ -545,7 +545,7 @@ err:
 
 EXTERN_C DIRECT_FN STATIC  int sumi_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
-	int i, ret, n_ids;
+	int i, ret = 0, n_ids;
 #if 0
 	struct sumi_fid_ep  *ep;
 	struct sumi_fid_av  *av;

--- a/src/sst/elements/mercury/components/operating_system.cc
+++ b/src/sst/elements/mercury/components/operating_system.cc
@@ -562,6 +562,8 @@ OperatingSystem::handleRequest(Request* req)
     out_->debug(CALL_INFO, 1, 0,
                 "OperatingSystem::handle_event: got event %s instead of library event\n",
                 toString(req).c_str());
+    // if libmsg is null we cannot continue
+    return;
   }
 
   bool found = handleEventLibraryRequest(libmsg->libname(), req);


### PR DESCRIPTION
Uninitialized stack variables contain garbage.  Set them to sane defaults.
