### PR TITLE
Add override to overriden functions to remove Clang warnings

### DIFF
--- a/src/sst/elements/memHierarchy/cacheController.h
+++ b/src/sst/elements/memHierarchy/cacheController.h
@@ -194,8 +194,8 @@ public:
     virtual void finish(void) override;
 
     /** Component API - debug and fatal */
-    void printStatus(Output & out); // Called on SIGUSR2
-    void emergencyShutdown();       // Called on output.fatal(), SIGINT/SIGTERM
+    void printStatus(Output & out) override; // Called on SIGUSR2
+    void emergencyShutdown() override;       // Called on output.fatal(), SIGINT/SIGTERM
 
 private:
     /** Cache factory methods **************************************************/

--- a/src/sst/elements/memHierarchy/coherencemgr/MESI_Inclusive.h
+++ b/src/sst/elements/memHierarchy/coherencemgr/MESI_Inclusive.h
@@ -493,43 +493,43 @@ public:
     }
 
     /** Event handlers **/
-    virtual bool handleGetS(MemEvent * event, bool inMSHR);
-    virtual bool handleGetX(MemEvent * event, bool inMSHR);
-    virtual bool handleGetSX(MemEvent * event, bool inMSHR);
-    virtual bool handleFlushLine(MemEvent * event, bool inMSHR);
-    virtual bool handleFlushLineInv(MemEvent * event, bool inMSHR);
-    virtual bool handleFlushAll(MemEvent * event, bool inMSHR);
-    virtual bool handleForwardFlush(MemEvent * event, bool inMSHR);
-    virtual bool handlePutS(MemEvent * event, bool inMSHR);
-    virtual bool handlePutX(MemEvent * event, bool inMSHR);
-    virtual bool handlePutE(MemEvent * event, bool inMSHR);
-    virtual bool handlePutM(MemEvent * event, bool inMSHR);
-    virtual bool handleInv(MemEvent * event, bool inMSHR);
-    virtual bool handleForceInv(MemEvent * event, bool inMSHR);
-    virtual bool handleFetch(MemEvent * event, bool inMSHR);
-    virtual bool handleFetchInv(MemEvent * event, bool inMSHR);
-    virtual bool handleFetchInvX(MemEvent * event, bool inMSHR);
-    virtual bool handleGetSResp(MemEvent * event, bool inMSHR);
-    virtual bool handleGetXResp(MemEvent * event, bool inMSHR);
-    virtual bool handleFlushLineResp(MemEvent * event, bool inMSHR);
-    virtual bool handleFlushAllResp(MemEvent * event, bool inMSHR);
-    virtual bool handleFetchResp(MemEvent * event, bool inMSHR);
-    virtual bool handleFetchXResp(MemEvent * event, bool inMSHR);
-    virtual bool handleAckInv(MemEvent * event, bool inMSHR);
-    virtual bool handleAckPut(MemEvent * event, bool inMSHR);
-    virtual bool handleAckFlush(MemEvent * event, bool inMSHR);
-    virtual bool handleUnblockFlush(MemEvent * event, bool inMSHR);
-    virtual bool handleNACK(MemEvent * event, bool inMSHR);
-    virtual bool handleNULLCMD(MemEvent * event, bool inMSHR);
+    virtual bool handleGetS(MemEvent * event, bool inMSHR) override;
+    virtual bool handleGetX(MemEvent * event, bool inMSHR) override;
+    virtual bool handleGetSX(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFlushLine(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFlushLineInv(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFlushAll(MemEvent * event, bool inMSHR) override;
+    virtual bool handleForwardFlush(MemEvent * event, bool inMSHR) override;
+    virtual bool handlePutS(MemEvent * event, bool inMSHR) override;
+    virtual bool handlePutX(MemEvent * event, bool inMSHR) override;
+    virtual bool handlePutE(MemEvent * event, bool inMSHR) override;
+    virtual bool handlePutM(MemEvent * event, bool inMSHR) override;
+    virtual bool handleInv(MemEvent * event, bool inMSHR) override;
+    virtual bool handleForceInv(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFetch(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFetchInv(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFetchInvX(MemEvent * event, bool inMSHR) override;
+    virtual bool handleGetSResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleGetXResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFlushLineResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFlushAllResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFetchResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleFetchXResp(MemEvent * event, bool inMSHR) override;
+    virtual bool handleAckInv(MemEvent * event, bool inMSHR) override;
+    virtual bool handleAckPut(MemEvent * event, bool inMSHR) override;
+    virtual bool handleAckFlush(MemEvent * event, bool inMSHR) override;
+    virtual bool handleUnblockFlush(MemEvent * event, bool inMSHR) override;
+    virtual bool handleNACK(MemEvent * event, bool inMSHR) override;
+    virtual bool handleNULLCMD(MemEvent * event, bool inMSHR) override;
 
     /** Cache interface **/
-    virtual Addr getBank(Addr addr) { return cacheArray_->getBank(addr); }
-    virtual void setSliceAware(uint64_t size, uint64_t step) { cacheArray_->setSliceAware(size, step); }
+    virtual Addr getBank(Addr addr) override { return cacheArray_->getBank(addr); }
+    virtual void setSliceAware(uint64_t size, uint64_t step) override { cacheArray_->setSliceAware(size, step); }
 
     /** Initialization **/
-    MemEventInitCoherence * getInitCoherenceEvent();
+    MemEventInitCoherence * getInitCoherenceEvent() override;
 
-    std::set<Command> getValidReceiveEvents() {
+    std::set<Command> getValidReceiveEvents() override {
         std::set<Command> cmds = { Command::GetS,
             Command::GetX,
             Command::GetSX,
@@ -563,7 +563,7 @@ public:
         return cmds;
     }
 
-    void printStatus(Output &out);
+    void printStatus(Output &out) override;
 
 private:
 
@@ -603,15 +603,15 @@ private:
     State doEviction(MemEvent * event, SharedCacheLine * line, State state);
 
     /** Call through to coherenceController with statistic recording */
-    void forwardByAddress(MemEventBase* ev, Cycle_t timestamp);
-    void forwardByDestination(MemEventBase* ev, Cycle_t timestamp);
+    void forwardByAddress(MemEventBase* ev, Cycle_t timestamp) override;
+    void forwardByDestination(MemEventBase* ev, Cycle_t timestamp) override;
 
 /* Miscellaneous functions */
     /* Record prefetch statistics. Line cannot be null. */
     void recordPrefetchResult(SharedCacheLine * line, Statistic<uint64_t> * stat);
 
     /* Record latency */
-    void recordLatency(Command cmd, int type, uint64_t latency);
+    void recordLatency(Command cmd, int type, uint64_t latency) override;
 
     void printLine(Addr addr);
     

--- a/src/sst/elements/memHierarchy/coherencemgr/MESI_L1.h
+++ b/src/sst/elements/memHierarchy/coherencemgr/MESI_L1.h
@@ -378,36 +378,36 @@ public:
     }
 
     /** Event handlers - called by controller */
-    bool handleGetS(MemEvent * event, bool inMSHR);
-    bool handleWrite(MemEvent * event, bool inMSHR);
-    bool handleGetX(MemEvent * event, bool inMSHR);
-    bool handleGetSX(MemEvent * event, bool inMSHR);
-    bool handleFlushLine(MemEvent * event, bool inMSHR);
-    bool handleFlushLineInv(MemEvent * event, bool inMSHR);
-    bool handleFlushAll(MemEvent * event, bool inMSHR);
-    bool handleForwardFlush(MemEvent * event, bool inMSHR);
-    bool handleFetch(MemEvent * event, bool inMSHR);
-    bool handleInv(MemEvent * event, bool inMSHR);
-    bool handleForceInv(MemEvent * event, bool inMSHR);
-    bool handleFetchInv(MemEvent * event, bool inMSHR);
-    bool handleFetchInvX(MemEvent * event, bool inMSHR);
-    bool handleGetSResp(MemEvent * event, bool inMSHR);
-    bool handleGetXResp(MemEvent * event, bool inMSHR);
-    bool handleFlushLineResp(MemEvent * event, bool inMSHR);
-    bool handleFlushAllResp(MemEvent * event, bool inMSHR);
-    bool handleUnblockFlush(MemEvent * event, bool inMSHR);
-    bool handleAckPut(MemEvent * event, bool inMSHR);
-    bool handleNULLCMD(MemEvent * event, bool inMSHR);
-    bool handleNACK(MemEvent * event, bool inMSHR);
+    bool handleGetS(MemEvent * event, bool inMSHR) override;
+    bool handleWrite(MemEvent * event, bool inMSHR) override;
+    bool handleGetX(MemEvent * event, bool inMSHR) override;
+    bool handleGetSX(MemEvent * event, bool inMSHR) override;
+    bool handleFlushLine(MemEvent * event, bool inMSHR) override;
+    bool handleFlushLineInv(MemEvent * event, bool inMSHR) override;
+    bool handleFlushAll(MemEvent * event, bool inMSHR) override;
+    bool handleForwardFlush(MemEvent * event, bool inMSHR) override;
+    bool handleFetch(MemEvent * event, bool inMSHR) override;
+    bool handleInv(MemEvent * event, bool inMSHR) override;
+    bool handleForceInv(MemEvent * event, bool inMSHR) override;
+    bool handleFetchInv(MemEvent * event, bool inMSHR) override;
+    bool handleFetchInvX(MemEvent * event, bool inMSHR) override;
+    bool handleGetSResp(MemEvent * event, bool inMSHR) override;
+    bool handleGetXResp(MemEvent * event, bool inMSHR) override;
+    bool handleFlushLineResp(MemEvent * event, bool inMSHR) override;
+    bool handleFlushAllResp(MemEvent * event, bool inMSHR) override;
+    bool handleUnblockFlush(MemEvent * event, bool inMSHR) override;
+    bool handleAckPut(MemEvent * event, bool inMSHR) override;
+    bool handleNULLCMD(MemEvent * event, bool inMSHR) override;
+    bool handleNACK(MemEvent * event, bool inMSHR) override;
 
     /** Configuration */
-    MemEventInitCoherence* getInitCoherenceEvent();
-    virtual std::set<Command> getValidReceiveEvents();
-    void setSliceAware(uint64_t interleaveSize, uint64_t interleaveStep);
+    MemEventInitCoherence* getInitCoherenceEvent() override;
+    virtual std::set<Command> getValidReceiveEvents() override;
+    void setSliceAware(uint64_t interleaveSize, uint64_t interleaveStep) override;
 
-    void printStatus(Output& out);
+    void printStatus(Output& out) override;
 
-    Addr getBank(Addr addr);
+    Addr getBank(Addr addr) override;
 
     /* LoadLink wakeup event - not serializable since it only goes over a self link */
     class LoadLinkWakeup : public SST::Event {
@@ -435,17 +435,17 @@ private:
     void handleLoadLinkExpiration(SST::Event* ev);
 
     /** Event send */
-    uint64_t sendResponseUp(MemEvent * event, vector<uint8_t>* data, bool inMSHR, uint64_t time, bool success = true);
+    uint64_t sendResponseUp(MemEvent * event, vector<uint8_t>* data, bool inMSHR, uint64_t time, bool success = true) override;
     void sendResponseDown(MemEvent * event, L1CacheLine * line, bool data);
     void forwardFlush(MemEvent * event, L1CacheLine * line, bool evict);
     void sendWriteback(Command cmd, L1CacheLine * line, bool dirty, bool flush);
     void snoopInvalidation(MemEvent * event, L1CacheLine * line);
-    void forwardByAddress(MemEventBase* ev, Cycle_t timestamp);
-    void forwardByDestination(MemEventBase* ev, Cycle_t timestamp);
+    void forwardByAddress(MemEventBase* ev, Cycle_t timestamp) override;
+    void forwardByDestination(MemEventBase* ev, Cycle_t timestamp) override;
 
     /** Statistics/Listeners */
     inline void recordPrefetchResult(L1CacheLine * line, Statistic<uint64_t>* stat);
-    void recordLatency(Command cmd, int type, uint64_t latency);
+    void recordLatency(Command cmd, int type, uint64_t latency) override;
     void eventProfileAndNotify(MemEvent * event, State state, NotifyAccessType type, NotifyResultType result, bool inMSHR);
 
     /** Miscellaneous */

--- a/src/sst/elements/memHierarchy/memLink.h
+++ b/src/sst/elements/memHierarchy/memLink.h
@@ -100,27 +100,27 @@ public:
     virtual void complete(unsigned int phase) override;
 
     /* Remote endpoint info management */
-    virtual std::set<EndpointInfo>* getSources();
-    virtual std::set<EndpointInfo>* getDests();
-    virtual std::set<EndpointInfo>* getPeers();
-    virtual bool isDest(std::string str);
-    virtual bool isSource(std::string str);
-    virtual bool isPeer(std::string str);
-    virtual std::string findTargetDestination(Addr addr);
-    virtual std::string getTargetDestination(Addr addr);
-    virtual bool isReachable(std::string dst);
+    virtual std::set<EndpointInfo>* getSources() override;
+    virtual std::set<EndpointInfo>* getDests() override;
+    virtual std::set<EndpointInfo>* getPeers() override;
+    virtual bool isDest(std::string str) override;
+    virtual bool isSource(std::string str) override;
+    virtual bool isPeer(std::string str) override;
+    virtual std::string findTargetDestination(Addr addr) override;
+    virtual std::string getTargetDestination(Addr addr) override;
+    virtual bool isReachable(std::string dst) override;
 
     /* Send and receive functions for MemLink */
-    virtual void sendUntimedData(MemEventInit * ev, bool broadcast, bool lookup_dst);
-    virtual MemEventInit* recvUntimedData();
-    virtual void send(MemEventBase * ev);
+    virtual void sendUntimedData(MemEventInit * ev, bool broadcast, bool lookup_dst) override;
+    virtual MemEventInit* recvUntimedData() override;
+    virtual void send(MemEventBase * ev) override;
     virtual MemEventBase * recv();
 
     /* Debug */
-    virtual void printStatus(Output &out) {
+    virtual void printStatus(Output &out) override {
         out.output("  MemHierarchy::MemLink: No status given\n");
     }
-    virtual std::string getAvailableDestinationsAsString();
+    virtual std::string getAvailableDestinationsAsString() override;
 
 protected:
     void addRemote(EndpointInfo info);

--- a/src/sst/elements/memHierarchy/memNICFour.h
+++ b/src/sst/elements/memHierarchy/memNICFour.h
@@ -94,8 +94,8 @@ public:
     ~MemNICFour() { }
 
     /* Functions called by parent for handling events */
-    bool isClocked() { return false; }
-    void send(MemEventBase * ev);
+    bool isClocked() override { return false; }
+    void send(MemEventBase * ev) override;
     bool recvNotifyReq(int);
     bool recvNotifyAck(int);
     bool recvNotifyFwd(int);
@@ -146,7 +146,7 @@ public:
     };
 
     /* Debug support */
-    void printStatus(Output& out);
+    void printStatus(Output& out) override;
 
 private:
 

--- a/src/sst/elements/memHierarchy/memoryController.h
+++ b/src/sst/elements/memHierarchy/memoryController.h
@@ -166,9 +166,9 @@ protected:
     CustomCmdMemHandler * customCommandHandler_;
 
     /* Debug -triggered by output.fatal() and/or SIGUSR2 */
-    virtual void printStatus(Output &out);
-    virtual void emergencyShutdown();
-    
+    virtual void printStatus(Output &out) override;
+    virtual void emergencyShutdown() override;
+
     void printDataValue(Addr addr, std::vector<uint8_t>* data, bool set);
 
 private:

--- a/src/sst/elements/vanadis/inst/vadd.h
+++ b/src/sst/elements/vanadis/inst/vadd.h
@@ -60,9 +60,10 @@ class VanadisAddInstruction : public virtual VanadisInstruction
 
         
 
-        void instOp(VanadisRegisterFile* regFile, 
-        uint16_t phys_int_regs_out_0, uint16_t phys_int_regs_in_0, 
-        uint16_t phys_int_regs_in_1)
+
+        void instOp(VanadisRegisterFile* regFile,
+        uint16_t phys_int_regs_out_0, uint16_t phys_int_regs_in_0,
+        uint16_t phys_int_regs_in_1) override
         {
             const gpr_format src_1 = regFile->getIntReg<gpr_format>(phys_int_regs_in_0);
             const gpr_format src_2 = regFile->getIntReg<gpr_format>(phys_int_regs_in_1);

--- a/src/sst/elements/vanadis/inst/vdiv.h
+++ b/src/sst/elements/vanadis/inst/vdiv.h
@@ -66,7 +66,7 @@ public:
     }
 
     void instOp(VanadisRegisterFile* regFile, uint16_t phys_int_regs_out_0,uint16_t phys_int_regs_in_0,
-                uint16_t phys_int_regs_in_1)
+                uint16_t phys_int_regs_in_1) override
     {
         const gpr_format src_1 = regFile->getIntReg<gpr_format>(phys_int_regs_in_0);
         const gpr_format src_2 = regFile->getIntReg<gpr_format>(phys_int_regs_in_1);

--- a/src/sst/elements/vanadis/inst/vfence.h
+++ b/src/sst/elements/vanadis/inst/vfence.h
@@ -34,24 +34,24 @@ public:
         fence = fenceT;
     }
 
-    VanadisFenceInstruction* clone() { return new VanadisFenceInstruction(*this); }
+    VanadisFenceInstruction* clone() override { return new VanadisFenceInstruction(*this); }
 
     bool createsLoadFence() const { return (fence == VANADIS_LOAD_FENCE) || (fence == VANADIS_LOAD_STORE_FENCE); }
 
     bool createsStoreFence() const { return (fence == VANADIS_STORE_FENCE) || (fence == VANADIS_LOAD_STORE_FENCE); }
 
-    virtual const char* getInstCode() const
+    virtual const char* getInstCode() const override
     {
         return (fence == VANADIS_LOAD_STORE_FENCE) ? "SYNC" : (fence == VANADIS_LOAD_FENCE) ? "LFENCE" : "SFENCE";
     }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) { snprintf(buffer, buffer_size, "%s", getInstCode()); }
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override { snprintf(buffer, buffer_size, "%s", getInstCode()); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_FENCE; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_FENCE; }
 
     virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override {}
 
-    virtual void print(SST::Output* output) { output->verbose(CALL_INFO, 8, 0, "%s", getInstCode()); }
+    virtual void print(SST::Output* output) override { output->verbose(CALL_INFO, 8, 0, "%s", getInstCode()); }
 
 protected:
     VanadisFenceType fence;

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -76,8 +76,8 @@ public:
             getInstCode(), isa_int_regs_out[0], phys_int_regs_out[0], isa_fp_regs_in[0], phys_fp_regs_in[0]);
     }
 
-    void log(SST::Output* output, int verboselevel, uint16_t sw_thr, 
-                            uint16_t phys_int_regs_out_0,uint16_t phys_fp_regs_in_0)
+    void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
+                            uint16_t phys_int_regs_out_0,uint16_t phys_fp_regs_in_0) override
                             {
         #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= verboselevel) {

--- a/src/sst/elements/vanadis/inst/vfpclass.h
+++ b/src/sst/elements/vanadis/inst/vfpclass.h
@@ -72,7 +72,7 @@ public:
     }
 
     void instOp(VanadisRegisterFile* regFile, uint16_t phys_fp_regs_in_0, uint16_t phys_fp_regs_in_1,
-                        uint16_t phys_int_regs_out_0)
+                        uint16_t phys_int_regs_out_0) override
     {
         uint64_t src;
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) ) {

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -132,8 +132,8 @@ public:
             getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_fp_regs_in[0], phys_fp_regs_in[0]);
     }
 
