### PR TITLE
fix misc warnings

### DIFF
--- a/src/sst/elements/mask-mpi/mpi_comm/mpi_comm_cart.h
+++ b/src/sst/elements/mask-mpi/mpi_comm/mpi_comm_cart.h
@@ -64,7 +64,7 @@ class MpiCommCart : public MpiComm
   virtual ~MpiCommCart() {}
 
   int dim(int i) const {
-    if (i > dims_.size()) {
+    if (i < 0 || i >= dims_.size()) {
       return -1;
     }
     return dims_[i];
@@ -73,7 +73,7 @@ class MpiCommCart : public MpiComm
   void set_coords(int rank, int* coords);
 
   int period(int i) const {
-    if (i > periods_.size()) {
+    if (i < 0 || i >= periods_.size()) {
       return -1;
     }
     return periods_[i];

--- a/src/sst/elements/mask-mpi/tests/sendrecv.cc
+++ b/src/sst/elements/mask-mpi/tests/sendrecv.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-  int nelems = 8;
+  const int nelems = 8;
 #define VALIDATE_BUFFERS
 #ifdef VALIDATE_BUFFERS
   int buf[nelems];

--- a/src/sst/elements/memHierarchy/cacheFactory.cc
+++ b/src/sst/elements/memHierarchy/cacheFactory.cc
@@ -708,7 +708,7 @@ uint64_t Cache::createMSHR(Params &params, uint64_t accessLatency, bool L1) {
         mshrLatency = 1;
     } else {
         // Otherwise if mshrLatency isn't set or is 0, intrapolate from cache latency
-        uint64_t N = 200; // max cache latency supported by the intrapolation method
+        const uint64_t N = 200; // max cache latency supported by the intrapolation method
         int y[N];
 
         /* L2 */

--- a/src/sst/elements/memHierarchy/directoryController.cc
+++ b/src/sst/elements/memHierarchy/directoryController.cc
@@ -813,7 +813,7 @@ void DirectoryController::processCompleteEvent(MemEventInit* event) {
         MemEventUntimedFlush* flush = static_cast<MemEventUntimedFlush*>(event);
 
         if ( flush->request() && flush_state_ == FlushState::Ready ) {
-            flush_state_ == FlushState::Invalidate;
+            flush_state_ = FlushState::Invalidate;
             std::set<MemLinkBase::EndpointInfo>* src = linkUp_->getSources();
             for (auto it = src->begin(); it != src->end(); it++) {
                 MemEventUntimedFlush* forward = new MemEventUntimedFlush(getName());

--- a/src/sst/elements/vanadis/lsq/vbasiclsq.h
+++ b/src/sst/elements/vanadis/lsq/vbasiclsq.h
@@ -1000,7 +1000,7 @@ class VanadisBasicLoadStoreQueue : public SST::Vanadis::VanadisLoadStoreQueue
             }
             else
             {
-                if((new_pending_store==nullptr))
+                if(new_pending_store==nullptr)
                 {
                     output->fatal(CALL_INFO, -1, "Error: store process failed (ins: 0x%" PRI_ADDR ", thr: %" PRIu32 ")\n",
                         store_ins->getInstructionAddress(), store_ins->getHWThread());


### PR DESCRIPTION
This fixes miscellaneous warnings found by Clang/LLVM using the default build's compiler flags.

@gvoskuilen In `memHierarchy/directoryController.cc`, a useless comparison looks like it should have been an assignment.

@jpkenny In `mask-mpi/mpi_comm/mpi_comm_cart.h`, there was an off-by-1 comparison of an array index. I fixed it and also flagged negative indices.

In `mask-mpi/tests/sendrecv.cc` and `memHierarchy/cacheFactory.cc`, variable-length array warnings were removed by making their dimension variables `const`.  (There are still other cases of VLAs in Elements which are non-`const` in size.)

In `vanadis/lsq/vbasiclsq.h`, redundant parentheses around a comparison were removed.
