### PR TITLE
Fix debug builds

### DIFF
--- a/src/sst/elements/memHierarchy/memNICBase.h
+++ b/src/sst/elements/memHierarchy/memNICBase.h
@@ -513,8 +513,10 @@ class MemNICBase : public MemLinkBase {
                 dbg.debug(_L10_, "    Peer: %s\n", it->toString().c_str());
             }
             if (peerEndpointInfo.empty()) dbg.debug(_L10_, "    Peer: NONE\n");
-            for (auto it = known_endpoints_.begin(); it != known_endpoints_.end(); it++) {
-                dbg.debug(_L10_, "    Endpoint: %s\n", it->toString().c_str());
+            for (const auto& [name, regions] : known_endpoints_) {
+                dbg.debug(_L10_, "    Endpoint: %s\n", name.c_str());
+                for(const MemRegion& region : regions)
+                    dbg.debug(_L10_, "        %s\n", region.toString().c_str());
             }
 #endif
             if (!initWaitForDst.empty()) {

--- a/src/sst/elements/memHierarchy/memTypes.h
+++ b/src/sst/elements/memHierarchy/memTypes.h
@@ -479,9 +479,9 @@ public:
 
     std::string toString() const {
         std::ostringstream str;
-        str << showbase << hex;
+        str << std::showbase << hex;
         str << "Start: " << start << " End: " << end;
-        str << noshowbase << dec;
+        str << std::noshowbase << dec;
         str << " InterleaveSize: " << interleaveSize;
         str << " InterleaveStep: " << interleaveStep;
         return str.str();


### PR DESCRIPTION
Debug builds currently get this error because a `std::map` value (a `std::pair`) does not have a `toString()` method. The map key is a `std::string` so the string key should be used directly. Also modernize the affected code to C++17.
```
../../../../../src/sst/elements/memHierarchy/memNICBase.h: In member function 'virtual void SST::MemHierarchy::MemNICBase::setup()':
../../../../../src/sst/elements/memHierarchy/memNICBase.h:517:60: error: 'struct std::pair<const std::__cxx11::basic_string<char>, std::set<SST::MemHierarchy::MemRegion> >' has no member named 'toString'
  517 |                 dbg.debug(_L10_, "    Endpoint: %s\n", it->toString().c_str());
      |                                                            ^~~~~~~~
```
