### PR TITLE
Mercury: fix race condition

### DIFF
--- a/src/sst/elements/mercury/common/thread_safe_int.h
+++ b/src/sst/elements/mercury/common/thread_safe_int.h
@@ -55,8 +55,8 @@ class thread_safe_int_t :
   }
 
   Integer operator++(int  /*i*/){
-    Integer tmp(value_);
     lock();
+    Integer tmp(value_);
     value_++;
     unlock();
     return tmp;

--- a/src/sst/elements/mercury/operating_system/process/app.cc
+++ b/src/sst/elements/mercury/operating_system/process/app.cc
@@ -100,8 +100,10 @@ static thread_lock dlopen_lock;
 void
 App::lockDlopen(int aid)
 {
+  dlopen_lock.lock();
   dlopen_entry& entry = exe_dlopens_[aid];
   entry.refcount++;
+  dlopen_lock.unlock();
 }
 
 void

--- a/src/sst/elements/mercury/operating_system/process/app.cc
+++ b/src/sst/elements/mercury/operating_system/process/app.cc
@@ -503,7 +503,9 @@ App::run()
 
   dlcloseCheck();
 
+  dlopen_lock.lock();
   app_rc_ = rc_;
+  dlopen_lock.unlock();
 }
 
 void


### PR DESCRIPTION
Lock `App::lockDlopen()` and raise the lock in `operator++()`.

This is possibly an incomplete list.  YMMV.
