### PR TITLE
GitHub Actions: Pin Python versions for macOS runners

### DIFF
--- a/.github/workflows/free-macos-14.yml
+++ b/.github/workflows/free-macos-14.yml
@@ -45,6 +45,11 @@ jobs:
           echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
+      - name: Pin Python version
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.9'
+
       - name: Compile core
         run: |
           # TODO the argument does nothing as long as Spack is unavailable

--- a/.github/workflows/free-macos-15.yml
+++ b/.github/workflows/free-macos-15.yml
@@ -45,6 +45,11 @@ jobs:
           echo "MAKEFLAGS=${MAKEFLAGS}" >> "${GITHUB_ENV}"
           echo "TERM=dumb" >> "${GITHUB_ENV}"
 
+      - name: Pin Python version
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
+        with:
+          python-version: '3.13'
+
       - name: Compile core
         run: |
           # TODO the argument does nothing as long as Spack is unavailable


### PR DESCRIPTION
The elements version of https://github.com/sstsimulator/sst-core/pull/1454 for https://github.com/sstsimulator/sst-core/issues/1453.