### PR TITLE
Merlin: test_nic parameter name mismatch

### DIFF
--- a/src/sst/elements/merlin/test/nic.cc
+++ b/src/sst/elements/merlin/test/nic.cc
@@ -56,7 +56,7 @@ nic::nic(ComponentId_t cid, Params& params) :
 
     num_msg = params.find<int>("num_messages",10);
 
-    send_untimed_bcast = params.find<bool>("send_untimed_bcast","false");
+    send_untimed_bcast = params.find<bool>("send_untimed_broadcast","false");
 
     UnitAlgebra message_size = params.find<std::string>("message_size","64b");
     if ( message_size.hasUnits("B") ) message_size  *= UnitAlgebra("8b/B");


### PR DESCRIPTION
Fix parameter name mismatch (source code didn't match ELI).
