### PR TITLE
Fix empty array and string parameter passing to MemNIC

### DIFF
--- a/src/sst/elements/memHierarchy/memNICBase.h
+++ b/src/sst/elements/memHierarchy/memNICBase.h
@@ -714,7 +714,7 @@ class MemNICBase : public MemLinkBase {
 
             dbg.debug(_L10_, "%s memNICBase info is: Name: %s, group: %" PRIu32 "\n",
                     getName().c_str(), info.name.c_str(), info.id);
-            
+
             // range_check current is off(0) or on(1) but is using a uint32_t to
             // allow for future selection of different algorithms
             this->range_check=params.find<uint32_t>("range_check", 1);


### PR DESCRIPTION
Properly read in `[]` or `""` as parameters to MemNIC's `sources` and `destinations` parameters. 
Will now set these to `NONE` instead of using the default values as if no parameter had been passed.
