### PR TITLE
Fix trafficgen

### DIFF
--- a/src/sst/elements/merlin/offeredload/offered_load.cc
+++ b/src/sst/elements/merlin/offeredload/offered_load.cc
@@ -323,7 +323,13 @@ void
 OfferedLoad::progress_messages(SimTime_t current_time) {
     while ( (next_time <= current_time) && link_if->spaceToSend(0,packet_size) ) {
         offered_load_event* ev = new offered_load_event(next_time);
-        SimpleNetwork::Request* req = new SimpleNetwork::Request(packetDestGen->getNextValue(), id, packet_size, true, true, ev);
+        int dest_id=id;
+        while (dest_id == id)
+        {   // Make sure the endpoint is not sending to itself
+            dest_id = packetDestGen->getNextValue();
+        }
+        SimpleNetwork::Request* req = new SimpleNetwork::Request(dest_id, id, packet_size, true, true, ev);
+
         link_if->send(req,0);
 
         next_time += send_interval;

--- a/src/sst/elements/merlin/target_generator/uniform.h
+++ b/src/sst/elements/merlin/target_generator/uniform.h
@@ -64,7 +64,7 @@ public:
 
         gen = new SST::RNG::MersenneRNG(id);
 
-        int dist_size = std::max(1, max-min);
+        int dist_size = std::max(1, max-min+1);
         dist = new SSTUniformDistribution(dist_size, gen);
 
     }
@@ -80,7 +80,7 @@ public:
         if ( min == -1 ) min = 0;
         if ( max == -1 ) max = num_peers;
 
-        int dist_size = std::max(1, max-min);
+        int dist_size = std::max(1, max-min+1);
         dist = new SSTUniformDistribution(dist_size, gen);
     }
 
@@ -93,7 +93,7 @@ public:
         delete dist;
         delete gen;
         gen = new SST::RNG::MersenneRNG((unsigned int) val);
-        dist = new SSTUniformDistribution(std::max(1, max-min),gen);
+        dist = new SSTUniformDistribution(std::max(1, max-min+1),gen);
     }
 };
 

--- a/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
@@ -175,7 +175,7 @@ class _topoMeshBase(Topology):
                 nodeID = local_ports * i + n
                 (ep, port_name) = endpoint.build(nodeID, {})
                 if ep:
-                    nicLink = sst.Link("nic.%d:%d"%(i, n))
+                    nicLink = sst.Link("nic_%d_%d"%(i, n))
                     if self.bundleEndpoints:
                        nicLink.setNoCut()
                     nicLink.connect( (ep, port_name, self.host_link_latency), (rtr, "port%d"%port, self.host_link_latency) )
@@ -240,7 +240,7 @@ class topoSingle(Topology):
         for l in range(self.num_ports):
             (ep, portname) = endpoint.build(l, {})
             if ep:
-                link = sst.Link("link%d"%l)
+                link = sst.Link("link_%d"%l)
                 if self.bundleEndpoints:
                     link.setNoCut()
                 link.connect( (ep, portname, self.link_latency), (rtr, "port%d"%l, self.link_latency) )

--- a/src/sst/elements/merlin/trafficgen/trafficgen.cc
+++ b/src/sst/elements/merlin/trafficgen/trafficgen.cc
@@ -324,7 +324,12 @@ TrafficGen::send_notify(int vn)
 
 int TrafficGen::getPacketDest(void)
 {
-    int dest = packetDestGen->getNextValue();
+    int dest = id;
+    while (dest == id)
+    {
+        dest = packetDestGen->getNextValue();
+    }
+    
     assert ( dest >= 0 );
     return dest;
 }

--- a/src/sst/elements/merlin/trafficgen/trafficgen.h
+++ b/src/sst/elements/merlin/trafficgen/trafficgen.h
@@ -202,7 +202,7 @@ private:
         {
 		gen = new SST::RNG::MersenneRNG();
 
-		dist_size = std::max(1, max-min);
+		dist_size = std::max(1, max-min + 1);
 		dist = new SSTUniformDistribution(dist_size, gen);
 	}
 


### PR DESCRIPTION
In the original sst-merlin code, there has been a very old bug for the uniform target generator. This commit fixes this bug and updates the corresponding implementation in offered_load.cc.

-------------------------------------------------------
Some explanations
-------------------------------------------------------
In the original sst-merlin code, the following lines create a range that does not correctly cover all possible peers. This is because the first input arg of SSTUniformDistribution is the number of bins, which need to equal to (max-min+1) here.

From [`uniform.h`](https://github.com/sstsimulator/sst-elements/blob/08c5200e95b2acf2ab79345a597d8cb2ff46ee67/src/sst/elements/merlin/target_generator/uniform.h#L59-L70):

```cpp
UniformDist(ComponentId_t cid, Params &params, int id, int num_peers) :
        TargetGenerator(cid)
    {
        min = params.find<int>("min",0);
        max = params.find<int>("max",num_peers - 1);

        gen = new SST::RNG::MersenneRNG(id);

        int dist_size = std::max(1, max-min);
        dist = new SSTUniformDistribution(dist_size, gen);

    }
```

This has been fixed in this commit, and correspondingly in offered_load.cc, it has been made sure that an Endpoint does not generate packet towards itself. Besides, some link naming fixes are also included to clear the warnings.
-------------------------------------------------------
Demonstrating the bug and the fix
-------------------------------------------------------
This bug is easy to reproduce with a 4x4 mesh topology, for example with the following config file:
[mesh_bug_reproduce.py](https://github.com/user-attachments/files/22214957/mesh_bug_reproduce.py)

Before this fix, the result shows that the last Endpoint receives no packets:

<img width="1196" height="343" alt="image" src="https://github.com/user-attachments/assets/9df2214b-0c34-48a5-8f5c-3bfa2c528385" />


After this fix:
<img width="1196" height="343" alt="image" src="https://github.com/user-attachments/assets/f7ab5302-94c2-41c2-864f-08753974971f" />



-------------------------------------------------------

I started with the master branch of sst-element-src... but since it is only ahead of the devel branch with merges, I hope this is ok?