-    void log(SST::Output* output, int verboselevel, uint16_t sw_thr, 
-                            uint16_t phys_fp_regs_out_0,uint16_t phys_fp_regs_in_0)
+    void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
+                            uint16_t phys_fp_regs_out_0,uint16_t phys_fp_regs_in_0) override
     {
         #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= verboselevel) {

--- a/src/sst/elements/vanadis/inst/vfpsqrt.h
+++ b/src/sst/elements/vanadis/inst/vfpsqrt.h
@@ -121,8 +121,8 @@ public:
         check_IEEE754_except();
     }
 
-    void log(SST::Output* output, int verboselevel, uint16_t sw_thr, 
-                uint16_t phys_fp_regs_in_0,uint16_t phys_fp_regs_out_0)
+    void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
+                uint16_t phys_fp_regs_in_0,uint16_t phys_fp_regs_out_0) override
     {
          #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= verboselevel ) {

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -73,8 +73,8 @@ public:
             getInstCode(), isa_fp_regs_out[0], phys_fp_regs_out[0], isa_int_regs_in[0], phys_int_regs_in[0]);
     }
 
-    void log(SST::Output* output, int verboselevel, uint16_t sw_thr, 
-                            uint16_t phys_int_regs_out_0,uint16_t phys_int_regs_in_0)
+    void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
+                            uint16_t phys_int_regs_out_0,uint16_t phys_int_regs_in_0) override
         {
             
             if(output->getVerboseLevel() >= verboselevel) {

--- a/src/sst/elements/vanadis/inst/vmin.h
+++ b/src/sst/elements/vanadis/inst/vmin.h
@@ -57,9 +57,9 @@ public:
             phys_int_regs_in[0], phys_int_regs_in[1]);
     }
 
