### PR TITLE
Don't skip test_testme() if threads > 1

### DIFF
--- a/src/sst/elements/mercury/tests/testsuite_default_hg.py
+++ b/src/sst/elements/mercury/tests/testsuite_default_hg.py
@@ -19,7 +19,6 @@ class testcase_hg(SSTTestCase):
 
 #####
 
-    @unittest.skipIf(testing_check_get_num_threads() > 1, "MT Mercury tests are currently non-deterministic")
     def test_testme(self):
         testdir = self.get_testsuite_dir()
         libdir = sstsimulator_conf_get_value("SST_ELEMENT_LIBRARY","SST_ELEMENT_LIBRARY_LIBDIR", str)


### PR DESCRIPTION
Mercury threading bugs were squashed in https://github.com/sstsimulator/sst-elements/pull/2519. Restore the multithread tests that were removed in https://github.com/sstsimulator/sst-elements/pull/2514.

Closes #2527.
