### PR TITLE
Disable long running tests for non-Nightly tests

### DIFF
--- a/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_sweep.py
@@ -152,6 +152,9 @@ class testcase_EmberSweep(SSTTestCase):
     def test_EmberSweep(self, index, hex_dig, topo, net_args, test, test_args):
         self._checkSkipConditions(index)
 
+        # Skip the first 100 tests if we are not in a Nightly test
+        if not testing_check_is_nightly() and index <= 100:
+            self.skipTest("Complete EmberSweep only runs on Nightly builds.")
         log_debug("Running Ember Sweep #{0} ({1}): {2}; Net arg = {3}; Test = {4}; Test Arg = {5}".format(index, hex_dig, topo, net_args, test, test_args))
         self.EmberSweep_test_template(index, hex_dig, topo, net_args, test, test_args)
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
@@ -77,10 +77,12 @@ class testcase_memHierarchy_memHA(SSTTestCase):
         self.memHA_Template("CoherenceDomains")
 
     @skip_on_sstsimulator_conf_empty_str("GOBLIN_HMCSIM", "LIBDIR", "GOBLIN_HMCSIM is not included as part of this build")
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendGoblinHMC only runs on Nightly builds.")
     def test_memHA_BackendGoblinHMC(self):
         self.memHA_Template("BackendGoblinHMC", testtimeout=400)
 
     @skip_on_sstsimulator_conf_empty_str("DRAMSIM3", "LIBDIR", "DRAMSIM3 is not included as part of this build")
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendDramsim3 only runs on Nightly builds.")
     def test_memHA_BackendDramsim3(self):
         self.memHA_Template("BackendDramsim3")
 
@@ -108,15 +110,19 @@ class testcase_memHierarchy_memHA(SSTTestCase):
     def test_memHierarchy_BackendRamulator2(self):
         self.memHA_Template("BackendRamulator2")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
     def test_memHA_BackendTimingDRAM_1(self):
         self.memHA_Template("BackendTimingDRAM_1")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
     def test_memHA_BackendTimingDRAM_2(self):
         self.memHA_Template("BackendTimingDRAM_2")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
     def test_memHA_BackendTimingDRAM_3(self):
         self.memHA_Template("BackendTimingDRAM_3")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
     def test_memHA_BackendTimingDRAM_4(self):
         self.memHA_Template("BackendTimingDRAM_4")
 

--- a/src/sst/elements/messier/tests/testsuite_default_Messier.py
+++ b/src/sst/elements/messier/tests/testsuite_default_Messier.py
@@ -16,15 +16,18 @@ class testcase_Messier_Component(SSTTestCase):
 
 #####
 
+    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
     def test_Messier_gupsgen(self):
         self.Messier_test_template("gupsgen")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
     def test_Messier_gupsgen_2RANKS(self):
         self.Messier_test_template("gupsgen_2RANKS")
 
     def test_Messier_gupsgen_fastNVM(self):
         self.Messier_test_template("gupsgen_fastNVM")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
     def test_Messier_stencil3dbench_messier(self):
         self.Messier_test_template("stencil3dbench_messier")
 

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -26,6 +26,7 @@ class testcase_miranda_Component(SSTTestCase):
 
     @unittest.skipIf(testing_check_get_num_ranks() > 1, "miranda: test_miranda_randomgen skipped if ranks > 1")
     @unittest.skipIf(testing_check_get_num_threads() > 1, "miranda: test_miranda_randomgen skipped if threads > 1")
+    @unittest.skipIf(not testing_check_is_nightly(), "miranda_randomgen only runs on Nightly builds.")
     def test_miranda_randomgen(self):
         self.miranda_test_template("randomgen", testtimeout=360)
 

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -30,6 +30,7 @@ class testcase_miranda_Component(SSTTestCase):
     def test_miranda_randomgen(self):
         self.miranda_test_template("randomgen", testtimeout=360)
 
+    @unittest.skipIf(not testing_check_is_nightly(), "miranda_stencil3dbench only runs on Nightly builds.")
     def test_miranda_stencil3dbench(self):
         self.miranda_test_template("stencil3dbench")
 

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -30,6 +30,7 @@ class testcase_prospero(SSTTestCase):
     libz_missing = not sst_elements_config_include_file_get_value("HAVE_LIBZ", type=int, default=0, disable_warning=True)
 
     @unittest.skipIf(libz_missing, "test_prospero_compressed_using_TAR_traces test: Requires LIBZ, but LIBZ is not found in build configuration.")
