### PR TITLE
Vanadis: Enable true Out-of-Order execution for RoCC instructions

### DIFF
--- a/src/sst/elements/vanadis/vanadis.h
+++ b/src/sst/elements/vanadis/vanadis.h
@@ -328,6 +328,7 @@ private:
 
     std::vector<VanadisRoCCInterface*> roccs_;
     std::vector<std::deque<VanadisInstruction*>> rocc_queues_;
+    std::vector<std::deque<VanadisInstruction*>> rocc_wait_queues_;
 
     uint32_t decode_start_thread_ = 0;
 


### PR DESCRIPTION
Fixes #2602 

**Summary**
This PR overhauls the `VanadisRoCCInterface` integration within the processor pipeline to support true Out-of-Order (OoO) execution. Previously, RoCC instructions were handled sequentially with immediate operand reading at the Issue stage and direct architectural register write-back, which artificially serialized execution and introduced RAW/WAW/WAR hazards.

**Technical Details**

This PR implements the following changes to align RoCC instruction handling with standard Vanadis functional units:

1.  **Register Renaming for RoCC (`assignRegistersToInstruction`)**:
    *   Removed the special handling block that bypassed register allocation.
    *   RoCC instructions now go through the standard output register allocation path, acquiring physical registers for `rd`. This resolves WAW and WAR hazards.

2.  **Delayed Dispatch Mechanism (`allocateFunctionalUnit`)**:
    *   Removed the immediate `push` to the RoCC interface during the Issue stage.
    *   Introduced `rocc_wait_queues_` to hold issued RoCC instructions that are waiting for source operands (acting as a reservation station).

3.  **Operand Readiness Check (`performExecute`)**:
    *   Added logic to the start of the Execute stage to scan `rocc_wait_queues_`.
    *   Instructions are only dispatched (pushed) to the accelerator when:
        *   The hardware RoCC queue is not full.
        *   All source physical registers are ready (checking `pendingIntWrites`).
    *   Source register values are now read from the register file at the moment of dispatch, ensuring correct data is sent.

4.  **Correct Physical Register Write-back**:
    *   Updated the response handling logic in `performExecute`.
    *   Results are now written to the allocated **physical register** index (retrieved from the instruction object) instead of the architectural register index.

**Impact**
These changes allow the Vanadis CPU to continue issuing independent instructions while RoCC instructions are waiting for operands or executing long-latency tasks. This significantly improves the accuracy of performance modeling for heterogeneous systems.

**Testing**
*   Verified with a custom CIM (Compute-in-Memory) RoCC component.
*   Confirmed that RAW dependencies are correctly respected (instruction waits for operands).
*   Confirmed that independent instructions can execute out-of-order relative to RoCC operations.