-    void instOp(VanadisRegisterFile* regFile, 
-        uint16_t phys_int_regs_out_0, uint16_t phys_int_regs_in_0, 
-        uint16_t phys_int_regs_in_1)
+    void instOp(VanadisRegisterFile* regFile,
+        uint16_t phys_int_regs_out_0, uint16_t phys_int_regs_in_0,
+        uint16_t phys_int_regs_in_1) override
     {
         const gpr_format src_1 = regFile->getIntReg<gpr_format>(phys_int_regs_in_0);
 	    const gpr_format src_2 = regFile->getIntReg<gpr_format>(phys_int_regs_in_1);

--- a/src/sst/elements/vanadis/inst/vnop.h
+++ b/src/sst/elements/vanadis/inst/vnop.h
@@ -28,13 +28,13 @@ public:
         VanadisInstruction(addr, hw_thr, isa_opts, 0, 0, 0, 0, 0, 0, 0, 0)
     {}
 
-    VanadisNoOpInstruction* clone() { return new VanadisNoOpInstruction(*this); }
+    VanadisNoOpInstruction* clone() override { return new VanadisNoOpInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_NOOP; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_NOOP; }
 
-    virtual const char* getInstCode() const { return "NOP"; }
+    virtual const char* getInstCode() const override { return "NOP"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size) { snprintf(buffer, buffer_size, "NOP"); }
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override { snprintf(buffer, buffer_size, "NOP"); }
 
     virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override { markExecuted(); }
 };

