### PR TITLE
small logic fix found during mi300 debugging

### DIFF
--- a/src/sst/elements/vanadis/os/vnodeos.cc
+++ b/src/sst/elements/vanadis/os/vnodeos.cc
@@ -170,6 +170,11 @@ if ( CHECKPOINT_LOAD != m_checkpoint ) {
         "mem_interface", ComponentInfo::SHARE_NONE,
         getTimeConverter("1ps"),
         new StandardMem::Handler2<SST::Vanadis::VanadisNodeOSComponent,&VanadisNodeOSComponent::handleIncomingMemoryCallback>(this));
+
+    if (mem_if == nullptr) {
+        output->fatal(CALL_INFO, -1, "Error: failed to load mem interface subcomponent!\n");
+    }
+
     output->verbose(CALL_INFO, 1, VANADIS_OS_DBG_INIT, "Configuring for %" PRIu32 " core links...\n", m_coreCount);
     core_links.reserve(m_coreCount);
 

--- a/src/sst/elements/vanadis/vanadis.cc
+++ b/src/sst/elements/vanadis/vanadis.cc
@@ -130,18 +130,18 @@ VANADIS_COMPONENT::VANADIS_COMPONENT(SST::ComponentId_t id, SST::Params& params)
         snprintf(decoder_name, 64, "decoder%" PRIu32 "", i);
         VanadisDecoder* thr_decoder = loadUserSubComponent<SST::Vanadis::VanadisDecoder>(decoder_name);
 
-        fp_flags.push_back(new VanadisFloatingPointFlags());
-        thr_decoder->setFPFlags(fp_flags[i]);
-        output->verbose(
-            CALL_INFO, 8, 0, "Loading decoder%" PRIu32 ": %s.\n", i,
-            (nullptr == thr_decoder) ? "failed" : "successful");
-
         if ( nullptr == thr_decoder ) {
             output->fatal(CALL_INFO, -1, "Error: was unable to load %s on thread %" PRIu32 "\n", decoder_name, i);
         }
         else {
             output->verbose(CALL_INFO, 8, 0, "-> Decoder configured for %s\n", thr_decoder->getISAName());
         }
+
+        fp_flags.push_back(new VanadisFloatingPointFlags());
+        thr_decoder->setFPFlags(fp_flags[i]);
+        output->verbose(
+            CALL_INFO, 8, 0, "Loading decoder%" PRIu32 ": %s.\n", i,
+            (nullptr == thr_decoder) ? "failed" : "successful");
 
         thr_decoder->setHardwareThread(i);
         thread_decoders.push_back(thr_decoder);


### PR DESCRIPTION
move vanadis thread decoder existence check to before the point where it is used
add similar check to memory interface on vanadis node os