### PR TITLE
Mercury: skip the test_testme() method

### DIFF
--- a/src/sst/elements/mercury/tests/testsuite_default_hg.py
+++ b/src/sst/elements/mercury/tests/testsuite_default_hg.py
@@ -19,6 +19,7 @@ class testcase_hg(SSTTestCase):
 
 #####
 
+    @unittest.skipIf(testing_check_get_num_threads() > 1, "MT Mercury tests are currently non-deterministic")
     def test_testme(self):
         testdir = self.get_testsuite_dir()
         libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR", str)


### PR DESCRIPTION
The Mercury test is currently non-deterministic and will sometimes fail on MT-2 / MT-4 platforms.  Disable them for now.