--- a/src/sst/elements/vanadis/inst/vnor.h
+++ b/src/sst/elements/vanadis/inst/vnor.h
@@ -35,13 +35,13 @@ public:
         isa_int_regs_out[0] = dest;
     }
 
-    virtual VanadisNorInstruction* clone() { return new VanadisNorInstruction(*this); }
+    virtual VanadisNorInstruction* clone() override { return new VanadisNorInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual const char* getInstCode() const { return "NOR"; }
+    virtual const char* getInstCode() const override { return "NOR"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,

--- a/src/sst/elements/vanadis/inst/vor.h
+++ b/src/sst/elements/vanadis/inst/vor.h
@@ -35,13 +35,13 @@ public:
         isa_int_regs_out[0] = dest;
     }
 
-    virtual VanadisOrInstruction* clone() { return new VanadisOrInstruction(*this); }
+    virtual VanadisOrInstruction* clone() override { return new VanadisOrInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual const char* getInstCode() const { return "OR"; }
+    virtual const char* getInstCode() const override { return "OR"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,

--- a/src/sst/elements/vanadis/inst/vori.h
+++ b/src/sst/elements/vanadis/inst/vori.h
@@ -36,13 +36,13 @@ public:
         imm_value = immediate;
     }
 
-    VanadisOrImmInstruction* clone() { return new VanadisOrImmInstruction(*this); }
+    VanadisOrImmInstruction* clone() override { return new VanadisOrImmInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual const char* getInstCode() const { return "ORI"; }
+    virtual const char* getInstCode() const override { return "ORI"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,

--- a/src/sst/elements/vanadis/inst/vpartialload.h
+++ b/src/sst/elements/vanadis/inst/vpartialload.h
@@ -60,19 +60,19 @@ public:
         register_offset = 0;
     }
 
-    VanadisPartialLoadInstruction* clone() { return new VanadisPartialLoadInstruction(*this); }
+    VanadisPartialLoadInstruction* clone() override { return new VanadisPartialLoadInstruction(*this); }
 
-    bool isPartialLoad() const { return true; }
+    bool isPartialLoad() const override { return true; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_LOAD; }
-    virtual const char*               getInstCode() const { return "PARTLOAD"; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_LOAD; }
+    virtual const char*               getInstCode() const override { return "PARTLOAD"; }
 
     uint16_t getMemoryAddressRegister() const { return phys_int_regs_in[0]; }
     uint16_t getTargetRegister() const { return phys_int_regs_in[1]; }
 
     virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override { markExecuted(); }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,
@@ -82,7 +82,7 @@ public:
             load_width);
     }
 
-    void computeLoadAddress(SST::Output* output, VanadisRegisterFile* regFile, uint64_t* out_addr, uint16_t* width)
+    void computeLoadAddress(SST::Output* output, VanadisRegisterFile* regFile, uint64_t* out_addr, uint16_t* width) override
     {
         const uint64_t mem_addr_reg_val = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
         #ifdef VANADIS_BUILD_DEBUG
@@ -113,14 +113,14 @@ public:
         #endif
     }
 
-    uint16_t getLoadWidth() const { return load_width; }
+    uint16_t getLoadWidth() const override { return load_width; }
 
     VanadisLoadRegisterType getValueRegisterType() const { return LOAD_INT_REGISTER; }
 
-    uint16_t getRegisterOffset() const { return register_offset; }
+    uint16_t getRegisterOffset() const override { return register_offset; }
 
 protected:
-    void computeLoadAddress(VanadisRegisterFile* reg, uint64_t* out_addr, uint16_t* width)
+    void computeLoadAddress(VanadisRegisterFile* reg, uint64_t* out_addr, uint16_t* width) override
     {
         const uint64_t width_64 = (uint64_t)load_width;
 

--- a/src/sst/elements/vanadis/inst/vpartialstore.h
+++ b/src/sst/elements/vanadis/inst/vpartialstore.h
@@ -42,15 +42,15 @@ public:
         register_offset = 0;
     }
 
-    virtual bool isPartialStore() { return true; }
+    virtual bool isPartialStore() override { return true; }
 
-    VanadisPartialStoreInstruction* clone() { return new VanadisPartialStoreInstruction(*this); }
+    VanadisPartialStoreInstruction* clone() override { return new VanadisPartialStoreInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_STORE; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_STORE; }
 
-    virtual const char* getInstCode() const { return "PARTSTORE"; }
+    virtual const char* getInstCode() const override { return "PARTSTORE"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,
@@ -62,7 +62,7 @@ public:
     virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override { markExecuted(); }
 
     virtual void
-    computeStoreAddress(SST::Output* output, VanadisRegisterFile* reg, uint64_t* store_addr, uint16_t* op_width)
+    computeStoreAddress(SST::Output* output, VanadisRegisterFile* reg, uint64_t* store_addr, uint16_t* op_width) override
     {
         #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= 16) {
@@ -118,7 +118,7 @@ public:
 
     uint16_t getStoreWidth() const { return store_width; }
 
-    virtual uint16_t getRegisterOffset() const { return register_offset; }
+    virtual uint16_t getRegisterOffset() const override { return register_offset; }
 
     uint16_t                 getMemoryAddressRegister() const { return phys_int_regs_in[0]; }
     uint16_t                 getValueRegister() const { return phys_int_regs_in[1]; }

--- a/src/sst/elements/vanadis/inst/vscmp.h
+++ b/src/sst/elements/vanadis/inst/vscmp.h
@@ -75,7 +75,7 @@ public:
         regFile->setIntReg<uint64_t>(phys_int_regs_out_0, compare_result ? 1 : 0);
     }
 
-    virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile)
+    virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
         
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);

