### PR TITLE
mask-mpi: pass parameters to halo3d

### DIFF
--- a/src/sst/elements/mask-mpi/skeletons/halo3d-26.cc
+++ b/src/sst/elements/mask-mpi/skeletons/halo3d-26.cc
@@ -85,9 +85,9 @@ int USER_MAIN(int argc, char* argv[]) {
 
   MPI_Comm halo_comm = MPI_COMM_WORLD;
 
-  int pex = 2;
-  int pey = 2;
-  int pez = 2;
+  int pex = 1;  // pex, pey, and pez should all be overridden in test_halo3d26.py
+  int pey = 1;  // otherwise will fail at (pex * pey * pez) != size) below
+  int pez = 1;
 
   int nx = 10;
   int ny = 10;
@@ -100,7 +100,6 @@ int USER_MAIN(int argc, char* argv[]) {
 
   int print = 0;
 
-/*
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "-nx") == 0) {
       if (i == argc) {
@@ -212,7 +211,6 @@ int USER_MAIN(int argc, char* argv[]) {
       exit(-1);
     }
   }
-*/
 
   MPI_Barrier(MPI_COMM_WORLD);
 

--- a/src/sst/elements/mask-mpi/tests/test_halo3d26.py
+++ b/src/sst/elements/mask-mpi/tests/test_halo3d26.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
         "verbose" : "0",
         "app1.name" : "halo3d26",
         "app1.exe_library_name" : "halo3d26",
+        "app1.argv" : "-pex 2 -pey 2 -pez 2",
         "app1.dependencies" : ["sumi", ],
         "app1.libraries" : ["computelibrary:ComputeLibrary",
                             "mask_mpi:MpiApi",],


### PR DESCRIPTION
This should ensure that parameter passing continues to work into the future wrt pymercury.  Otherwise, test_halo3d26 will fail.
