### PR TITLE
Fix null pointer format string passed to Output::fatal()

### DIFF
--- a/src/sst/elements/ariel/frontend/epa/epafrontend.cc
+++ b/src/sst/elements/ariel/frontend/epa/epafrontend.cc
@@ -172,7 +172,7 @@ int EPAFrontend::forkChildProcess(const char* app, char** args, std::map<std::st
         if ("" != redirect_info.stdin_file) {
             output->verbose(CALL_INFO, 1, 0, "Redirecting child stdin from file %s\n", redirect_info.stdin_file.c_str());
             if (!freopen(redirect_info.stdin_file.c_str(), "r", stdin)) {
-                output->fatal(CALL_INFO, 1, 0, "Failed to redirect stdin\n");
+                output->fatal(CALL_INFO, 1, "Failed to redirect stdin\n");
             }
         }
         if ("" != redirect_info.stdout_file) {
@@ -182,7 +182,7 @@ int EPAFrontend::forkChildProcess(const char* app, char** args, std::map<std::st
                 mode = "a+";
             }
             if (!freopen(redirect_info.stdout_file.c_str(), mode.c_str(), stdout)) {
-                output->fatal(CALL_INFO, 1, 0, "Failed to redirect stdout\n");
+                output->fatal(CALL_INFO, 1, "Failed to redirect stdout\n");
             }
         }
         if ("" != redirect_info.stderr_file) {
@@ -192,7 +192,7 @@ int EPAFrontend::forkChildProcess(const char* app, char** args, std::map<std::st
                 mode = "a+";
             }
             if (!freopen(redirect_info.stderr_file.c_str(), mode.c_str(), stderr)) {
-                output->fatal(CALL_INFO, 1, 0, "Failed to redirect stderr\n");
+                output->fatal(CALL_INFO, 1, "Failed to redirect stderr\n");
             }
         }
 


### PR DESCRIPTION
Apparently not knowing that `Output::verbose()` and `Output::fatal()` take a different number of arguments, three calls to `Output::fatal` in https://github.com/sstsimulator/sst-elements/pull/2493 were passing a value of `0` (a null pointer) for the format string.

This appeared in the builds as warnings:

```
../../../../../src/sst/elements/ariel/frontend/epa/epafrontend.cc: In member function 'virtual int SST::ArielComponent::EPAFrontend:
:forkChildProcess(const char*, char**, std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >&, SST::ArielCom
ponent::ariel_redirect_info_t)':
../../../../../src/sst/elements/ariel/frontend/epa/epafrontend.cc:181:48: warning: too many arguments for format [-Wformat-extra-arg
s]
  181 |                 output->fatal(CALL_INFO, 1, 0, "Failed to redirect stdin\n");
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../src/sst/elements/ariel/frontend/epa/epafrontend.cc:191:48: warning: too many arguments for format [-Wformat-extra-arg
s]
  191 |                 output->fatal(CALL_INFO, 1, 0, "Failed to redirect stdout\n");
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../src/sst/elements/ariel/frontend/epa/epafrontend.cc:201:48: warning: too many arguments for format [-Wformat-extra-arg
s]
  201 |                 output->fatal(CALL_INFO, 1, 0, "Failed to redirect stderr\n");
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The third argument `0` is being interpreted as the format string pointer, which is a `nullptr`, and hence the warnings about the real format string following it being "too many arguments for format".

@accauble 