--- a/src/sst/elements/vanadis/inst/vslli.h
+++ b/src/sst/elements/vanadis/inst/vslli.h
@@ -96,7 +96,7 @@ public:
         regFile->setIntReg<register_format>(phys_int_regs_out_0, src_1 << imm_value);
     }
 
-    virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile)
+    virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);

--- a/src/sst/elements/vanadis/inst/vstore.h
+++ b/src/sst/elements/vanadis/inst/vstore.h
@@ -67,16 +67,16 @@ public:
             if ( MEM_TRANSACTION_LLSC_STORE == accessT ) { isa_fp_regs_out[0] = valueReg; }
         } break;
         }
-        
+
     }
 
-    VanadisStoreInstruction* clone() { return new VanadisStoreInstruction(*this); }
+    VanadisStoreInstruction* clone() override { return new VanadisStoreInstruction(*this); }
 
     virtual bool isPartialStore() { return false; }
 
     VanadisMemoryTransaction getTransactionType() const  { return memAccessType; }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_STORE; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_STORE; }
 
     virtual const char* getInstCode() const override
     {
@@ -180,8 +180,8 @@ public:
         assert(0); // stop compiler "warning: control reaches end of non-void function [-Wreturn-type]"
     }
 
-    virtual void markExecuted() 
-    { 
+    virtual void markExecuted() override
+    {
         hasExecuted = true;
     }
 

--- a/src/sst/elements/vanadis/inst/vsyscall.h
+++ b/src/sst/elements/vanadis/inst/vsyscall.h
@@ -42,13 +42,13 @@ public:
         }
     }
 