+    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_compressed_using_TAR_traces only runs on Nightly builds.")
     def test_prospero_compressed_using_TAR_traces(self):
         self.prospero_test_template("compressed", NO_TIMINGDRAM, USE_TAR_TRACES)
 
@@ -37,9 +38,11 @@ class testcase_prospero(SSTTestCase):
     def test_prospero_compressed_withtimingdram_using_TAR_traces(self):
         self.prospero_test_template("compressed", WITH_TIMINGDRAM, USE_TAR_TRACES)
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_text_using_TAR_traces only runs on Nightly builds.")
     def test_prospero_text_using_TAR_traces(self):
         self.prospero_test_template("text", NO_TIMINGDRAM, USE_TAR_TRACES)
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_binary_using_TAR_traces only runs on Nightly builds.")
     def test_prospero_binary_using_TAR_traces(self):
         self.prospero_test_template("binary", NO_TIMINGDRAM, USE_TAR_TRACES)
 
@@ -50,10 +53,12 @@ class testcase_prospero(SSTTestCase):
         self.prospero_test_template("binary", WITH_TIMINGDRAM, USE_TAR_TRACES)
 
     @unittest.skipIf(not pin_loaded, "test_prospero_text_using_PIN_traces: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
+    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_text_using_PIN_traces only runs on Nightly builds.")
     def test_prospero_text_using_PIN_traces(self):
         self.prospero_test_template("text", NO_TIMINGDRAM, USE_PIN_TRACES)
 
     @unittest.skipIf(not pin_loaded, "test_prospero_binary_using_PIN_traces: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
+    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_binary_using_PIN_traces only runs on Nightly builds.")
     def test_prospero_binary_using_PIN_traces(self):
         self.prospero_test_template("binary", NO_TIMINGDRAM, USE_PIN_TRACES)
 

--- a/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
+++ b/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
@@ -81,6 +81,8 @@ class testcase_rdmaNic(SSTTestCase):
     def test_rdmaNic_short_tests(self, testnum, testname, sdlfile, elftestdir, elffile, arch, env, timeout_sec):
         self._checkSkipConditions()
 
+        if not testing_check_is_nightly() and testnum == 2:
+            self.skipTest("Complete rdmaNic only runs on Nightly builds.")
         log_debug("Running RdmaNic test #{0} ({1}): elffile={4} in dir {3}; using sdl={2}".format(testnum, testname, sdlfile, elftestdir, elffile, env, timeout_sec))
         self.rdmaNic_test_template(testnum, testname, sdlfile, elftestdir, elffile, arch, env, timeout_sec)
 

--- a/src/sst/elements/samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/samba/tests/testsuite_default_Samba.py
@@ -25,6 +25,7 @@ class testcase_Samba_Component(SSTTestCase):
     def test_Samba_gupsgen_mmu_three_levels(self):
         self.Samba_test_template("gupsgen_mmu_three_levels")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "test_Samba_stencil3dbench_mmu only runs on Nightly builds.")
     def test_Samba_stencil3dbench_mmu(self):
         self.Samba_test_template("stencil3dbench_mmu", testtimeout=240)
 

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -159,6 +159,9 @@ class testcase_vanadis(SSTTestCase):
 
         if MakeTests:
             self.makeTest( testname, isa, elftestdir, elffile )
+        # Only run the first 15 tests if we are not in a Nightly test
+        if not testing_check_is_nightly() and testnum > 15:
+            self.skipTest("Complete vanadis_short_tests only runs on Nightly builds.")
         log_debug("Running Vanadis test #{0} ({1}): elffile={4} in dir {3}, isa {5}; using sdl={2}".format(testnum, testname, sdlfile, elftestdir, elffile, isa, timeout_sec))
         self.vanadis_test_template(testnum, testname, sdlfile, elftestdir, elffile, isa, numCores, numHwThreads, goldfiledir, timeout_sec )
 

--- a/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
+++ b/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
@@ -29,6 +29,7 @@ class testcase_SiriusZodiacTrace(SSTTestCase):
     def test_Sirius_Zodiac_16(self):
         self.SiriusZodiacTrace_test_template("4x4")
 
+    @unittest.skipIf(not testing_check_is_nightly(), "Sirius_Zodiac_128 only runs on Nightly builds.")
     def test_Sirius_Zodiac_128(self):
         self.SiriusZodiacTrace_test_template("8x8x2")
 


### PR DESCRIPTION
Including:
* EmberSweep
* miranda_randomgen
* vanadis_short_tests

This cuts the running time of `sst-test-elements` by ~20 minutes.

The tests are still there and will run during Nightly testing.

Depends on https://github.com/sstsimulator/sst-core/pull/1290
