### PR TITLE
mercury: add "argv" to pymercury params

### DIFF
--- a/src/sst/elements/mercury/pymercury.py
+++ b/src/sst/elements/mercury/pymercury.py
@@ -97,6 +97,7 @@ class HgOS(TemplateBase):
                                      ])
         self._declareParamsWithUserPrefix("params","app1",
                                           ["name",
+                                           "argv",
                                            "exe_library_name",
                                            "libraries",
                                            "dependencies",


### PR DESCRIPTION
Add `argv` to pymercury params list.