-    VanadisSysCallInstruction* clone() { return new VanadisSysCallInstruction(*this); }
+    VanadisSysCallInstruction* clone() override { return new VanadisSysCallInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_SYSCALL; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_SYSCALL; }
 
-    virtual const char* getInstCode() const { return "SYSCALL"; }
+    virtual const char* getInstCode() const override { return "SYSCALL"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size, "SYSCALL (syscall-code-isa: %" PRIu16 ", phys: %" PRIu16 ")\n",
@@ -66,8 +66,8 @@ public:
         markExecuted();
     }
 
-    virtual bool performIntRegisterRecovery() const { return false; }
-    virtual bool performFPRegisterRecovery() const { return false; }
+    virtual bool performIntRegisterRecovery() const override { return false; }
+    virtual bool performFPRegisterRecovery() const override { return false; }
 };
 
 } // namespace Vanadis

--- a/src/sst/elements/vanadis/inst/vxor.h
+++ b/src/sst/elements/vanadis/inst/vxor.h
@@ -35,13 +35,13 @@ public:
         isa_int_regs_out[0] = dest;
     }
 
-    virtual VanadisXorInstruction* clone() { return new VanadisXorInstruction(*this); }
+    virtual VanadisXorInstruction* clone() override { return new VanadisXorInstruction(*this); }
 
-    virtual VanadisFunctionalUnitType getInstFuncType() const { return INST_INT_ARITH; }
+    virtual VanadisFunctionalUnitType getInstFuncType() const override { return INST_INT_ARITH; }
 
-    virtual const char* getInstCode() const { return "XOR"; }
+    virtual const char* getInstCode() const override { return "XOR"; }
 
-    virtual void printToBuffer(char* buffer, size_t buffer_size)
+    virtual void printToBuffer(char* buffer, size_t buffer_size) override
     {
         snprintf(
             buffer, buffer_size,


### PR DESCRIPTION
By the default build flags, Clang/LLVM prints warnings for overriden functions not marked `override`.

Remove trailing whitespace from `memHierarchy` `Makefile.am`.