### PR TITLE
Compile a debug and regular version of vanadis libraries.

### DIFF
--- a/src/sst/elements/golem/tests/small/crosssim_float_array/multi_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/crosssim_float_array/multi_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 2, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 82635; SumSQ.u64 = 82635; Count.u64 = 82635; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 179692; SumSQ.u64 = 179692; Count.u64 = 179692; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 34764; SumSQ.u64 = 34764; Count.u64 = 34764; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/crosssim_float_array/single_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/crosssim_float_array/single_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 1, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 50310; SumSQ.u64 = 50310; Count.u64 = 50310; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 90338; SumSQ.u64 = 90338; Count.u64 = 90338; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 17648; SumSQ.u64 = 17648; Count.u64 = 17648; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/crosssim_int_array/multi_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/crosssim_int_array/multi_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 2, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 65486; SumSQ.u64 = 65486; Count.u64 = 65486; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 106326; SumSQ.u64 = 106326; Count.u64 = 106326; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 15271; SumSQ.u64 = 15271; Count.u64 = 15271; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/crosssim_int_array/single_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/crosssim_int_array/single_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 1, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 43152; SumSQ.u64 = 43152; Count.u64 = 43152; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 50687; SumSQ.u64 = 50687; Count.u64 = 50687; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 7892; SumSQ.u64 = 7892; Count.u64 = 7892; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/mvm_float_array/multi_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/mvm_float_array/multi_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 2, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 70930; SumSQ.u64 = 70930; Count.u64 = 70930; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 133915; SumSQ.u64 = 133915; Count.u64 = 133915; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 34248; SumSQ.u64 = 34248; Count.u64 = 34248; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/mvm_float_array/single_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/mvm_float_array/single_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 1, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 44468; SumSQ.u64 = 44468; Count.u64 = 44468; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 65619; SumSQ.u64 = 65619; Count.u64 = 65619; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 17402; SumSQ.u64 = 17402; Count.u64 = 17402; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/mvm_int_array/multi_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/mvm_int_array/multi_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 2, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 59414; SumSQ.u64 = 59414; Count.u64 = 59414; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 85886; SumSQ.u64 = 85886; Count.u64 = 85886; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 15271; SumSQ.u64 = 15271; Count.u64 = 15271; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/golem/tests/small/mvm_int_array/single_array/riscv64/sst.stdout.gold
+++ b/src/sst/elements/golem/tests/small/mvm_int_array/single_array/riscv64/sst.stdout.gold
@@ -1,6 +1,6 @@
 [RoCC 0]: node0.cpu0:rocc: numArrays: 1, arrayInputSize: 6, arrayOutputSize: 6 
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 38601; SumSQ.u64 = 38601; Count.u64 = 38601; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 41855; SumSQ.u64 = 41855; Count.u64 = 41855; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 7892; SumSQ.u64 = 7892; Count.u64 = 7892; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/rdmaNic/tests/app/mpi/riscv64/IMB-MPI1.out.gold
+++ b/src/sst/elements/rdmaNic/tests/app/mpi/riscv64/IMB-MPI1.out.gold
@@ -1,7 +1,7 @@
 node=1 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
 node=0 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 797688; SumSQ.u64 = 797688; Count.u64 = 797688; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 1469374; SumSQ.u64 = 1469374; Count.u64 = 1469374; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 328188; SumSQ.u64 = 328188; Count.u64 = 328188; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/rdmaNic/tests/app/rdma/riscv64/msg.out.gold
+++ b/src/sst/elements/rdmaNic/tests/app/rdma/riscv64/msg.out.gold
@@ -1,7 +1,7 @@
 node=0 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
 node=1 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3514; SumSQ.u64 = 3514; Count.u64 = 3514; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 5028; SumSQ.u64 = 5028; Count.u64 = 5028; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1099; SumSQ.u64 = 1099; Count.u64 = 1099; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/Makefile.am
+++ b/src/sst/elements/vanadis/Makefile.am
@@ -4,11 +4,10 @@
 
 AM_CPPFLAGS += \
 	$(MPI_CPPFLAGS) \
-	-I$(top_srcdir)/src \
-	-DVANADIS_BUILD_DEBUG
+	-I$(top_srcdir)/src
 
 compdir = $(pkglibdir)
-comp_LTLIBRARIES = libvanadis.la
+comp_LTLIBRARIES = libvanadis.la libvanadisdbg.la
 
 VANADIS_SRC_FILES = \
 utils.h \
@@ -602,13 +601,15 @@ libvanadis_la_SOURCES = \
 	vanadis.cc \
 	$(VANADIS_SRC_FILES)
 
-#libvanadisdbg_la_SOURCES = \
-#	vanadisdbg.cc \
-#	$(VANADIS_SRC_FILES)
+libvanadisdbg_la_SOURCES = \
+	vanadis.cc \
+	$(VANADIS_SRC_FILES)
 
 libvanadis_la_LDFLAGS = -module -avoid-version
 
-#libvanadisdbg_la_LDFLAGS = -module -avoid-version
+libvanadisdbg_la_LDFLAGS = -module -avoid-version
+
+libvanadisdbg_la_CPPFLAGS = -DVANADIS_BUILD_DEBUG $(AM_CPPFLAGS)
 
 bin_PROGRAMS = sst-vanadis-tracediff
 
@@ -622,3 +623,4 @@ sst_vanadis_tracediff_SOURCES = tools/tracediff/tracediff.cc
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     vanadis=$(abs_srcdir)
 	$(SST_REGISTER_TOOL) SST_ELEMENT_TESTS      vanadis=$(abs_srcdir)/tests
+	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     vanadisdbg=$(abs_srcdir)

--- a/src/sst/elements/vanadis/decoder/vdecoder.h
+++ b/src/sst/elements/vanadis/decoder/vdecoder.h
@@ -215,7 +215,9 @@ public:
     {
         ip = newIP;
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 16, 0, "[decoder] -> clear decode-q and set new ip: 0x%" PRI_ADDR "\n", newIP);
+        #endif
 
         // Clear out the decode queue, need to restart
         // decoded_q->clear();

--- a/src/sst/elements/vanadis/inst/vaddi.h
+++ b/src/sst/elements/vanadis/inst/vaddi.h
@@ -97,7 +97,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile, phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 private:

--- a/src/sst/elements/vanadis/inst/vaddiu.h
+++ b/src/sst/elements/vanadis/inst/vaddiu.h
@@ -71,12 +71,16 @@ public:
             uint16_t phys_int_regs_out_0 = phys_int_regs_out[0];
             uint16_t phys_int_regs_in_0 = phys_int_regs_in[0];
             instOp(regFile,phys_int_regs_out_0,phys_int_regs_in_0);
+            #ifdef VANADIS_BUILD_DEBUG
             log(output, 16, 65535, phys_int_regs_out_0,phys_int_regs_in_0,0);
+            #endif
         }
         else
         {
             flagError();
+            #ifdef VANADIS_BUILD_DEBUG
             output->verbose(CALL_INFO, 16, 0, "hw_thr=%d sw_thr = %d Execute: (addr=%p) ADDIU setting traperror = true\n", getHWThread(), 65535, (void*)getInstructionAddress());
+            #endif
         }
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vandi.h
+++ b/src/sst/elements/vanadis/inst/vandi.h
@@ -74,7 +74,9 @@ public:
     {
         uint16_t phys_int_regs_out_0 = phys_int_regs_out[0];
         uint16_t phys_int_regs_in_0 = phys_int_regs_in[0];
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0,phys_int_regs_in_0);
+        #endif
         instOp(regFile, phys_int_regs_out_0,phys_int_regs_in_0);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vbcmp.h
+++ b/src/sst/elements/vanadis/inst/vbcmp.h
@@ -110,7 +110,9 @@ public:
         uint16_t phys_int_regs_in_1 = phys_int_regs_in[1];
         bool compare_result = false;
         instOp(output, regFile, phys_int_regs_in_0, phys_int_regs_in_1,&compare_result);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,compare_result,phys_int_regs_in_0,phys_int_regs_in_1);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vbcmpi.h
+++ b/src/sst/elements/vanadis/inst/vbcmpi.h
@@ -91,7 +91,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         bool compare_result = false;
         instOp(output, regFile, phys_int_regs_in_0, &compare_result);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,compare_result,phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vbcmpil.h
+++ b/src/sst/elements/vanadis/inst/vbcmpil.h
@@ -108,7 +108,9 @@ public:
         uint16_t phys_int_regs_out_0 = phys_int_regs_out[0];
         bool compare_result = false;
         instOp(output, regFile, phys_int_regs_in_0, phys_int_regs_out_0,&compare_result);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,compare_result,phys_int_regs_in_0,phys_int_regs_out_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vbfp.h
+++ b/src/sst/elements/vanadis/inst/vbfp.h
@@ -85,7 +85,9 @@ public:
         const uint16_t fp_cond_reg = phys_fp_regs_in[0];
         bool compare_result = false;
         instOp(regFile, fp_cond_reg, &compare_result);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,compare_result,fp_cond_reg);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vcimov.h
+++ b/src/sst/elements/vanadis/inst/vcimov.h
@@ -87,7 +87,9 @@ public:
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         bool compare_result = false;
         instOp(output,regFile, phys_int_regs_out_0,phys_int_regs_in_0, phys_int_regs_in_1,&compare_result);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0,phys_int_regs_in_0,phys_int_regs_in_1,compare_result);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vdiv.h
+++ b/src/sst/elements/vanadis/inst/vdiv.h
@@ -109,8 +109,10 @@ public:
         uint16_t phys_int_regs_out_0 = phys_int_regs_out[0];
         uint16_t phys_int_regs_in_0 = phys_int_regs_in[0];
         uint16_t phys_int_regs_in_1 = phys_int_regs_in[1];
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0,phys_int_regs_in_0,
                 phys_int_regs_in_1);
+        #endif
         instOp(regFile, phys_int_regs_out_0,phys_int_regs_in_0,
                 phys_int_regs_in_1);
         markExecuted();

--- a/src/sst/elements/vanadis/inst/vfp2fp.h
+++ b/src/sst/elements/vanadis/inst/vfp2fp.h
@@ -93,7 +93,9 @@ public:
         }
         instOp(regFile,phys_fp_regs_out_0, phys_fp_regs_out_1,
                                 phys_fp_regs_in_0,phys_fp_regs_in_1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_fp_regs_out_0,phys_fp_regs_in_0);
+        #endif
 
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vfp2gpr.h
+++ b/src/sst/elements/vanadis/inst/vfp2gpr.h
@@ -115,7 +115,9 @@ public:
             phys_fp_regs_in_1 = getPhysFPRegIn(1);
         }
         instOp(regFile,phys_fp_regs_in_0,phys_fp_regs_in_1,phys_int_regs_out_0 );
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0,phys_fp_regs_in_0);
+        #endif
 
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vfpadd.h
+++ b/src/sst/elements/vanadis/inst/vfpadd.h
@@ -127,7 +127,9 @@ public:
         uint16_t phys_fp_regs_in_2 = 0;
         uint16_t phys_fp_regs_in_3 = 0;
         uint16_t phys_fp_regs_out_1 = 0;
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
         if ( sizeof(fp_format) > regFile->getFPRegWidth() )
         {
             phys_fp_regs_in_2 = getPhysFPRegIn(2);

--- a/src/sst/elements/vanadis/inst/vfpclass.h
+++ b/src/sst/elements/vanadis/inst/vfpclass.h
@@ -139,7 +139,9 @@ public:
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         uint16_t phys_fp_regs_in_0 = getPhysFPRegIn(0);
         uint16_t phys_fp_regs_in_1 = getPhysFPRegIn(1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
         instOp(regFile, phys_fp_regs_in_0, phys_fp_regs_in_1, phys_int_regs_out_0);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vfpconv.h
+++ b/src/sst/elements/vanadis/inst/vfpconv.h
@@ -247,7 +247,9 @@ public:
         uint16_t phys_fp_regs_in_0 = getPhysFPRegIn(0);
         uint16_t phys_fp_regs_in_1 = 0;
         uint16_t phys_fp_regs_out_1 = 0;
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0);
+        #endif
 
         if ( VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode() )
         {

--- a/src/sst/elements/vanadis/inst/vfpdiv.h
+++ b/src/sst/elements/vanadis/inst/vfpdiv.h
@@ -144,7 +144,9 @@ public:
         uint16_t phys_fp_regs_in_2 = 0;
         uint16_t phys_fp_regs_in_3 = 0;
         uint16_t phys_fp_regs_out_1 = 0;
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
         if ( sizeof(fp_format) > regFile->getFPRegWidth() )
         {
             phys_fp_regs_in_2 = getPhysFPRegIn(2);

--- a/src/sst/elements/vanadis/inst/vfpflagsread.h
+++ b/src/sst/elements/vanadis/inst/vfpflagsread.h
@@ -58,11 +58,13 @@ public:
 
 	void log(SST::Output* output, int verboselevel, uint16_t sw_thr, uint64_t flags_out, uint16_t phys_int_regs_out_0 )
 	{
+        #ifdef VANADIS_BUILD_DEBUG
 		if(output->getVerboseLevel() >= verboselevel) {
 				output->verbose(CALL_INFO, verboselevel, 0, "hw_thr=%d sw_thr = %d Execute: 0x%" PRI_ADDR " %s out-reg: %" PRIu16 " / out-mask: 0x%" PRI_ADDR " / copy_round: %c / shift_round: %c / copy_fp: %c\n",
 						getHWThread(),sw_thr, getInstructionAddress(), getInstCode(), phys_int_regs_out_0, flags_out,
 						copy_round_mode ? 'y' : 'n', shift_round_mode ? 'y' : 'n', copy_fp_flags ? 'y' : 'n');
 			}
+		#endif
 	}
 
 	void instOp( VanadisRegisterFile* regFile, uint64_t* flags_out, uint16_t phys_int_regs_out_0)
@@ -95,7 +97,9 @@ public:
 		  	uint64_t flags_out = 0;
 			uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
 			instOp(regFile, &flags_out, phys_int_regs_out_0);
+        	#ifdef VANADIS_BUILD_DEBUG
 			log(output, 16, 65535, flags_out, phys_int_regs_out_0);
+			#endif
 			markExecuted();
 		}
     }

--- a/src/sst/elements/vanadis/inst/vfpflagsset.h
+++ b/src/sst/elements/vanadis/inst/vfpflagsset.h
@@ -57,10 +57,12 @@ public:
     void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
                             uint16_t phys_int_regs_in_0, uint64_t mask_in)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= verboselevel) {
 				output->verbose(CALL_INFO, verboselevel, 0, "hw_thr=%d sw_thr = %d Execute: 0x%" PRI_ADDR " %s in-reg: %" PRIu16 " / phys: %" PRIu16 " -> mask = %" PRIu64 " (0x%" PRI_ADDR ")\n",
 					getHWThread(),sw_thr, getInstructionAddress(), getInstCode(), isa_int_regs_in[0], phys_int_regs_in_0, mask_in, mask_in);
 			}
+        #endif
     }
 
     void instOp(VanadisRegisterFile* regFile, uint16_t phys_int_regs_in_0, uint64_t* mask_in)
@@ -75,10 +77,14 @@ public:
             uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
             uint64_t mask_in = 0;
 			instOp(regFile, phys_int_regs_in_0, &mask_in);
+            #ifdef VANADIS_BUILD_DEBUG
             log(output, 16, 65535, phys_int_regs_in_0, mask_in);
+            #endif
 			markExecuted();
+        #ifdef VANADIS_BUILD_DEBUG
 		} else {
 			output->verbose(CALL_INFO, 16, 0, "hw_thr=%d, sw_thr=%d, not front of ROB for ins: 0x%" PRI_ADDR " %s\n", getHWThread(), 65535,  getInstructionAddress(), getInstCode());
+        #endif
 		}
     }
 protected:

--- a/src/sst/elements/vanadis/inst/vfpflagssetimm.h
+++ b/src/sst/elements/vanadis/inst/vfpflagssetimm.h
@@ -56,10 +56,12 @@ public:
 
     void log(SST::Output* output, int verboselevel, uint16_t sw_thr)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         if(output->getVerboseLevel() >= verboselevel) {
 				output->verbose(CALL_INFO, verboselevel, 0, "hw_thr=%d sw_thr = %d Execute: 0x%" PRI_ADDR " %s FPFLAGS <- mask = %" PRIu64 " (0x%" PRI_ADDR ")\n",
 					getHWThread(),sw_thr, getInstructionAddress(), getInstCode(), imm_value, imm_value);
 			}
+        #endif
     }
 
 
@@ -73,10 +75,11 @@ public:
     void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
 		if(checkFrontOfROB()) {
+            #ifdef VANADIS_BUILD_DEBUG
 			log(output, 16, 65535);
+            #endif
 
 			instOp();
-
 			markExecuted();
 		}
     }

--- a/src/sst/elements/vanadis/inst/vfpinst.h
+++ b/src/sst/elements/vanadis/inst/vfpinst.h
@@ -28,7 +28,6 @@
 
 #include <cstring>
 #include <cmath>
-#include <sst/core/output.h>
 
 namespace SST {
 namespace Vanadis {

--- a/src/sst/elements/vanadis/inst/vfpmadd.h
+++ b/src/sst/elements/vanadis/inst/vfpmadd.h
@@ -175,7 +175,9 @@ public:
             phys_fp_regs_in_5 = getPhysFPRegIn(5);
             phys_fp_regs_out_1 = getPhysFPRegOut(1);
         }
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_fp_regs_in_0,phys_fp_regs_in_1,phys_fp_regs_in_2,phys_fp_regs_out_0);
+        #endif
         instOp(regFile,phys_fp_regs_in_0,
                         phys_fp_regs_in_1, phys_fp_regs_in_2,
                         phys_fp_regs_in_3, phys_fp_regs_in_4,

--- a/src/sst/elements/vanadis/inst/vfpmin.h
+++ b/src/sst/elements/vanadis/inst/vfpmin.h
@@ -159,7 +159,9 @@ public:
         uint16_t phys_fp_regs_in_2 = 0;
         uint16_t phys_fp_regs_in_3 = 0;
         uint16_t phys_fp_regs_out_1 = 0;
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
 
         if ( (sizeof(fp_format) == 8) && (VANADIS_REGISTER_MODE_FP32 == isa_options->getFPRegisterMode()) )
         {

--- a/src/sst/elements/vanadis/inst/vfpmsub.h
+++ b/src/sst/elements/vanadis/inst/vfpmsub.h
@@ -174,7 +174,9 @@ public:
             phys_fp_regs_in_5 = getPhysFPRegIn(5);
             phys_fp_regs_out_1 = getPhysFPRegOut(1);
         }
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_fp_regs_in_0,phys_fp_regs_in_1,phys_fp_regs_in_2,phys_fp_regs_out_0);
+        #endif
         instOp(regFile,phys_fp_regs_in_0,
                         phys_fp_regs_in_1, phys_fp_regs_in_2,
                         phys_fp_regs_in_3, phys_fp_regs_in_4,

--- a/src/sst/elements/vanadis/inst/vfpmul.h
+++ b/src/sst/elements/vanadis/inst/vfpmul.h
@@ -147,7 +147,9 @@ public:
         instOp(regFile, phys_fp_regs_in_0, phys_fp_regs_in_1,
                         phys_fp_regs_in_2, phys_fp_regs_in_3,
                         phys_fp_regs_out_0,phys_fp_regs_out_1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
         markExecuted();
     }
 };

--- a/src/sst/elements/vanadis/inst/vfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vfpscmp.h
@@ -227,7 +227,9 @@ public:
         const bool compare_result = performCompare(output, regFile,phys_fp_regs_in_0, phys_fp_regs_in_1, phys_fp_regs_in_2,
                                                     phys_fp_regs_in_3);
         regFile->setIntReg<uint64_t>(phys_int_regs_out_0, compare_result ? 1 : 0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16,65535, phys_int_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1, compare_result);
+        #endif
         markExecuted();
     }
 };

--- a/src/sst/elements/vanadis/inst/vfpsignlogic.h
+++ b/src/sst/elements/vanadis/inst/vfpsignlogic.h
@@ -232,7 +232,9 @@ public:
             phys_fp_regs_out_1 = getPhysFPRegOut(1);
         }
         instOp(regFile,phys_fp_regs_in_0, phys_fp_regs_in_1,phys_fp_regs_in_2,phys_fp_regs_in_3,phys_fp_regs_out_0,phys_fp_regs_out_1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_in_0,phys_fp_regs_in_1,phys_fp_regs_in_2,phys_fp_regs_in_3,phys_fp_regs_out_0,phys_fp_regs_out_1);
+        #endif
         markExecuted();
     }
 };

--- a/src/sst/elements/vanadis/inst/vfpsqrt.h
+++ b/src/sst/elements/vanadis/inst/vfpsqrt.h
@@ -145,7 +145,9 @@ public:
             phys_fp_regs_in_1 = getPhysFPRegIn(1);
             phys_fp_regs_out_1 = getPhysFPRegOut(1);
         }
+        #ifdef VANADIS_BUILD_DEBUG
         log(output,16, 65535, phys_fp_regs_in_0,phys_fp_regs_out_0);
+        #endif
         instOp(regFile, phys_fp_regs_in_0,
                         phys_fp_regs_in_1, phys_fp_regs_out_0,phys_fp_regs_out_1);
 

--- a/src/sst/elements/vanadis/inst/vfpsub.h
+++ b/src/sst/elements/vanadis/inst/vfpsub.h
@@ -170,7 +170,9 @@ public:
         instOp(regFile, phys_fp_regs_in_0, phys_fp_regs_in_1,
                         phys_fp_regs_in_2, phys_fp_regs_in_3,
                         phys_fp_regs_out_0,phys_fp_regs_out_1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_fp_regs_out_0, phys_fp_regs_in_0, phys_fp_regs_in_1);
+        #endif
         markExecuted();
     }
 };

--- a/src/sst/elements/vanadis/inst/vgpr2fp.h
+++ b/src/sst/elements/vanadis/inst/vgpr2fp.h
@@ -76,7 +76,7 @@ public:
     void log(SST::Output* output, int verboselevel, uint16_t sw_thr,
                             uint16_t phys_int_regs_out_0,uint16_t phys_int_regs_in_0) override
         {
-
+            #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= verboselevel) {
                 output->verbose(
                 CALL_INFO, verboselevel, 0,
@@ -85,6 +85,7 @@ public:
                 getHWThread(),sw_thr, getInstructionAddress(), getInstCode(), phys_int_regs_out_0, phys_int_regs_in_0,
                  isa_fp_regs_out[0], isa_int_regs_in[0]);
             }
+            #endif
         }
 
     inline void bitwise_convert(VanadisRegisterFile* regFile,
@@ -166,7 +167,9 @@ public:
             phys_fp_regs_out_1 = getPhysFPRegOut(1);
         }
         instOp(regFile, phys_fp_regs_out_0, phys_fp_regs_out_1, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output,16, 65535, phys_fp_regs_out_0,phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 };

--- a/src/sst/elements/vanadis/inst/vinst.h
+++ b/src/sst/elements/vanadis/inst/vinst.h
@@ -339,7 +339,9 @@ class VanadisInstruction
             uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
             uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
             uint16_t phys_int_regs_in_1 = getPhysIntRegIn(1);
+            #ifdef VANADIS_BUILD_DEBUG
             log(output, 16, 65535,phys_int_regs_out_0,phys_int_regs_in_0,phys_int_regs_in_1);
+            #endif
             instOp(regFile,phys_int_regs_out_0, phys_int_regs_in_0, phys_int_regs_in_1);
             markExecuted();
         }

--- a/src/sst/elements/vanadis/inst/vjl.h
+++ b/src/sst/elements/vanadis/inst/vjl.h
@@ -72,7 +72,9 @@ public:
     {
         const uint64_t link_value = calculateStandardNotTakenAddress();
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65355, link_value, phys_int_regs_out_0, takenAddress);
+        #endif
         instOp(regFile, phys_int_regs_out_0, link_value );
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vjlr.h
+++ b/src/sst/elements/vanadis/inst/vjlr.h
@@ -91,7 +91,9 @@ public:
         uint64_t link_value = 0;
         uint64_t jump_to = 0;
         instOp(regFile, phys_int_regs_out_0, phys_int_regs_in_0, &jump_to, &link_value);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output,16, 65535,phys_int_regs_out_0,phys_int_regs_in_0, jump_to, link_value);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vjr.h
+++ b/src/sst/elements/vanadis/inst/vjr.h
@@ -67,8 +67,10 @@ public:
     {
 
         instOp(regFile, phys_int_regs_in[0]);
-        log(output, 16, 65535, phys_int_regs_in[0]);
 
+        #ifdef VANADIS_BUILD_DEBUG
+        log(output, 16, 65535, phys_int_regs_in[0]);
+        #endif
         //        if ((takenAddress & 0x3) != 0) {
         //            flagError();
         //        }

--- a/src/sst/elements/vanadis/inst/vload.h
+++ b/src/sst/elements/vanadis/inst/vload.h
@@ -147,6 +147,7 @@ public:
 
         mem_addr_reg_val = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
 
+        #ifdef VANADIS_BUILD_DEBUG
         switch ( regType ) {
         case LOAD_INT_REGISTER:
         {
@@ -173,7 +174,6 @@ public:
         } break;
         }
 
-        #ifdef VANADIS_BUILD_DEBUG
         // if(output->getVerboseLevel() >= 16)
         {
             output->verbose(

--- a/src/sst/elements/vanadis/inst/vmin.h
+++ b/src/sst/elements/vanadis/inst/vmin.h
@@ -76,7 +76,9 @@ public:
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_in_1 = getPhysIntRegIn(1);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0,phys_int_regs_in_0,phys_int_regs_in_1);
+        #endif
         instOp(regFile,phys_int_regs_out_0, phys_int_regs_in_0, phys_int_regs_in_1);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vmipsfpscmp.h
+++ b/src/sst/elements/vanadis/inst/vmipsfpscmp.h
@@ -98,11 +98,13 @@ public:
                 ? combineFromRegisters<fp_format>(regFile, phys_fp_regs_in[2], phys_fp_regs_in[3])
                 : regFile->getFPReg<fp_format>(phys_fp_regs_in[1]);
 
+        #ifdef VANADIS_BUILD_DEBUG
         if ( output->getVerboseLevel() >= 16 ) {
             std::ostringstream ss;
             ss << "---> fp-values: left: " << left_value << " / right: " << right_value;
             output->verbose( CALL_INFO, 16, 0, "%s\n", ss.str().c_str());
         }
+        #endif
 
         switch ( compare_type ) {
         case REG_COMPARE_EQ:

--- a/src/sst/elements/vanadis/inst/vmulsplit.h
+++ b/src/sst/elements/vanadis/inst/vmulsplit.h
@@ -89,12 +89,14 @@ public:
             const register_format result_lo       = (register_format)(multiply_result & lo_mask);
             const register_format result_hi       = (register_format)(multiply_result >> (sizeof(register_format) * 8));
 
+            #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= 16) {
                 std::ostringstream ss;
                 ss << "-> Execute: 0x" << std::hex << getInstructionAddress() << std::dec << " " << getInstCode();
                 ss << " " << src_1 <<" * " << src_2 << " = "<< multiply_result << " = (lo: " << result_lo << ", hi: " << result_hi;
                 output->verbose( CALL_INFO, 16, 0, "%s\n", ss.str().c_str());
             }
+            #endif
 
             regFile->setIntReg<register_format>(phys_int_regs_out[0], result_lo);
             regFile->setIntReg<register_format>(phys_int_regs_out[1], result_hi);
@@ -103,12 +105,14 @@ public:
             const register_format result_lo       = (register_format)(multiply_result & lo_mask);
             const register_format result_hi       = (register_format)(multiply_result >> (sizeof(register_format) * 8));
 
+            #ifdef VANADIS_BUILD_DEBUG
             if(output->getVerboseLevel() >= 16) {
                 std::ostringstream ss;
                 ss << "-> Execute: 0x" << std::hex << getInstructionAddress() << std::dec << " " << getInstCode();
                 ss << " " << src_1 <<" * " << src_2 << " = "<< multiply_result << " = (lo: " << result_lo << ", hi: " << result_hi;
                 output->verbose( CALL_INFO, 16, 0, "%s\n", ss.str().c_str());
             }
+            #endif
 
             regFile->setIntReg<register_format>(phys_int_regs_out[0], result_lo);
             regFile->setIntReg<register_format>(phys_int_regs_out[1], result_hi);

--- a/src/sst/elements/vanadis/inst/vori.h
+++ b/src/sst/elements/vanadis/inst/vori.h
@@ -82,7 +82,9 @@ public:
 
 
         instOp(regFile,phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0,phys_int_regs_in_0,0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vpartialload.h
+++ b/src/sst/elements/vanadis/inst/vpartialload.h
@@ -84,8 +84,8 @@ public:
 
     void computeLoadAddress(SST::Output* output, VanadisRegisterFile* regFile, uint64_t* out_addr, uint16_t* width) override
     {
-        const uint64_t mem_addr_reg_val = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
         #ifdef VANADIS_BUILD_DEBUG
+        const uint64_t mem_addr_reg_val = regFile->getIntReg<uint64_t>(phys_int_regs_in[0]);
         if(output->getVerboseLevel() >= 16) {
             output->verbose(
                 CALL_INFO, 16, 0, "[execute-partload]: reg[%5" PRIu16 "]: %" PRIu64 " / 0x%" PRI_ADDR "\n", phys_int_regs_in[0],

--- a/src/sst/elements/vanadis/inst/vpcaddi.h
+++ b/src/sst/elements/vanadis/inst/vpcaddi.h
@@ -86,7 +86,9 @@ public:
 
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile, phys_int_regs_out_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vscmp.h
+++ b/src/sst/elements/vanadis/inst/vscmp.h
@@ -81,7 +81,10 @@ public:
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_in_1 = getPhysIntRegIn(1);
+
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0,phys_int_regs_in_0,phys_int_regs_in_1);
+        #endif
         instOp(output, regFile,phys_int_regs_out_0, phys_int_regs_in_0, phys_int_regs_in_1);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vscmpi.h
+++ b/src/sst/elements/vanadis/inst/vscmpi.h
@@ -96,7 +96,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(output, regFile, phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_int_regs_in_0,0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vsetreg.h
+++ b/src/sst/elements/vanadis/inst/vsetreg.h
@@ -74,7 +74,9 @@ public:
     virtual void scalarExecute(SST::Output* output, VanadisRegisterFile* regFile) override
     {
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0);
+        #endif
         instOp(regFile,phys_int_regs_out_0);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vsetregcallable.h
+++ b/src/sst/elements/vanadis/inst/vsetregcallable.h
@@ -74,7 +74,9 @@ public:
     {
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile,phys_int_regs_out_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0);
+        #endif
         markExecuted();
     }
 private:

--- a/src/sst/elements/vanadis/inst/vslli.h
+++ b/src/sst/elements/vanadis/inst/vslli.h
@@ -100,7 +100,9 @@ public:
     {
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535,phys_int_regs_out_0,phys_int_regs_in_0);
+        #endif
         instOp(regFile,phys_int_regs_out_0, phys_int_regs_in_0);
         markExecuted();
     }

--- a/src/sst/elements/vanadis/inst/vsrai.h
+++ b/src/sst/elements/vanadis/inst/vsrai.h
@@ -110,7 +110,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile, phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vsrli.h
+++ b/src/sst/elements/vanadis/inst/vsrli.h
@@ -120,7 +120,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile, phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/inst/vstore.h
+++ b/src/sst/elements/vanadis/inst/vstore.h
@@ -142,6 +142,7 @@ public:
         (*store_addr) = (uint64_t)(reg_tmp + offset);
         (*op_width)   = store_width;
 
+        #ifdef VANADIS_BUILD_DEBUG
         switch ( regType ) {
         case STORE_INT_REGISTER:
         {
@@ -162,6 +163,8 @@ public:
                 (*store_addr));
         } break;
         }
+        #endif
+
     }
 
     uint16_t getStoreWidth() const { return store_width; }

--- a/src/sst/elements/vanadis/inst/vxori.h
+++ b/src/sst/elements/vanadis/inst/vxori.h
@@ -79,7 +79,9 @@ public:
         uint16_t phys_int_regs_in_0 = getPhysIntRegIn(0);
         uint16_t phys_int_regs_out_0 = getPhysIntRegOut(0);
         instOp(regFile, phys_int_regs_out_0, phys_int_regs_in_0);
+        #ifdef VANADIS_BUILD_DEBUG
         log(output, 16, 65535, phys_int_regs_out_0, phys_int_regs_in_0);
+        #endif
         markExecuted();
     }
 

--- a/src/sst/elements/vanadis/lsq/vlsq.h
+++ b/src/sst/elements/vanadis/lsq/vlsq.h
@@ -61,8 +61,10 @@ public:
         std::string prefix = "[lsq " + getName() + " !t]: ";
         output = new SST::Output(prefix, verbosity, mask, SST::Output::STDOUT);
 
+        #ifdef VANADIS_BUILD_DEBUG
         setDbgInsAddrs( params.find<std::string>("dbgInsAddrs", "") );
         setDbgAddrs( params.find<std::string>("dbgAddrs", "") );
+        #endif
 
         core_id = coreid;
         hw_threads = hwthreads;
@@ -72,8 +74,10 @@ public:
     virtual ~VanadisLoadStoreQueue() { delete output; }
 
     void setRegisterFiles(std::vector<VanadisRegisterFile*>* reg_f) {
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 8, 0, "Setting register files (%" PRIu32 " register files in set)\n",
                         (uint32_t)reg_f->size());
+        #endif
         assert(reg_f != nullptr);
 
         registerFiles = reg_f;

--- a/src/sst/elements/vanadis/os/include/virtMemMap.cc
+++ b/src/sst/elements/vanadis/os/include/virtMemMap.cc
@@ -307,9 +307,18 @@ uint64_t VirtMemMap::addRegion(
     std::fflush(stdout);
 
     if ( start ) {
-        assert( free_list_->alloc( start, length ) );
+        if ( !free_list_->alloc( start, length ) ) {
+            printf("Error: %s, unable to allocate a block for addr=%#" PRIx64 " size=%zu\n", name.c_str(), start, length );
+            std::fflush(stdout);
+            assert(0);
+        }
     } else {
-        assert( start = free_list_->alloc( length ) );
+        start = free_list_->alloc( length );
+        if (! start ) {
+            printf("Error: %s, unable to allocate a block of size=%zu\n", name.c_str(), length);
+            std::fflush(stdout);
+            assert(start);
+        }
     }
 
     region_map_[start] = new MemoryRegion( name, start, length, perms, backing );

--- a/src/sst/elements/vanadis/os/syscall/access.h
+++ b/src/sst/elements/vanadis/os/syscall/access.h
@@ -27,14 +27,17 @@ public:
     VanadisAccessSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallAccessEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "access" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-access] access( 0x%" PRI_ADDR ", %" PRIu64 " )\n", event->getPathPointer(), event->getAccessMode());
+        #endif
 
         readString(event->getPathPointer(),m_filename);
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "-> [syscall-access] path is: \"%s\"\n", m_filename.c_str());
-
+        #endif
         int ret = access( m_filename.c_str(), getEvent<VanadisSyscallAccessEvent*>()->getAccessMode() );
         if ( ret ) {
             setReturnFail( -errno );

--- a/src/sst/elements/vanadis/os/syscall/brk.h
+++ b/src/sst/elements/vanadis/os/syscall/brk.h
@@ -30,18 +30,22 @@ public:
         uint64_t brk = process->getBrk();
         if (event->getUpdatedBRK() < brk) {
 
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
                                 "[syscall-brk]: brk provided (0x%" PRI_ADDR ") is less than existing brk "
                                 "point (0x%" PRI_ADDR "), so returning current brk point\n",
                                 event->getUpdatedBRK(), brk);
+            #endif
         } else {
             if ( ! process->setBrk( event->getUpdatedBRK() ) ) {
                 m_output->fatal(CALL_INFO, -1, "-> error: brk() %#" PRIx64 " ran out of memory\n",event->getUpdatedBRK());
             }
 
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
                                 "[syscall-brk] old brk: 0x%" PRI_ADDR " -> new brk: 0x%" PRI_ADDR " (diff: %" PRIu64 ")\n", brk,
                                 event->getUpdatedBRK(), (event->getUpdatedBRK() - brk));
+            #endif
             process->printRegions( "after brk" );
         }
 

--- a/src/sst/elements/vanadis/os/syscall/clone3.cc
+++ b/src/sst/elements/vanadis/os/syscall/clone3.cc
@@ -39,10 +39,11 @@ using namespace SST::Vanadis;
 VanadisClone3Syscall::VanadisClone3Syscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallClone3Event* event )
         : VanadisSyscall( os, coreLink, process, event, "clone3" )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->debug(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
         "[syscall-clone3] cloneArgsAddr=%#" PRIx64 " size=%" PRIu64 "\n",
         event->getCloneArgsAddr(), event->getCloneArgsSize());
-
+    #endif
     if ( event->getOSBitType() == VanadisOSBitType::VANADIS_OS_32B ) {
         m_output->fatal(CALL_INFO, -1, "Error: clone3 is not support for 32b systems\n");
     }
@@ -67,8 +68,9 @@ void VanadisClone3Syscall::handleEvent( VanadisCoreEvent* ev )
     auto resp = dynamic_cast<VanadisGetThreadStateResp*>( ev );
     assert(resp);
 
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone3] got thread state response\n");
-
+    #endif
     _VanadisStartThreadBaseReq* req;
 
     if ( exit_signal_ == VANADIS_LINUX_SIGCHLD ) {
@@ -80,8 +82,10 @@ void VanadisClone3Syscall::handleEvent( VanadisCoreEvent* ev )
     req->setIntRegs( resp->intRegs );
     req->setFpRegs( resp->fpRegs );
 
-     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone3] core=%d thread=%d tid=%d instPtr=%" PRI_ADDR "\n",
-                 hw_thread_id_->core, hw_thread_id_->hwThread, new_thread_->gettid(), resp->getInstPtr() );
+    #ifdef VANADIS_BUILD_DEBUG
+    m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone3] core=%d thread=%d tid=%d instPtr=%" PRI_ADDR "\n",
+                hw_thread_id_->core, hw_thread_id_->hwThread, new_thread_->gettid(), resp->getInstPtr() );
+    #endif
 
     m_os->sendEvent( hw_thread_id_->core, req );
 
@@ -164,8 +168,10 @@ void VanadisClone3Syscall::parseCloneArgs(VanadisSyscallClone3Event* event)
     new_thread_->setHwThread( *hw_thread_id_ );
     m_os->setThread( new_thread_->gettid(), new_thread_ );
 
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "[syscall-clone3] newthread pid=%d tid=%d ppid=%d numThreads=%d\n",
             new_thread_->getpid(), new_thread_->gettid(), new_thread_->getppid(), new_thread_->numThreads() );
+    #endif
 
     m_os->setProcess( hw_thread_id_->core, hw_thread_id_->hwThread, new_thread_ );
     m_os->getMMU()->setCoreToPageTable( hw_thread_id_->core, hw_thread_id_->hwThread, new_thread_->getpid() );
@@ -176,7 +182,9 @@ void VanadisClone3Syscall::parseCloneArgs(VanadisSyscallClone3Event* event)
 // State 2: Handle the VANADIS_LINUX_CLONE_PARENT_SETTID flag
 void VanadisClone3Syscall::setTidAtParent(VanadisSyscallClone3Event* event)
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,"setTidAddress %#" PRIx64 " \n", child_tid_);
+    #endif
     new_thread_->setTidAddress( child_tid_ );
 
     // this code could be collapsed
@@ -186,8 +194,10 @@ void VanadisClone3Syscall::setTidAtParent(VanadisSyscallClone3Event* event)
     buffer_.resize(sizeof(uint32_t));
     *((uint32_t*)buffer_.data()) = new_thread_->gettid();
 
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,"PARENT_SETTID addr %#" PRIx64 " tid=%d\n",
         parent_tid_,  new_thread_->gettid());
+    #endif
 
     writeMemory( parent_tid_, buffer_ );
     state_ = State::ChildSetTid;
@@ -196,6 +206,8 @@ void VanadisClone3Syscall::setTidAtParent(VanadisSyscallClone3Event* event)
 // State 3: Finish up and return
 void VanadisClone3Syscall::finish(VanadisSyscallClone3Event* event)
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL, "\n");
+    #endif
     sendNeedThreadState();
 }

--- a/src/sst/elements/vanadis/os/syscall/close.h
+++ b/src/sst/elements/vanadis/os/syscall/close.h
@@ -27,7 +27,9 @@ public:
     VanadisCloseSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallCloseEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "close" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-close] -> call is close( %" PRIu32 " )\n", event->getFileDescriptor());
+        #endif
 
         auto retval = process->closeFile( event->getFileDescriptor() );
         if ( retval < 0 ) {

--- a/src/sst/elements/vanadis/os/syscall/exit.cc
+++ b/src/sst/elements/vanadis/os/syscall/exit.cc
@@ -26,7 +26,9 @@ using namespace SST::Vanadis;
 VanadisExitSyscall::VanadisExitSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallExitEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "exit" )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL, "[syscall-exit] core %d thread %d process %d\n",event->getCoreID(), event->getThreadID(), process->getpid() );
+    #endif
 
     if ( m_os->getNodeNum() >= 0 ) {
         printf("node=%d pid=%d tid=%d has exited\n", m_os->getNodeNum(), process->getpid(), process->gettid());

--- a/src/sst/elements/vanadis/os/syscall/exitgroup.cc
+++ b/src/sst/elements/vanadis/os/syscall/exitgroup.cc
@@ -25,9 +25,10 @@ using namespace SST::Vanadis;
 VanadisExitGroupSyscall::VanadisExitGroupSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallExitGroupEvent* event )
     : VanadisSyscall( os, coreLink, process, event, "exitgroup" )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, 0, "[syscall-exitgroup] core=%d thread=%d tid=%d pid=%d exit_code=%" PRIu64 "\n",
             event->getCoreID(), event->getThreadID(), process->gettid(), process->getpid(), event->getExitCode() );
-
+    #endif
     // given we are terminating all threads in the group, I'm assuming we don't have to write 0 to the tidAddress
 
     auto threads = process->getThreadList();

--- a/src/sst/elements/vanadis/os/syscall/fork.cc
+++ b/src/sst/elements/vanadis/os/syscall/fork.cc
@@ -23,7 +23,9 @@ using namespace SST::Vanadis;
 VanadisForkSyscall::VanadisForkSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallForkEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "fork" )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, 0, "[syscall-fork]\n");
+    #endif
 
     // get a new hwThread to run the new process on
     m_threadID = m_os->allocHwThread();
@@ -65,7 +67,10 @@ void VanadisForkSyscall::handleEvent( VanadisCoreEvent* ev )
 {
     auto resp = dynamic_cast<VanadisGetThreadStateResp*>( ev );
     assert(resp);
+
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, 0, "[syscall-fork] got thread state response\n");
+    #endif
 
     VanadisStartThreadForkReq* req = new VanadisStartThreadForkReq( m_threadID->hwThread, resp->getInstPtr(), resp->getTlsPtr() );
     req->setIntRegs( resp->intRegs );

--- a/src/sst/elements/vanadis/os/syscall/fstat.h
+++ b/src/sst/elements/vanadis/os/syscall/fstat.h
@@ -67,8 +67,9 @@ public:
     VanadisFstatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallFstatEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "fstat" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
 	    m_output->verbose(CALL_INFO, 16, 0, "-> call is fstat( %d, 0x%0" PRI_ADDR " )\n", event->getFileHandle(), event->getStructAddress());
-
+        #endif
         setReturnFail(-LINUX_EINVAL);
 
  #if 0

--- a/src/sst/elements/vanadis/os/syscall/fstatat.h
+++ b/src/sst/elements/vanadis/os/syscall/fstatat.h
@@ -72,9 +72,10 @@ public:
     VanadisFstatatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallFstatAtEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "fstatat" ), m_state( READ )
     {
+        #ifdef VANADIS_BUILD_DEBUG
 	    m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-fstatat] dirfd=%" PRIu64 " pathaname=%#" PRIx64 " statbuf=%#" PRIx64 " flags=%#" PRIx64 "\n",
                 event->getDirfd(), event->getPathname(), event->getStatbuf(), event->getFlags() );
-
+        #endif
         setReturnFail(-LINUX_EINVAL);
 #if 0
         assert( event->getFlags() == VANDAID_AT_EMPTY_PATH );

--- a/src/sst/elements/vanadis/os/syscall/getaffinity.h
+++ b/src/sst/elements/vanadis/os/syscall/getaffinity.h
@@ -27,9 +27,10 @@ public:
     VanadisGetaffinitySyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetaffinityEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "getaffinity" ), m_cpusetSize(event->getCpusetsize())
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-getaffinity] uname pid=%" PRIu64 " cpusetsize=%" PRIu64 " maskAddr=%#" PRIx64 "\n",
                                             event->getPid(), event->getCpusetsize(), event->getMaskAddr());
-
+        #endif
         m_mask.resize(m_cpusetSize, 0);
         std::vector<uint8_t> affinity = m_process->getAffinity();
         m_mask.assign(affinity.begin(), affinity.end());

--- a/src/sst/elements/vanadis/os/syscall/getcpu.h
+++ b/src/sst/elements/vanadis/os/syscall/getcpu.h
@@ -27,7 +27,9 @@ public:
     VanadisGetcpuSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetxEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "getcpu" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-getcpu] cpu=%u hwThread=%u\n",process->getCore(),process->getHwThread());
+        #endif
 
         uint32_t logicalCore = process->getCore() * os->getNumHwThreads() + process->getHwThread();
         setReturnSuccess(logicalCore);

--- a/src/sst/elements/vanadis/os/syscall/getpgid.h
+++ b/src/sst/elements/vanadis/os/syscall/getpgid.h
@@ -27,7 +27,9 @@ public:
     VanadisGetpgidSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetxEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "getpgid" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-getpgid]\n");
+        #endif
         setReturnSuccess(process->getpgid());
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/getpid.h
+++ b/src/sst/elements/vanadis/os/syscall/getpid.h
@@ -27,7 +27,9 @@ public:
     VanadisGetpidSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetxEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "getpid" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-getpid] pid=%d\n",process->getpid());
+        #endif
         setReturnSuccess(process->getpid());
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/getppid.h
+++ b/src/sst/elements/vanadis/os/syscall/getppid.h
@@ -27,7 +27,9 @@ public:
     VanadisGetppidSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetxEvent* event  )
         : VanadisSyscall( os, coreLink, process, event, "getppid" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-getppid]\n");
+        #endif
         setReturnSuccess(process->getppid());
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/getrandom.h
+++ b/src/sst/elements/vanadis/os/syscall/getrandom.h
@@ -29,8 +29,10 @@ public:
     VanadisGetrandomSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetrandomEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "getrandom" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-getrandom] buf=%#" PRIx64 " buflen=%" PRIu64 " flags=%#" PRIx64 "\n",
             event->getBuf(),event->getBuflen(),event->getFlags());
+        #endif
 
         payload.resize( event->getBuflen() );
 

--- a/src/sst/elements/vanadis/os/syscall/gettid.h
+++ b/src/sst/elements/vanadis/os/syscall/gettid.h
@@ -27,7 +27,9 @@ public:
     VanadisGettidSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallGetxEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "gettid" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-gettid] pid=%d tid=%d\n",process->getpid(),process->gettid());
+        #endif
         setReturnSuccess(process->gettid());
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/gettime.h
+++ b/src/sst/elements/vanadis/os/syscall/gettime.h
@@ -30,10 +30,11 @@ public:
         uint64_t sim_seconds = (uint64_t)(sim_time_ns / 1000000000ULL);
         uint32_t sim_ns = (uint32_t)(sim_time_ns % 1000000000ULL);
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,
                             "[syscall-gettime64] --> sim-time: %" PRIu64 " ns -> %" PRIu64 " secs + %" PRIu32 " us\n",
                             sim_time_ns, sim_seconds, sim_ns);
-
+        #endif
 
         if ( VanadisOSBitType::VANADIS_OS_64B == event->getOSBitType() ) {
             payload.resize( 16 );

--- a/src/sst/elements/vanadis/os/syscall/ioctl.h
+++ b/src/sst/elements/vanadis/os/syscall/ioctl.h
@@ -27,13 +27,14 @@ public:
     VanadisIoctlSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallIoctlEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "ioctl" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
                             "[syscall-ioctl] ioctl( %" PRId64 ", r: %c / w: %c / ptr: 0x%" PRI_ADDR " / size: %" PRIu64
                             " / op: %" PRIu64 " / drv: %" PRIu64 " )\n",
                             event->getFileDescriptor(), event->isRead() ? 'y' : 'n',
                             event->isWrite() ? 'y' : 'n', event->getDataPointer(), event->getDataLength(),
                             event->getIOOperation(), event->getIODriver());
-
+        #endif
         setReturnFail(-LINUX_ENOTTY );
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/kill.h
+++ b/src/sst/elements/vanadis/os/syscall/kill.h
@@ -27,6 +27,7 @@ public:
     VanadisKillSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallKillEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "kill" )
     {
+        // TODO kill running process and shutdown gracefully
         m_output->verbose(CALL_INFO, 0, 0, "[syscall-kill] ---> pid=%" PRIu64 " sig=%" PRIu64 "\n", event->getPid(), event->getSig() );
         assert(0);
     }

--- a/src/sst/elements/vanadis/os/syscall/lseek.h
+++ b/src/sst/elements/vanadis/os/syscall/lseek.h
@@ -27,8 +27,10 @@ public:
     VanadisLseekSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallLseekEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "lseek" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-lseek] -> call is lseek( %" PRId32 " %" PRId64 " %" PRId32 " )\n",
                 event->getFileDescriptor(), event->getOffset(), event->getWhence() );
+        #endif
 
         int fd = process->getFileDescriptor( event->getFileDescriptor() );
         if ( -1 == fd ) {
@@ -41,7 +43,9 @@ public:
          } else {
 
             off_t ret = lseek( fd, (off_t) event->getOffset(), (int) event->getWhence() );
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-lseek] ret=%" PRIu64 "\n",ret );
+            #endif
             if ( -1 == ret  ) {
                 // need to map host errno values to vanadis exe errno values
                 assert(0);

--- a/src/sst/elements/vanadis/os/syscall/mmap.h
+++ b/src/sst/elements/vanadis/os/syscall/mmap.h
@@ -37,9 +37,11 @@ public:
         uint64_t call_stack = event->getStackPointer();
         uint64_t offset_units = event->getOffsetUnits();
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-mmap] addr=%#" PRIx64 " length=%#" PRIx64 " prot=%#" PRIx64 " flags=%#" PRIx64
                 " fd=%d offset=%" PRIu64 " call_stack=%#" PRIx64 " offset_units=%" PRIu64 "\n",
                     address,length,protect,flags,fd,offset,call_stack,offset_units);
+        #endif
 
         // if that stackAddr is valid  we need to get mmap() arguments that are not in registers
         if ( event->getStackPointer() ) {

--- a/src/sst/elements/vanadis/os/syscall/mprotect.cc
+++ b/src/sst/elements/vanadis/os/syscall/mprotect.cc
@@ -23,8 +23,10 @@ using namespace SST::Vanadis;
 VanadisMprotectSyscall::VanadisMprotectSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallMprotectEvent* event)
     : VanadisSyscall( os, coreLink, process, event, "mprotect" )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-mprotect] core %d thread %d process %d addr=%" PRIx64 " len=%" PRIu64 " prot=%#" PRIx64 "\n",
             event->getCoreID(), event->getThreadID(), process->getpid(), event->getAddr(), event->getLen(), event->getProt() );
+    #endif
 
     int perms = 0;
     if ( event->getProt() & PROT_READ ) {

--- a/src/sst/elements/vanadis/os/syscall/open.h
+++ b/src/sst/elements/vanadis/os/syscall/open.h
@@ -27,20 +27,28 @@ public:
     VanadisOpenSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallOpenEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "open" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-open] -> call is open( %" PRId64 " )\n", event->getPathPointer());
+        #endif
 
         readString(event->getPathPointer(),m_filename);
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-open] path: \"%s\"\n", m_filename.c_str());
+        #endif
 
         int fd = m_process->openFile( m_filename.c_str(), getEvent<VanadisSyscallOpenEvent*>()->getFlags(), getEvent<VanadisSyscallOpenEvent*>()->getMode() );
         if ( fd < 0 ) {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-open] open of %s failed\n", m_filename.c_str() );
+            #endif
             setReturnFail(fd);
         }else{
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-open] open of %s succeeded\n", m_filename.c_str() );
+            #endif
             setReturnSuccess(fd);
         }
     }

--- a/src/sst/elements/vanadis/os/syscall/openat.h
+++ b/src/sst/elements/vanadis/os/syscall/openat.h
@@ -27,7 +27,9 @@ public:
     VanadisOpenatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallOpenatEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "openat" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-openat] -> call is openat( %" PRId64 " )\n", event->getPathPointer());
+        #endif
 
         m_dirFd  = event->getDirectoryFileDescriptor();
         // if the directory fd passed by the syscall is positive it should point to a entry in the file_descriptor table
@@ -41,17 +43,22 @@ public:
                 return;
             }
             // get the FD that SST will use
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "sst fd=%d pathname=%s\n", m_dirFd, process->getFilePath(m_dirFd).c_str());
+            #endif
         }
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-openat] -> call is openat( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                 event->getDirectoryFileDescriptor(), event->getPathPointer(), event->getFlags());
-
+        #endif
         readString(event->getPathPointer(),m_filename);
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-openat] path: \"%s\"\n", m_filename.c_str());
+        #endif
 
         int fd = m_process->openFile( m_filename.c_str(), m_dirFd, getEvent<VanadisSyscallOpenatEvent*>()->getFlags(), getEvent<VanadisSyscallOpenatEvent*>()->getMode() );
 
@@ -68,7 +75,9 @@ public:
 #else
             str = strerror_r(myErrno,buf,100);
 #endif
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-openat] open of %s failed, errno=%d `%s`\n", m_filename.c_str(), myErrno, str );
+            #endif
 
             setReturnFail( -myErrno );
         } else {

--- a/src/sst/elements/vanadis/os/syscall/prlimit.h
+++ b/src/sst/elements/vanadis/os/syscall/prlimit.h
@@ -35,9 +35,10 @@ public:
     VanadisPrlimitSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallPrlimitEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "prlimit" ), m_state( READ )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-prlimit] pid=%" PRIu64 " resource=%" PRIu64 " new_limit=%#" PRIx64 " old_limit=%#" PRIx64 "\n",
             event->getPid(),event->getResource(),event->getNewLimit(),event->getOldLimit());
-
+        #endif
         assert( event->getResource() == VANADIS_RLIMIT_STACK );
 
         payload.resize( sizeof( struct vanadis_rlimit ) );

--- a/src/sst/elements/vanadis/os/syscall/read.h
+++ b/src/sst/elements/vanadis/os/syscall/read.h
@@ -27,9 +27,10 @@ public:
     VanadisReadSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallReadEvent* event  )
         : VanadisSyscall( os, coreLink, process, event, "read" ), m_numRead(0), m_eof(false)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "-> call is read( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                             event->getFileDescriptor(), event->getBufferAddress(), event->getBufferCount());
-
+        #endif
         m_fd = process->getFileDescriptor( event->getFileDescriptor());
         if (-1 == m_fd ) {
             m_output->verbose(CALL_INFO, 16, 0,
@@ -52,7 +53,9 @@ public:
 
         m_data.resize(length);
         ssize_t retval = read( m_fd, m_data.data(), length );
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,"SST %zu = read( %d, %zu)\n",retval,m_fd,length);
+        #endif
         assert(retval>=0);
 
         if ( retval ) {
@@ -63,7 +66,9 @@ public:
             m_numRead += retval;
 
             if ( retval < length ) {
+                #ifdef VANADIS_BUILD_DEBUG
                 m_output->verbose(CALL_INFO, 16, 0,"read EOF\n");
+                #endif
                 m_eof = true;
             }
         } else {

--- a/src/sst/elements/vanadis/os/syscall/readlink.h
+++ b/src/sst/elements/vanadis/os/syscall/readlink.h
@@ -27,17 +27,20 @@ public:
     VanadisReadlinkSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallReadLinkEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "readlink" ), m_data( event->getBufferSize() ), m_done(false)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-readlink] -> readlink( 0x%0" PRI_ADDR ", 0x%" PRI_ADDR ", %" PRId64 " )\n",
                                 event->getPathPointer(), event->getBufferPointer(),
                                 event->getBufferSize());
-
+        #endif
         readString(event->getPathPointer(),m_filename);
     }
 
     void memReqIsDone(bool) {
         if ( ! m_done ) {
             m_done = true;
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-readlink] path: \"%s\"\n", m_filename.c_str());
+            #endif
 
             int ret = readlink( m_filename.c_str(), (char*) m_data.data(), m_data.size() );
             if ( -1 == ret ) {

--- a/src/sst/elements/vanadis/os/syscall/readlinkat.h
+++ b/src/sst/elements/vanadis/os/syscall/readlinkat.h
@@ -27,8 +27,10 @@ public:
     VanadisReadlinkatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallReadLinkAtEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "readlinkat" ), m_data( event->getBufsize()), m_state(READ)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-readlinkat] -> readlinkat( dirfd=%" PRIu64 " pathname=%#" PRIx64 " buf=%#" PRIx64 " size=%" PRIu64 ")\n",
                                 event->getDirfd(), event->getPathname(), event->getBuf(), event->getBufsize());
+        #endif
 
         m_dirFd  = event->getDirfd();
         // if the directory fd passed by the syscall is positive it should point to a entry in the file_descriptor table

--- a/src/sst/elements/vanadis/os/syscall/readv.h
+++ b/src/sst/elements/vanadis/os/syscall/readv.h
@@ -30,7 +30,9 @@ public:
     { }
 
     void startIoVecTransfer() {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,"\n");
+        #endif
         m_currentVecOffset = 0;
         readSomeData();
     }
@@ -38,7 +40,9 @@ public:
     void readSomeData() {
         m_dataBuffer.resize( calcBuffSize() );
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,"%zu\n", m_dataBuffer.size());
+        #endif
 
         ssize_t numRead = read( m_fd, m_dataBuffer.data(), m_dataBuffer.size());
         assert( numRead >= 0 );
@@ -47,11 +51,15 @@ public:
         // if we have not filled the vector and have not hit EOF
         if ( numRead < m_dataBuffer.size() ) {
             m_eof = true;
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0,"reached EOF %zu\n",m_totalBytes);
+            #endif
         }
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,"numRead=%zu totalWritten=%zu currentVecOffset=%zu vecLength=%zu\n",
             numRead,m_totalBytes, m_currentVecOffset, m_ioVecTable->getLength(m_currentVec));
+        #endif
 
         writeMemory( m_ioVecTable->getAddr(m_currentVec) +  m_currentVecOffset, m_dataBuffer );
 
@@ -61,18 +69,26 @@ public:
     void ioVecWork() {
 
         if ( m_eof ) {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0,"return success total written %zu\n",m_totalBytes);
+            #endif
             setReturnSuccess( m_totalBytes );
         } else if ( m_currentVecOffset < m_ioVecTable->getLength(m_currentVec) ) {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0,"read %zu bytes\n",m_dataBuffer.size());
+            #endif
             readSomeData();
         } else {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0,"vector %d is complete \n",m_currentVec);
+            #endif
             ++m_currentVec;
             if ( findNonZeroIoVec() ) {
                 startIoVecTransfer();
             } else {
+                #ifdef VANADIS_BUILD_DEBUG
                 m_output->verbose(CALL_INFO, 16, 0,"return success total written %zu\n",m_totalBytes);
+                #endif
                 setReturnSuccess( m_totalBytes );
             }
         }

--- a/src/sst/elements/vanadis/os/syscall/schedyield.h
+++ b/src/sst/elements/vanadis/os/syscall/schedyield.h
@@ -31,8 +31,10 @@ public:
     : VanadisSyscall(os, coreLink, process, event, "sched_yield")
     {
         // No arguments to decode
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,
             "[syscall-sched_yield] -> sched_yield()\n");
+        #endif
         setReturnSuccess(0);
     }
 };

--- a/src/sst/elements/vanadis/os/syscall/setaffinity.h
+++ b/src/sst/elements/vanadis/os/syscall/setaffinity.h
@@ -31,8 +31,10 @@ public:
         VanadisSyscallSetaffinityEvent* event )
     : VanadisSyscall(os, coreLink, process, event, "setaffinity")
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-setaffinity] pid=%" PRIu64 " cpusetsize=%" PRIu64 " maskAddr=%#" PRIx64 "\n",
                                       event->getPid(), event->getCpusetsize(), event->getMaskAddr());
+        #endif
 
         // Load the CPU mask from memory
         m_mask.resize(event->getCpusetsize(), 0);

--- a/src/sst/elements/vanadis/os/syscall/setrobustlist.h
+++ b/src/sst/elements/vanadis/os/syscall/setrobustlist.h
@@ -27,8 +27,9 @@ public:
     VanadisSetRobustListSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallSetRobustListEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "set_robust_list" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-set_robust_list] head %#" PRIx64 ", len=%" PRIu64 "\n", event->getHead(),event->getLen());
-
+        #endif
 //        process->setRobustList( event->getRobustList() );
 
         setReturnSuccess(0);

--- a/src/sst/elements/vanadis/os/syscall/settidaddress.h
+++ b/src/sst/elements/vanadis/os/syscall/settidaddress.h
@@ -27,8 +27,9 @@ public:
     VanadisSetTidAddressSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallSetTidAddressEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "set_tid_address" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL, "[syscall-set_tid_address] address %#" PRIx64 "\n", event->getTidAddress());
-
+        #endif
         process->setTidAddress( event->getTidAddress() );
 
         setReturnSuccess(0);

--- a/src/sst/elements/vanadis/os/syscall/statx.h
+++ b/src/sst/elements/vanadis/os/syscall/statx.h
@@ -27,8 +27,10 @@ public:
     VanadisStatxSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallStatxEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "statx" )
     {
+    #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-statx] -> dirFd=%#" PRIx64 " pathPtr=%#" PRIx64 ", flags=%#" PRIx64 ", mask=%#" PRIx32 ",stackPtr=%#" PRIx64 "\n",
             event->getDirectoryFileDescriptor(), event->getPathPointer(), event->getFlags(), event->getMask(), event->getStackPtr() );
+        #endif
 
         if ( AT_FDCWD == event->getDirectoryFileDescriptor() ) {
             m_output->fatal(CALL_INFO, -1, "Error: statx does not support AT_FDCWD\n");
@@ -38,7 +40,9 @@ public:
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-open] path: \"%s\"\n", m_filename.c_str());
+        #endif
 
         if ( 0 == m_filename.compare("") ) {
             m_output->fatal(CALL_INFO, -1, "Error: statx does not support use of path\n");

--- a/src/sst/elements/vanadis/os/syscall/syscall.cc
+++ b/src/sst/elements/vanadis/os/syscall/syscall.cc
@@ -33,13 +33,14 @@ VanadisSyscall::~VanadisSyscall() {
 
     resp->setHWThread( m_event->getThreadID() );
 
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 2, VANADIS_OS_DBG_SYSCALL,"syscall '%s' has finished, send response to core %d hwThead %d, %s, returnCode=%" PRIu64 "\n",
         getName().c_str(),
         m_event->getCoreID(),
         m_event->getThreadID(),
         resp->isSuccessful() ? "Success" : "Failed",
         resp->getReturnCode() );
-
+    #endif
     m_coreLink->send( resp );
 
     m_os->clearSyscall( getCoreId(), getThreadId() );

--- a/src/sst/elements/vanadis/os/syscall/syscall.h
+++ b/src/sst/elements/vanadis/os/syscall/syscall.h
@@ -157,12 +157,16 @@ private:
 
                     auto req =  new StandardMem::LoadLink( physAddr, length, 0, virtAddr, 0, 0 );
 
+                    #ifdef VANADIS_BUILD_DEBUG
                     obj->m_output->verbose(CALL_INFO, 16, 0, " %s\n",req->getString().c_str());
+                    #endif
                     return req;
                 } else {
 
                     auto req =  new StandardMem::Read( physAddr, length, 0, virtAddr, 0, 0 );
+                    #ifdef VANADIS_BUILD_DEBUG
                     obj->m_output->verbose(CALL_INFO, 16, 0, " %s\n",req->getString().c_str());
+                    #endif
                     return req;
                 }
             }
@@ -232,17 +236,23 @@ private:
             physAddr = m_process->virtToPhys( virtAddr );
         }
         if ( physAddr == -1 ) {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"physAddr not found for virtAddr=%#" PRIx64  "\n",virtAddr);
+            #endif
             m_pageFaultAddr = virtAddr;
             m_pageFaultIsWrite = isWrite;
+        #ifdef VANADIS_BUILD_DEBUG
         } else {
             m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"virtAddr %#" PRIx64 " -> physAddr %#" PRIx64 "\n",virtAddr,physAddr);
+        #endif
         }
         return physAddr;
     }
 
     StandardMem::Request* getMemoryRequest() {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0,"\n");
+        #endif
         StandardMem::Request* req = nullptr;
         if ( m_memHandler ) {
 
@@ -323,34 +333,43 @@ private:
 };
 
 inline void VanadisSyscall::readString( uint64_t addr, std::string& str ) {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"addr=%#" PRIx64 "\n",addr);
+    #endif
     assert(nullptr == m_memHandler);
     m_memHandler = new ReadStringHandler( this, m_output, addr, str );
 }
 
 inline void VanadisSyscall::readMemory( uint64_t addr, std::vector<uint8_t>& buffer, bool lock ) {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"addr=%#" PRIx64 " length=%zu\n", addr, buffer.size() );
+    #endif
     assert(nullptr == m_memHandler);
     m_memHandler = new ReadMemoryHandler( this, m_output, addr, buffer, lock );
 }
 
 inline void VanadisSyscall::writeMemory( uint64_t addr, std::vector<uint8_t>& buffer, OS::ProcessInfo* process ) {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"writeMemory addr=%#" PRIx64 " length=%zu\n", addr, buffer.size() );
+    #endif
     assert(nullptr == m_memHandler);
     m_memHandler = new WriteMemoryHandler( this, m_output, addr, buffer, false, process );
 }
 
 inline void VanadisSyscall::writeMemory( uint64_t addr, std::vector<uint8_t>& buffer, bool lock ) {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"writeMemory addr=%#" PRIx64 " length=%zu\n", addr, buffer.size() );
+    #endif
     assert(nullptr == m_memHandler);
     m_memHandler = new WriteMemoryHandler( this, m_output, addr, buffer, lock );
 }
 
 inline bool VanadisSyscall::handleMemRespBase( StandardMem::Request* req )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL, "recv memory event (%s)\n", req->getString().c_str());
     m_output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_SYSCALL,"m_pendingMem.size() %zu\n",m_pendingMem.size());
-
+    #endif
     auto find_event = m_pendingMem.find(req->getID());
 
     assert( find_event != m_pendingMem.end() );

--- a/src/sst/elements/vanadis/os/syscall/uname.h
+++ b/src/sst/elements/vanadis/os/syscall/uname.h
@@ -27,7 +27,9 @@ public:
     VanadisUnameSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallUnameEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "uname" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-uname] ---> uname struct is at address 0x%0" PRI_ADDR "\n", event->getUnameInfoAddress());
+        #endif
 
 #if 0
 struct new_utsname {

--- a/src/sst/elements/vanadis/os/syscall/unlink.h
+++ b/src/sst/elements/vanadis/os/syscall/unlink.h
@@ -27,14 +27,17 @@ public:
     VanadisUnlinkSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallUnlinkEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "unlink" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-unlink] -> call is unlink( %" PRId64 " )\n", event->getPathPointer());
+        #endif
 
         readString(event->getPathPointer(),filename);
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-unlink] path: \"%s\"\n", filename.c_str());
-
+        #endif
         if ( unlink( filename.c_str() ) ) {
             auto myErrno = errno;
             char buf[100];

--- a/src/sst/elements/vanadis/os/syscall/unlinkat.h
+++ b/src/sst/elements/vanadis/os/syscall/unlinkat.h
@@ -27,8 +27,9 @@ public:
     VanadisUnlinkatSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallUnlinkatEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "unlinkat" )
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-unlinkat] -> call is unlinkat( %" PRId64 " )\n", event->getPathPointer());
-
+        #endif
         m_dirFd  = event->getDirectoryFileDescriptor();
         // if the directory fd passed by the syscall is positive it should point to a entry in the file_descriptor table
         // if the directory fd is negative pass that to to the unlinkat handler ( AT_FDCWD is negative )
@@ -41,18 +42,22 @@ public:
                 return;
             }
             // get the FD that SST will use
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "sst fd=%d pathname=%s\n", m_dirFd, process->getFilePath(m_dirFd).c_str());
+            #endif
         }
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose( CALL_INFO, 16, 0, "[syscall-unlinkat] -> call is unlinkat( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                 event->getDirectoryFileDescriptor(), event->getPathPointer(), event->getFlags());
-
+        #endif
         readString(event->getPathPointer(),m_filename);
     }
 
     void memReqIsDone(bool) {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-unlinkat] path: \"%s\"\n", m_filename.c_str());
-
+        #endif
         if ( unlinkat( m_dirFd, m_filename.c_str(), getEvent<VanadisSyscallUnlinkatEvent*>()->getFlags() ) ) {
             auto myErrno = errno;
             char buf[100];
@@ -65,7 +70,9 @@ public:
 #else
             str = strerror_r(errno,buf,100);
 #endif
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 16, 0, "[syscall-unlinkat] unlink of %s failed, errno=%d `%s`\n", m_filename.c_str(), errno, str );
+            #endif
             setReturnFail( -myErrno );
         } else {
             setReturnSuccess(0);

--- a/src/sst/elements/vanadis/os/syscall/unmap.h
+++ b/src/sst/elements/vanadis/os/syscall/unmap.h
@@ -31,7 +31,9 @@ public:
         uint64_t address = event->getDeallocationAddress();
         uint64_t length = event->getDeallocationLength();
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-unmap] addr=%#" PRI_ADDR " length=%" PRIu64 "\n",address, length);
+        #endif
 
         auto threads = process->getThreadList();
         for ( const auto iter : threads) {

--- a/src/sst/elements/vanadis/os/syscall/write.h
+++ b/src/sst/elements/vanadis/os/syscall/write.h
@@ -27,9 +27,10 @@ public:
     VanadisWriteSyscall( VanadisNodeOSComponent* os, SST::Link* coreLink, OS::ProcessInfo* process, VanadisSyscallWriteEvent* event )
         : VanadisSyscall( os, coreLink, process, event, "write" ), m_numWritten(0)
     {
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 16, 0, "[syscall-write] -> call is write( %" PRId64 ", 0x%0" PRI_ADDR ", %" PRId64 " )\n",
                             event->getFileDescriptor(), event->getBufferAddress(), event->getBufferCount());
-
+        #endif
         m_fd = process->getFileDescriptor( event->getFileDescriptor());
         if ( -1 == m_fd ) {
             m_output->verbose(CALL_INFO, 16, 0,

--- a/src/sst/elements/vanadis/os/syscall/writev.h
+++ b/src/sst/elements/vanadis/os/syscall/writev.h
@@ -34,9 +34,10 @@ public:
         m_currentVecOffset = 0;
 
         m_dataBuffer.resize( calcBuffSize() );
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,
             "[syscall-writev] pos=%i length=%zu buffer length=%zu\n", m_currentVec, m_ioVecTable->getLength(m_currentVec)  ,m_dataBuffer.size());
-
+        #endif
         readMemory( m_ioVecTable->getAddr(m_currentVec), m_dataBuffer );
     }
 
@@ -46,21 +47,28 @@ public:
         m_totalBytes += numWritten;
         m_currentVecOffset += m_dataBuffer.size();
 
+        #ifdef VANADIS_BUILD_DEBUG
         m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,
             "[syscall-writev] numWriten=%zu totalWritten=%zu currentVecOffset=%zu vecLength=%zu\n",
             numWritten,m_totalBytes, m_currentVecOffset, m_ioVecTable->getLength(m_currentVec));
-
+        #endif
         if ( m_currentVecOffset < m_ioVecTable->getLength(m_currentVec)  ) {
             m_dataBuffer.resize( calcBuffSize() );
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,"[syscall-writev] read %zu bytes\n", m_dataBuffer.size());
+            #endif
             readMemory( m_ioVecTable->getAddr(m_currentVec) + m_currentVecOffset, m_dataBuffer );
         } else {
+            #ifdef VANADIS_BUILD_DEBUG
             m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,"[syscall-writev] vector %d is complete \n",m_currentVec);
+            #endif
             ++m_currentVec;
             if ( findNonZeroIoVec() ) {
                 startIoVecTransfer();
             } else {
+                #ifdef VANADIS_BUILD_DEBUG
                 m_output->verbose(CALL_INFO, 3, VANADIS_OS_DBG_SYSCALL,"[syscall-writev] return success total written %zu\n",m_totalBytes);
+                #endif
                 setReturnSuccess( m_totalBytes );
             }
         }

--- a/src/sst/elements/vanadis/os/vappruntimememory.h
+++ b/src/sst/elements/vanadis/os/vappruntimememory.h
@@ -62,7 +62,11 @@ class AppRuntimeMemory32 : public AppRuntimeMemory<uint32_t> {
   public:
     SST_ELI_REGISTER_MODULE(
         AppRuntimeMemory32,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
         "vanadis",
+    #endif
         "AppRuntimeMemory32",
         SST_ELI_ELEMENT_VERSION(1,0,0),
         "Application runtime memory loader for 32 OS",
@@ -76,7 +80,11 @@ class AppRuntimeMemory64 : public AppRuntimeMemory<uint64_t> {
   public:
     SST_ELI_REGISTER_MODULE(
         AppRuntimeMemory64,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
         "vanadis",
+    #endif
         "AppRuntimeMemory64",
         SST_ELI_ELEMENT_VERSION(1,0,0),
         "Application runtime memory loader for 64b OS",
@@ -139,8 +147,9 @@ uint64_t AppRuntimeMemory<Type>::configurePhdr(  Output* output, int page_size, 
 
         random_values_data_block.push_back('\0');
     }
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT,"phdr_address=%#" PRIx64 " length=%zu\n",phdr_address,phdr_data_block.size());
-
+    #endif
     // pad to full page
     phdr_data_block.insert( phdr_data_block.end(), page_size - (phdr_data_block.size() % page_size), 0 );
 
@@ -154,8 +163,9 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
 {
     Params& params = processInfo->getParams();
     auto elf_info = processInfo->getElfInfo();
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "Application Startup Processing %s bit\n",8 == sizeof(Type)? "64":"32");
-
+    #endif
     const uint32_t arg_count = params.find<uint32_t>("argc", 1);
     const uint32_t env_count = params.find<uint32_t>("env_count", 0);
 
@@ -169,7 +179,9 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
         if ( "" == arg_value ) {
             if ( 0 == arg ) {
                 arg_value = elf_info->getBinaryPathShort();
+                #ifdef VANADIS_BUILD_DEBUG
                 output->verbose(CALL_INFO, 8, VANADIS_OS_DBG_APP_INIT, "--> auto-set \"%s\" to \"%s\"\n", arg_name, arg_value.c_str());
+                #endif
             }
             else {
                 output->fatal(
@@ -180,7 +192,9 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
             }
         }
 
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Found %s = \"%s\"\n", arg_name, arg_value.c_str());
+        #endif
 
         uint8_t* arg_value_ptr = (uint8_t*)&arg_value.c_str()[0];
 
@@ -211,7 +225,9 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
                 env_var_name);
         }
 
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Found %s = \"%s\"\n", env_var_name, env_value.c_str());
+        #endif
 
         uint8_t* env_value_ptr = (uint8_t*)&env_value.c_str()[0];
 
@@ -365,6 +381,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
     // ints, so really div by 4
     const int aux_entry_count = aux_data_block.size() / sizeof(Type);
 
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Argument Count:                       %" PRIu32 "\n", arg_count);
     output->verbose(
             CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "---> Data Size for items:                %" PRIu32 "\n",
@@ -382,7 +399,7 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
     output->verbose(
             CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Setting SP to (not-aligned):          %" PRIu64 " / 0x%0" PRI_ADDR "\n", start_stack_address,
             start_stack_address);
-
+    #endif
     uint64_t arg_env_space_needed = 1 + arg_count + 1 + env_count + 1 + aux_entry_count;
     uint64_t arg_env_space_and_data_needed =
             (arg_env_space_needed * sizeof(Type)) + arg_data_block.size() + env_data_block.size() + aux_data_block.size();
@@ -391,36 +408,42 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
     const uint64_t padding_needed              = (aligned_start_stack_address % 64);
     aligned_start_stack_address                = aligned_start_stack_address - padding_needed;
 
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(
             CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT,
             "Aligning stack address to 64 bytes (%" PRIu64 " - %" PRIu64 " - padding: %" PRIu64 " = %" PRIu64
             " / 0x%0" PRI_ADDR ")\n",
             start_stack_address, (uint64_t)arg_env_space_and_data_needed, padding_needed, aligned_start_stack_address,
             aligned_start_stack_address);
-
+    #endif
     start_stack_address = aligned_start_stack_address;
 
     const uint64_t arg_env_data_start = start_stack_address + (arg_env_space_needed * sizeof(Type));
 
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Setting start of stack data to:       %#" PRIx64 "\n", arg_env_data_start );
+    #endif
 
     vanadis_vec_copy_in<Type>(stack_data, arg_count);
 
     for ( size_t i = 0; i < arg_start_offsets.size(); ++i ) {
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
                 CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting arg%" PRIu32 " to point to address %" PRIu64 " / 0x%" PRI_ADDR "\n", (uint32_t)i,
                 arg_env_data_start + arg_start_offsets[i], arg_env_data_start + arg_start_offsets[i]);
+        #endif
         vanadis_vec_copy_in<Type>(stack_data, (Type)(arg_env_data_start + arg_start_offsets[i]));
     }
 
     vanadis_vec_copy_in<Type>(stack_data, 0);
 
     for ( size_t i = 0; i < env_start_offsets.size(); ++i ) {
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(
                 CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "--> Setting env%" PRIu32 " to point to address %" PRIu64 " / 0x%" PRI_ADDR "\n", (uint32_t)i,
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i],
                 arg_env_data_start + arg_data_block.size() + env_start_offsets[i]);
-
+        #endif
         vanadis_vec_copy_in<Type>(
                 stack_data, (Type)(arg_env_data_start + arg_data_block.size() + env_start_offsets[i]));
     }
@@ -443,10 +466,11 @@ uint64_t AppRuntimeMemory<Type>::configureStack(  Output* output, int page_size,
         vanadis_vec_copy_in<uint8_t>(stack_data, (uint8_t)0);
     }
 
+    #ifdef VANADIS_BUILD_DEBUG
     output->verbose(
             CALL_INFO, 16, VANADIS_OS_DBG_APP_INIT, "-> Pushing %" PRIu64 " bytes to the start of stack (0x%" PRI_ADDR ") via memory init event..\n",
             (uint64_t)stack_data.size(), start_stack_address);
-
+    #endif
 #if 0  // PHDR
     output->verbose(CALL_INFO, 16, 0,"phdr_address=%#" PRIx64 " length=%zu\n",phdr_address,phdr_data_block.size());
 

--- a/src/sst/elements/vanadis/os/vloadpage.cc
+++ b/src/sst/elements/vanadis/os/vloadpage.cc
@@ -51,15 +51,18 @@ void loadPages( SST::Output* output, SST::Interfaces::StandardMem* mem_if, MMU_L
         std::vector< uint8_t > pageBuffer( buffer.begin() + offset, buffer.begin() + offset + page_size );
 #endif
 
-
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose( CALL_INFO, 2, 0, "pageVirtAddr=%#" PRIx64 " physPageNum=%d physAddr=%#" PRIx64 "\n", pageVirtAddr, physPageNum, physAddr );
+        #endif
 
 #if 1
         uint64_t offset = 0;
         for ( int num = 0; num < page_size/64; num++ ) {
             std::vector< uint8_t > tmp( buffer.begin() + offset, buffer.begin() + offset + 64  );
             Interfaces::StandardMem::Request* req = new SST::Interfaces::StandardMem::Write( physAddr + offset, tmp.size(), tmp );
+            #ifdef VANADIS_BUILD_DEBUG
             printf("%s() %s\n",__func__,req->getString().c_str());
+            #endif
             offset += 64;
             mem_if->send(req);
         }

--- a/src/sst/elements/vanadis/os/vmipscpuos.h
+++ b/src/sst/elements/vanadis/os/vmipscpuos.h
@@ -153,7 +153,9 @@ public:
         T1 buf_ptr    = getArgRegister(1);
         T1 size        = getArgRegister(2);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "readLink( %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 ")\n",path,buf_ptr,size);
+        #endif
         return new VanadisSyscallReadLinkEvent(core_id_, hw_thr, BitType, path, buf_ptr, size);
     }
 
@@ -161,8 +163,9 @@ public:
     VanadisSyscallEvent* UNLINK( int hw_thr ) {
         T1 path_addr = getArgRegister( 0 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "unlink( %" PRId32 " )\n",path_addr);
-
+        #endif
         return new VanadisSyscallUnlinkEvent(core_id_, hw_thr, BitType, path_addr);
     }
 
@@ -171,8 +174,9 @@ public:
         T1 flags      = getArgRegister(1);
         T1 mode       = getArgRegister(2);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "open( %#" PRIx32 ", %" PRIu32 ", %" PRIu32 " )\n", path_ptr, flags, mode);
-
+        #endif
         return new VanadisSyscallOpenEvent(core_id_, hw_thr, BitType, path_ptr, convertFlags(flags), mode);
     }
 
@@ -180,7 +184,9 @@ public:
         T1 path_ptr       = getArgRegister(0);
         T1 access_mode    = getArgRegister(1);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "access( %#" PRIx32 ", %" PRId32 " )\n", path_ptr, access_mode);
+        #endif
         return new VanadisSyscallAccessEvent(core_id_, hw_thr, BitType, path_ptr, access_mode);
     }
 
@@ -193,23 +199,27 @@ public:
 
         assert( stackPtr );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                 "clone( %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 " )\n",
                 flags, threadStack, ptid, tls, stackPtr );
-
+        #endif
         return new VanadisSyscallCloneEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_32B, instPtr, threadStack, flags, ptid, tls, 0, stackPtr );
     }
 
     VanadisSyscallEvent* FORK( int hw_thr ) {
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "fork()\n");
+        #endif
         return new VanadisSyscallForkEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_32B);
     }
 
     VanadisSyscallEvent* SET_THREAD_AREA( int hw_thr ) {
         T1 ptr = getArgRegister(0);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "set_thread_area( %#" PRIx32 ")\n", ptr);
-
+        #endif
         if (tls_address_ != nullptr) {
             (*tls_address_) = ptr;
         } else {
@@ -232,8 +242,10 @@ public:
        }
 #endif
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "statx( %" PRId32 ", %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 ", %#" PRIx32 " )\n",
                         dirfd, pathname, flags, mask, stackPtr );
+        #endif
 
         return new VanadisSyscallStatxEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_32B, dirfd, pathname, flags, mask, stackPtr);
     }
@@ -245,8 +257,10 @@ public:
         uint32_t timeout_addr   = getArgRegister(3);
         uint32_t stack_ptr      = getSP();
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "futex( %#" PRIx32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 ", sp: %#" PRIx32 " (arg-count is greater than 4))\n",
                             addr, op, val, timeout_addr, stack_ptr);
+        #endif
 
         return new VanadisSyscallFutexEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_32B, addr, op, val, timeout_addr, stack_ptr );
     }
@@ -258,9 +272,10 @@ public:
         int32_t  flags      = getArgRegister(3);
         uint32_t stack_ptr  = getSP();
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "mmap2( %#" PRIx32 ", %" PRIu32 ", %" PRId32 ", %" PRId32 ", sp: %#" PRIx32 " (> 4 arguments) )\n",
                             addr, len, prot, flags, stack_ptr);
-
+        #endif
         if ( flags & MIPS_MAP_FIXED ) {
             output_->verbose(CALL_INFO, 8, 0,"mmap2() we don't support MAP_FIXED return error EEXIST\n");
 
@@ -277,7 +292,9 @@ public:
         int32_t  clk_type   = getArgRegister(0);
         uint32_t time_addr  = getArgRegister(1);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "clock_gettime64( %" PRId32 ", %#" PRIx32 ")\n", clk_type, time_addr);
+        #endif
 
         return new VanadisSyscallGetTime64Event(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_32B, clk_type, time_addr);
     }
@@ -293,9 +310,11 @@ public:
 #endif
 
     void recvSyscallResp( VanadisSyscallResponse* os_resp ) {
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "syscall return-code: %" PRId64 " (success: %3s)\n",
                             os_resp->getReturnCode(), os_resp->isSuccessful() ? "yes" : "no");
         output_->verbose(CALL_INFO, 8, 0, "-> issuing call-backs to clear syscall ROB stops...\n");
+        #endif
 
         // Set up the return code (according to ABI, this goes in r2)
         const uint16_t rc_reg = isa_table_->getIntPhysReg(2);
@@ -322,18 +341,20 @@ private:
         const uint16_t succ_reg = isa_table_->getIntPhysReg(7);
 
         if (success) {
+            #ifdef VANADIS_BUILD_DEBUG
             output_->verbose(CALL_INFO, 8, 0,
                             "syscall - generating successful (v: 0) result (isa-reg: "
                             "7, phys-reg: %" PRIu16 ")\n",
                             succ_reg);
-
+            #endif
             reg_file_->setIntReg(succ_reg, os_success);
         } else {
+            #ifdef VANADIS_BUILD_DEBUG
             output_->verbose(CALL_INFO, 8, 0,
                             "syscall - generating failed (v: 1) result (isa-reg: 7, "
                             "phys-reg: %" PRIu16 ")\n",
                             succ_reg);
-
+            #endif
             reg_file_->setIntReg(succ_reg, os_failed);
         }
     }
@@ -394,11 +415,16 @@ private:
 class VanadisMIPSOSHandler : public VanadisMIPSOSHandler2< uint32_t, VanadisOSBitType::VANADIS_OS_32B, MIPS_ARG_REG_ZERO, MIPS_OS_CODE_REG, MIPS_LINK_REG > {
 
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT(VanadisMIPSOSHandler, "vanadis",
-                                            "VanadisMIPSOSHandler",
-                                            SST_ELI_ELEMENT_VERSION(1, 0, 0),
-                                            "Provides SYSCALL handling for a MIPS-based decoding core",
-                                            SST::Vanadis::VanadisCPUOSHandler)
+    SST_ELI_REGISTER_SUBCOMPONENT(VanadisMIPSOSHandler,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
+        "vanadis",
+    #endif
+        "VanadisMIPSOSHandler",
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Provides SYSCALL handling for a MIPS-based decoding core",
+        SST::Vanadis::VanadisCPUOSHandler)
 
     VanadisMIPSOSHandler(ComponentId_t id, Params& params) :
         VanadisMIPSOSHandler2<uint32_t, VanadisOSBitType::VANADIS_OS_32B, MIPS_ARG_REG_ZERO, MIPS_OS_CODE_REG, MIPS_LINK_REG >(id, params) { }

--- a/src/sst/elements/vanadis/os/vnodeoshandler.cc
+++ b/src/sst/elements/vanadis/os/vnodeoshandler.cc
@@ -70,10 +70,12 @@ static const char* SyscallName[] = {
 
 VanadisSyscall* VanadisNodeOSComponent::handleIncomingSyscall( OS::ProcessInfo* process, VanadisSyscallEvent* sys_ev, SST::Link* coreLink )
 {
+    #ifdef VANADIS_BUILD_DEBUG
     if ( sys_ev->getOperation() < NUM_SYSCALLS  ) {
-       output->verbose(CALL_INFO, 1, VANADIS_OS_DBG_SYSCALL, "from core=%" PRIu32 " thr=%" PRIu32 " syscall=%s\n",
+        output->verbose(CALL_INFO, 1, VANADIS_OS_DBG_SYSCALL, "from core=%" PRIu32 " thr=%" PRIu32 " syscall=%s\n",
                     sys_ev->getCoreID(), sys_ev->getThreadID(),SyscallName[sys_ev->getOperation()]);
     }
+    #endif
 
     VanadisSyscall* syscall=NULL;
 

--- a/src/sst/elements/vanadis/os/vriscvcpuos.h
+++ b/src/sst/elements/vanadis/os/vriscvcpuos.h
@@ -169,9 +169,11 @@ public:
         int64_t  tls            = getArgRegister(3);
         int64_t  ctid           = getArgRegister(4);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                     "clone( %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ")\n",
                     instPtr,threadStack,flags,ptid,tls,ctid);
+        #endif
         return new VanadisSyscallCloneEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, instPtr,
                     threadStack, flags, ptid, tls, ctid );
     }
@@ -180,9 +182,11 @@ public:
         uint64_t cl_args_addr  = getArgRegister( 0 ); // struct clone_args *cl_args
         uint64_t cl_args_size = getArgRegister( 1 );  // size_t size
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                     "clone3( %#" PRIx64 ", %#" PRIx64 ", %" PRIu64 ")\n",
                     instPtr,cl_args_addr, cl_args_size);
+        #endif
         return new VanadisSyscallClone3Event(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, instPtr,
                     cl_args_addr, cl_args_size);
     }
@@ -192,7 +196,9 @@ public:
         uint64_t buflen = getArgRegister( 1 );
         uint64_t flags  = getArgRegister( 2 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "getrandom( %" PRIu64 ", %" PRIu64 ", %#" PRIx64 ")\n", buf, buflen, flags);
+        #endif
 
         return new VanadisSyscallGetrandomEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, buf, buflen, flags );
     }
@@ -209,8 +215,10 @@ public:
         }
 #endif
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "readlinkat( %" PRIu64 ", %#" PRIx64 ", %#" PRIx64 ", %" PRIu64 ")\n",
                     dirfd, pathname, buf, bufsize);
+        #endif
 
         return new VanadisSyscallReadLinkAtEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, dirfd, pathname, buf, bufsize);
     }
@@ -226,9 +234,9 @@ public:
             dirfd = AT_FDCWD;
         }
 #endif
-
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "fstat( %d, %#" PRIx64 ", %#" PRIx64 ", %#" PRIx64 ")\n",dirfd,pathname,statbuf,flags);
-
+        #endif
         return new VanadisSyscallFstatAtEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, dirfd, pathname, statbuf, flags );
     }
 
@@ -240,10 +248,11 @@ public:
         uint64_t addr2          = getArgRegister(4);
         uint32_t val3           = getArgRegister(5);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                             "futex( %#" PRIx64 ", %" PRIx32 ", %" PRIx32 ", %" PRIx64 ", %" PRIx64 ", %" PRIu32 " )\n",
                             addr, op, val, timeout_addr, addr2, val3);
-
+        #endif
         return new VanadisSyscallFutexEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, addr, op, val, timeout_addr, addr2, val3 );
     }
 
@@ -251,7 +260,9 @@ public:
         uint64_t  head  = getArgRegister( 0 );
         uint64_t  len   = getArgRegister( 1 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "set_robust_list(  %#" PRIx64 ", %" PRIu64" )\n",head,len);
+        #endif
 
         return new VanadisSyscallSetRobustListEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, head, len );
     }
@@ -287,9 +298,11 @@ public:
             }
             this->sst_assert( map_flags == 0, CALL_INFO, -1, "Unhandled mmap flags" );
 
+            #ifdef VANADIS_BUILD_DEBUG
             output_->verbose(CALL_INFO, 8, 0,
                         "mmap2( 0x%" PRI_ADDR ", %" PRIu64 ", %" PRId32 ", %" PRId32 ", %d, %" PRIu64 ")\n",
                         map_addr, map_len, map_prot, map_flags, fd, offset );
+            #endif
 
             return new VanadisSyscallMemoryMapEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B,
                     map_addr, map_len, map_prot, hostFlags, fd, offset, 0, 0);
@@ -300,20 +313,27 @@ public:
         int64_t  clk_type   = getArgRegister( 0 );
         uint64_t time_addr  = getArgRegister( 1 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                             "clock_gettime64( %" PRId64 ", 0x%" PRI_ADDR " )\n", clk_type, time_addr);
-
+        #endif
         return new VanadisSyscallGetTime64Event(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, clk_type, time_addr);
     }
 
     VanadisSyscallEvent* HWPROBE( int hw_thr ) {
+        #ifdef VANADIS_BUILD_DEBUG
+        // Warning but ifdef'd because this rarely causes a problem
         output_->output("Warning: VANADIS_SYSCALL_RISCV64_HWPROBE not implemented return success\n");
+        #endif
         recvSyscallResp(new VanadisSyscallResponse(0));
         return nullptr;
     }
 
     VanadisSyscallEvent* RSEQ( int hw_thr ) {
+        #ifdef VANADIS_BUILD_DEBUG
+        // Warning but ifdef'd because this rarely causes a problem
         output_->output("Warning: VANADIS_SYSCALL_RISCV64_RSEQ not implemented return success\n");
+        #endif
         recvSyscallResp(new VanadisSyscallResponse(0));
         return nullptr;
     }
@@ -324,11 +344,13 @@ public:
         uint64_t signal_set_out = getArgRegister( 2 );
         int32_t  signal_set_size = getArgRegister( 3 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                             "rt_sigprocmask( %" PRId32 ", 0x%" PRI_ADDR ", 0x%" PRI_ADDR ", %" PRId32 ")\n",
                             how, signal_set_in, signal_set_out, signal_set_size);
 
-        printf("Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented return success\n");
+        output_->output("Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented return success\n");
+        #endif
 
         recvSyscallResp(new VanadisSyscallResponse(0));
         return nullptr;
@@ -340,8 +362,10 @@ public:
         uint64_t new_limit  = getArgRegister( 2 );
         uint64_t old_limit  = getArgRegister( 3 );
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0,
                             "prlimit( %" PRIu64 ", %" PRIu64 ",  %#" PRIx64 ", %#" PRIx64 ")\n", pid, resource, new_limit, old_limit );
+        #endif
 
         return new VanadisSyscallPrlimitEvent(core_id_, hw_thr, VanadisOSBitType::VANADIS_OS_64B, pid, resource, new_limit, old_limit);
     }
@@ -351,16 +375,19 @@ public:
         uint64_t offset   = getArgRegister(1);
         int32_t whence   = getArgRegister(2);
 
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "lseek( %" PRId32 ", %" PRIu64 ", %" PRId32 " )\n", fd, offset, whence);
+        #endif
         return new VanadisSyscallLseekEvent(core_id_, hw_thr, BitType, fd, offset, whence);
     }
 
 
     void recvSyscallResp( VanadisSyscallResponse* os_resp ) {
+        #ifdef VANADIS_BUILD_DEBUG
         output_->verbose(CALL_INFO, 8, 0, "return-code: %" PRId64 " (success: %3s)\n",
                             os_resp->getReturnCode(), os_resp->isSuccessful() ? "yes" : "no");
         output_->verbose(CALL_INFO, 8, 0, "issuing call-backs to clear syscall ROB stops...\n");
-
+        #endif
         // Set up the return code (according to ABI, this goes in r10)
         const uint16_t rc_reg = isa_table_->getIntPhysReg( VANADIS_SYSCALL_RISCV_RET_REG );
         const int64_t rc_val = (int64_t)os_resp->getReturnCode();
@@ -416,12 +443,17 @@ class VanadisRISCV64OSHandler :
     public VanadisRISCV64OSHandler2< uint64_t, VanadisOSBitType::VANADIS_OS_64B, RISCV_ARG_REG_ZERO, RISCV_OS_CODE_REG, RISCV_LINK_REG > {
 
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT(VanadisRISCV64OSHandler,
-                                            "vanadis",
-                                            "VanadisRISCV64OSHandler",
-                                            SST_ELI_ELEMENT_VERSION(1, 0, 0),
-                                            "Provides SYSCALL handling for a RISCV-based decoding core",
-                                            SST::Vanadis::VanadisCPUOSHandler)
+    SST_ELI_REGISTER_SUBCOMPONENT(
+        VanadisRISCV64OSHandler,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
+        "vanadis",
+    #endif
+        "VanadisRISCV64OSHandler",
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Provides SYSCALL handling for a RISCV-based decoding core",
+        SST::Vanadis::VanadisCPUOSHandler)
 
     VanadisRISCV64OSHandler(ComponentId_t id, Params& params) :
         VanadisRISCV64OSHandler2<uint64_t, VanadisOSBitType::VANADIS_OS_64B, RISCV_ARG_REG_ZERO, RISCV_OS_CODE_REG, RISCV_LINK_REG >(id, params) { }

--- a/src/sst/elements/vanadis/rocc/vbasicrocc.h
+++ b/src/sst/elements/vanadis/rocc/vbasicrocc.h
@@ -35,10 +35,17 @@ namespace Vanadis {
 class VanadisRoCCBasic : public SST::Vanadis::VanadisRoCCInterface {
 
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT(VanadisRoCCBasic, "vanadis", "VanadisRoCCBasic",
-                                          SST_ELI_ELEMENT_VERSION(1, 0, 0),
-                                          "Implements a basic example of a RoCC accelerator",
-                                          SST::Vanadis::VanadisRoCCInterface)
+    SST_ELI_REGISTER_SUBCOMPONENT(
+        VanadisRoCCBasic,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
+        "vanadis",
+    #endif
+        "VanadisRoCCBasic",
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Implements a basic example of a RoCC accelerator",
+        SST::Vanadis::VanadisRoCCInterface)
 
     SST_ELI_DOCUMENT_SUBCOMPONENT_SLOTS({ "memory_interface", "Set the interface to memory",
                                             "SST::Interfaces::StandardMem" })

--- a/src/sst/elements/vanadis/tests/basic_vanadis.py
+++ b/src/sst/elements/vanadis/tests/basic_vanadis.py
@@ -22,6 +22,7 @@ isa="riscv64"
 
 loader_mode = os.getenv("VANADIS_LOADER_MODE", "0")
 
+lib="vanadis"
 testDir="basic-io"
 exe = "hello-world"
 #exe = "hello-world-cpp"
@@ -94,7 +95,7 @@ cpu_clock = os.getenv("VANADIS_CPU_CLOCK", "2.3GHz")
 numCpus = int(os.getenv("VANADIS_NUM_CORES", 1))
 numThreads = int(os.getenv("VANADIS_NUM_HW_THREADS", 1))
 
-vanadis_cpu_type = "vanadis."
+vanadis_cpu_type = lib + "."
 vanadis_cpu_type += os.getenv("VANADIS_CPU_ELEMENT_NAME","dbg_VanadisCPU")
 
 if (verbosity > 0):
@@ -124,8 +125,8 @@ else:
     if (verbosity > 0):
         print("No application arguments found, continuing with argc=1")
 
-vanadis_decoder = "vanadis.Vanadis" + vanadis_isa + "Decoder"
-vanadis_os_hdlr = "vanadis.Vanadis" + vanadis_isa + "OSHandler"
+vanadis_decoder = lib + ".Vanadis" + vanadis_isa + "Decoder"
+vanadis_os_hdlr = lib + ".Vanadis" + vanadis_isa + "OSHandler"
 
 
 protocol="MESI"
@@ -353,12 +354,12 @@ class CPU_Builder:
             os_hdlr.addParams( osHdlrParams )
 
             # CPU.decocer.branch_pred
-            branch_pred = decode.setSubComponent( "branch_unit", "vanadis.VanadisBasicBranchUnit" )
+            branch_pred = decode.setSubComponent( "branch_unit", lib + ".VanadisBasicBranchUnit" )
             branch_pred.addParams( branchPredParams )
             branch_pred.enableAllStatistics()
 
         # CPU.lsq
-        cpu_lsq = cpu.setSubComponent( "lsq", "vanadis.VanadisBasicLoadStoreQueue" )
+        cpu_lsq = cpu.setSubComponent( "lsq", lib + ".VanadisBasicLoadStoreQueue" )
         cpu_lsq.addParams(lsqParams)
         cpu_lsq.enableAllStatistics()
 
@@ -452,7 +453,7 @@ def addParamsPrefix(prefix,params):
     return ret
 
 # node OS
-node_os = sst.Component("os", "vanadis.VanadisNodeOS")
+node_os = sst.Component("os", lib + ".VanadisNodeOS")
 node_os.addParams(osParams)
 
 num=0

--- a/src/sst/elements/vanadis/tests/small/basic-io/fread-fwrite/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/fread-fwrite/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 13925; SumSQ.u64 = 13925; Count.u64 = 13925; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4110; SumSQ.u64 = 4110; Count.u64 = 4110; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 970; SumSQ.u64 = 970; Count.u64 = 970; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/fread-fwrite/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/fread-fwrite/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 14538; SumSQ.u64 = 14538; Count.u64 = 14538; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 5288; SumSQ.u64 = 5288; Count.u64 = 5288; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 946; SumSQ.u64 = 946; Count.u64 = 946; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/hello-world-cpp/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/hello-world-cpp/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 11693; SumSQ.u64 = 11693; Count.u64 = 11693; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7072; SumSQ.u64 = 7072; Count.u64 = 7072; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1699; SumSQ.u64 = 1699; Count.u64 = 1699; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/hello-world-cpp/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/hello-world-cpp/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 16598; SumSQ.u64 = 16598; Count.u64 = 16598; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 18938; SumSQ.u64 = 18938; Count.u64 = 18938; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 3170; SumSQ.u64 = 3170; Count.u64 = 3170; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/hello-world/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/hello-world/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 549; SumSQ.u64 = 549; Count.u64 = 549; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 561; SumSQ.u64 = 561; Count.u64 = 561; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 139; SumSQ.u64 = 139; Count.u64 = 139; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/hello-world/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/hello-world/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 875; SumSQ.u64 = 875; Count.u64 = 875; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 784; SumSQ.u64 = 784; Count.u64 = 784; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 129; SumSQ.u64 = 129; Count.u64 = 129; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/lseek/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/lseek/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 4959; SumSQ.u64 = 4959; Count.u64 = 4959; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7729; SumSQ.u64 = 7729; Count.u64 = 7729; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1377; SumSQ.u64 = 1377; Count.u64 = 1377; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/openat/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/openat/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 5562; SumSQ.u64 = 5562; Count.u64 = 5562; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 8956; SumSQ.u64 = 8956; Count.u64 = 8956; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2047; SumSQ.u64 = 2047; Count.u64 = 2047; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/openat/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/openat/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 7499; SumSQ.u64 = 7499; Count.u64 = 7499; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 11191; SumSQ.u64 = 11191; Count.u64 = 11191; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2073; SumSQ.u64 = 2073; Count.u64 = 2073; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/printf-check/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/printf-check/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 4408; SumSQ.u64 = 4408; Count.u64 = 4408; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 6533; SumSQ.u64 = 6533; Count.u64 = 6533; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1536; SumSQ.u64 = 1536; Count.u64 = 1536; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/printf-check/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/printf-check/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 5795; SumSQ.u64 = 5795; Count.u64 = 5795; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 8056; SumSQ.u64 = 8056; Count.u64 = 8056; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1660; SumSQ.u64 = 1660; Count.u64 = 1660; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/read-write/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/read-write/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 7777; SumSQ.u64 = 7777; Count.u64 = 7777; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 11985; SumSQ.u64 = 11985; Count.u64 = 11985; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2795; SumSQ.u64 = 2795; Count.u64 = 2795; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/read-write/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/read-write/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 9648; SumSQ.u64 = 9648; Count.u64 = 9648; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 15790; SumSQ.u64 = 15790; Count.u64 = 15790; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2831; SumSQ.u64 = 2831; Count.u64 = 2831; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlink/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlink/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 2488; SumSQ.u64 = 2488; Count.u64 = 2488; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 3395; SumSQ.u64 = 3395; Count.u64 = 3395; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 815; SumSQ.u64 = 815; Count.u64 = 815; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlink/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlink/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3296; SumSQ.u64 = 3296; Count.u64 = 3296; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4352; SumSQ.u64 = 4352; Count.u64 = 4352; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 823; SumSQ.u64 = 823; Count.u64 = 823; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 2461; SumSQ.u64 = 2461; Count.u64 = 2461; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 3366; SumSQ.u64 = 3366; Count.u64 = 3366; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 793; SumSQ.u64 = 793; Count.u64 = 793; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-io/unlinkat/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3316; SumSQ.u64 = 3316; Count.u64 = 3316; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4405; SumSQ.u64 = 4405; Count.u64 = 4405; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 839; SumSQ.u64 = 839; Count.u64 = 839; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1011070; SumSQ.u64 = 1011070; Count.u64 = 1011070; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 50855; SumSQ.u64 = 50855; Count.u64 = 50855; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 12616; SumSQ.u64 = 12616; Count.u64 = 12616; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-double/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1029069; SumSQ.u64 = 1029069; Count.u64 = 1029069; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 84727; SumSQ.u64 = 84727; Count.u64 = 84727; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 19291; SumSQ.u64 = 19291; Count.u64 = 19291; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1001213; SumSQ.u64 = 1001213; Count.u64 = 1001213; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 39939; SumSQ.u64 = 39939; Count.u64 = 39939; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 10089; SumSQ.u64 = 10089; Count.u64 = 10089; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-math/sqrt-float/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1012163; SumSQ.u64 = 1012163; Count.u64 = 1012163; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 55014; SumSQ.u64 = 55014; Count.u64 = 55014; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 12986; SumSQ.u64 = 12986; Count.u64 = 12986; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 2901384; SumSQ.u64 = 2901384; Count.u64 = 2901384; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 1597; SumSQ.u64 = 1597; Count.u64 = 1597; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 431; SumSQ.u64 = 431; Count.u64 = 431; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-branch/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3202010; SumSQ.u64 = 3202010; Count.u64 = 3202010; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 2198; SumSQ.u64 = 2198; Count.u64 = 2198; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 445; SumSQ.u64 = 445; Count.u64 = 445; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 575979; SumSQ.u64 = 575979; Count.u64 = 575979; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 1062716; SumSQ.u64 = 1062716; Count.u64 = 1062716; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 216542; SumSQ.u64 = 216542; Count.u64 = 216542; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/basic-ops/test-shift/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 543144; SumSQ.u64 = 543144; Count.u64 = 543144; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 902105; SumSQ.u64 = 902105; Count.u64 = 902105; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 151219; SumSQ.u64 = 151219; Count.u64 = 151219; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/clone/mipsel/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/clone/mipsel/gold1/sst.stdout.gold
@@ -1,6 +1,6 @@
 pid=100 tid=101 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 10202; SumSQ.u64 = 10202; Count.u64 = 10202; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7873; SumSQ.u64 = 7873; Count.u64 = 7873; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1769; SumSQ.u64 = 1769; Count.u64 = 1769; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/clone/mipsel/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/clone/mipsel/gold2/sst.stdout.gold
@@ -1,6 +1,6 @@
 pid=100 tid=101 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 7145; SumSQ.u64 = 7145; Count.u64 = 7145; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7880; SumSQ.u64 = 7880; Count.u64 = 7880; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1769; SumSQ.u64 = 1769; Count.u64 = 1769; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/clone/riscv64/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/clone/riscv64/gold1/sst.stdout.gold
@@ -1,6 +1,6 @@
 pid=100 tid=101 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 8668; SumSQ.u64 = 8668; Count.u64 = 8668; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 9502; SumSQ.u64 = 9502; Count.u64 = 9502; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1757; SumSQ.u64 = 1757; Count.u64 = 1757; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/clone/riscv64/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/clone/riscv64/gold2/sst.stdout.gold
@@ -1,6 +1,6 @@
 pid=100 tid=101 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 6890; SumSQ.u64 = 6890; Count.u64 = 6890; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 9510; SumSQ.u64 = 9510; Count.u64 = 9510; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1757; SumSQ.u64 = 1757; Count.u64 = 1757; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/fork/mipsel/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/fork/mipsel/gold1/sst.stdout.gold
@@ -1,12 +1,6 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
 pid=101 tid=101 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3059; SumSQ.u64 = 3059; Count.u64 = 3059; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4043; SumSQ.u64 = 4043; Count.u64 = 4043; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1010; SumSQ.u64 = 1010; Count.u64 = 1010; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/fork/mipsel/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/fork/mipsel/gold2/sst.stdout.gold
@@ -1,12 +1,6 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
 pid=101 tid=101 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3065; SumSQ.u64 = 3065; Count.u64 = 3065; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4059; SumSQ.u64 = 4059; Count.u64 = 4059; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1010; SumSQ.u64 = 1010; Count.u64 = 1010; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/fork/riscv64/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/fork/riscv64/gold1/sst.stdout.gold
@@ -1,12 +1,6 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
 pid=101 tid=101 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3935; SumSQ.u64 = 3935; Count.u64 = 3935; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4993; SumSQ.u64 = 4993; Count.u64 = 4993; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1032; SumSQ.u64 = 1032; Count.u64 = 1032; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/fork/riscv64/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/fork/riscv64/gold2/sst.stdout.gold
@@ -1,12 +1,6 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
 pid=101 tid=101 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3928; SumSQ.u64 = 3928; Count.u64 = 3928; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4999; SumSQ.u64 = 4999; Count.u64 = 4999; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1032; SumSQ.u64 = 1032; Count.u64 = 1032; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/gettime/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/gettime/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 2139; SumSQ.u64 = 2139; Count.u64 = 2139; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 2976; SumSQ.u64 = 2976; Count.u64 = 2976; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 718; SumSQ.u64 = 718; Count.u64 = 718; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/gettime/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/gettime/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3055; SumSQ.u64 = 3055; Count.u64 = 3055; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 3716; SumSQ.u64 = 3716; Count.u64 = 3716; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 684; SumSQ.u64 = 684; Count.u64 = 684; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/mem-test/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/mem-test/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1111; SumSQ.u64 = 1111; Count.u64 = 1111; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 1160; SumSQ.u64 = 1160; Count.u64 = 1160; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 281; SumSQ.u64 = 281; Count.u64 = 281; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/mem-test/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/mem-test/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 1605; SumSQ.u64 = 1605; Count.u64 = 1605; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 1727; SumSQ.u64 = 1727; Count.u64 = 1727; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 293; SumSQ.u64 = 293; Count.u64 = 293; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 338752; SumSQ.u64 = 338752; Count.u64 = 338752; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 12349; SumSQ.u64 = 12349; Count.u64 = 12349; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 3116; SumSQ.u64 = 3116; Count.u64 = 3116; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/mt-dgemm/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 371217; SumSQ.u64 = 371217; Count.u64 = 371217; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 17866; SumSQ.u64 = 17866; Count.u64 = 17866; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4163; SumSQ.u64 = 4163; Count.u64 = 4163; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/2core-2thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/2core-2thread/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 18855; SumSQ.u64 = 18855; Count.u64 = 18855; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7953; SumSQ.u64 = 7953; Count.u64 = 7953; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2053; SumSQ.u64 = 2053; Count.u64 = 2053; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/4core/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/4core/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 29358; SumSQ.u64 = 29358; Count.u64 = 29358; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7847; SumSQ.u64 = 7847; Count.u64 = 7847; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2044; SumSQ.u64 = 2044; Count.u64 = 2044; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/4thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/mipsel/4thread/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 12400; SumSQ.u64 = 12400; Count.u64 = 12400; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 8323; SumSQ.u64 = 8323; Count.u64 = 8323; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2042; SumSQ.u64 = 2042; Count.u64 = 2042; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/2core-2thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/2core-2thread/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 10169; SumSQ.u64 = 10169; Count.u64 = 10169; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 10851; SumSQ.u64 = 10851; Count.u64 = 10851; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2327; SumSQ.u64 = 2327; Count.u64 = 2327; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/4core/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/4core/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 9354; SumSQ.u64 = 9354; Count.u64 = 9354; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 10816; SumSQ.u64 = 10816; Count.u64 = 10816; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2316; SumSQ.u64 = 2316; Count.u64 = 2316; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/4thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp/riscv64/4thread/sst.stdout.gold
@@ -1,22 +1,8 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 9564; SumSQ.u64 = 9564; Count.u64 = 9564; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 11137; SumSQ.u64 = 11137; Count.u64 = 11137; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2272; SumSQ.u64 = 2272; Count.u64 = 2272; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/16core/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/16core/sst.stdout.gold
@@ -1,53 +1,3 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -64,7 +14,7 @@ pid=100 tid=113 has exited
 pid=100 tid=114 has exited
 pid=100 tid=115 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 19165; SumSQ.u64 = 19165; Count.u64 = 19165; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 14338; SumSQ.u64 = 14338; Count.u64 = 14338; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2807; SumSQ.u64 = 2807; Count.u64 = 2807; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/32thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/32thread/sst.stdout.gold
@@ -1,101 +1,3 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -128,7 +30,7 @@ pid=100 tid=129 has exited
 pid=100 tid=130 has exited
 pid=100 tid=131 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder.0:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 16230; SumSQ.u64 = 16230; Count.u64 = 16230; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder.0:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 26966; SumSQ.u64 = 26966; Count.u64 = 26966; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder.0:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4325; SumSQ.u64 = 4325; Count.u64 = 4325; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/4core-8thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/mipsel/4core-8thread/sst.stdout.gold
@@ -1,101 +1,3 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -128,7 +30,7 @@ pid=100 tid=129 has exited
 pid=100 tid=130 has exited
 pid=100 tid=131 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder.0:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 17811; SumSQ.u64 = 17811; Count.u64 = 17811; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder.0:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 25379; SumSQ.u64 = 25379; Count.u64 = 25379; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder.0:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4331; SumSQ.u64 = 4331; Count.u64 = 4331; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/16core/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/16core/sst.stdout.gold
@@ -1,53 +1,3 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -64,7 +14,7 @@ pid=100 tid=113 has exited
 pid=100 tid=114 has exited
 pid=100 tid=115 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 9562; SumSQ.u64 = 9562; Count.u64 = 9562; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 15468; SumSQ.u64 = 15468; Count.u64 = 15468; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2993; SumSQ.u64 = 2993; Count.u64 = 2993; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/32thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/32thread/sst.stdout.gold
@@ -1,101 +1,3 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -128,7 +30,7 @@ pid=100 tid=129 has exited
 pid=100 tid=130 has exited
 pid=100 tid=131 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 21870; SumSQ.u64 = 21870; Count.u64 = 21870; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 34820; SumSQ.u64 = 34820; Count.u64 = 34820; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4871; SumSQ.u64 = 4871; Count.u64 = 4871; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/4core-8thread/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/openmp2/riscv64/4core-8thread/sst.stdout.gold
@@ -1,101 +1,3 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=103 has exited
@@ -128,7 +30,7 @@ pid=100 tid=129 has exited
 pid=100 tid=130 has exited
 pid=100 tid=131 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 14718; SumSQ.u64 = 14718; Count.u64 = 14718; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 30071; SumSQ.u64 = 30071; Count.u64 = 30071; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4866; SumSQ.u64 = 4866; Count.u64 = 4866; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/pthread/mipsel/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/pthread/mipsel/gold1/sst.stdout.gold
@@ -1,16 +1,7 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=102 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3158; SumSQ.u64 = 3158; Count.u64 = 3158; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 5367; SumSQ.u64 = 5367; Count.u64 = 5367; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1319; SumSQ.u64 = 1319; Count.u64 = 1319; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/pthread/mipsel/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/pthread/mipsel/gold2/sst.stdout.gold
@@ -1,16 +1,7 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=102 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3162; SumSQ.u64 = 3162; Count.u64 = 3162; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 5359; SumSQ.u64 = 5359; Count.u64 = 5359; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1328; SumSQ.u64 = 1328; Count.u64 = 1328; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/pthread/riscv64/gold1/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/pthread/riscv64/gold1/sst.stdout.gold
@@ -1,16 +1,7 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=102 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 4207; SumSQ.u64 = 4207; Count.u64 = 4207; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 6544; SumSQ.u64 = 6544; Count.u64 = 6544; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1275; SumSQ.u64 = 1275; Count.u64 = 1275; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/pthread/riscv64/gold2/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/pthread/riscv64/gold2/sst.stdout.gold
@@ -1,16 +1,7 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=102 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder[0]:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 4286; SumSQ.u64 = 4286; Count.u64 = 4286; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 6549; SumSQ.u64 = 6549; Count.u64 = 6549; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder[0]:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1293; SumSQ.u64 = 1293; Count.u64 = 1293; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/splitLoad/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/splitLoad/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 10120; SumSQ.u64 = 10120; Count.u64 = 10120; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 20333; SumSQ.u64 = 20333; Count.u64 = 20333; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 4092; SumSQ.u64 = 4092; Count.u64 = 4092; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/splitLoad/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/splitLoad/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 22335; SumSQ.u64 = 22335; Count.u64 = 22335; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 36852; SumSQ.u64 = 36852; Count.u64 = 36852; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 6255; SumSQ.u64 = 6255; Count.u64 = 6255; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/stream-fortran/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/stream-fortran/mipsel/sst.stdout.gold
@@ -1,20 +1,5 @@
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_MIPS_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 141976; SumSQ.u64 = 141976; Count.u64 = 141976; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 102832; SumSQ.u64 = 102832; Count.u64 = 102832; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 28338; SumSQ.u64 = 28338; Count.u64 = 28338; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/stream-fortran/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/stream-fortran/riscv64/sst.stdout.gold
@@ -1,20 +1,5 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGACTION not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 163184; SumSQ.u64 = 163184; Count.u64 = 163184; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 145391; SumSQ.u64 = 145391; Count.u64 = 145391; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 32755; SumSQ.u64 = 32755; Count.u64 = 32755; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/stream/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/stream/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 204241; SumSQ.u64 = 204241; Count.u64 = 204241; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 31486; SumSQ.u64 = 31486; Count.u64 = 31486; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 7854; SumSQ.u64 = 7854; Count.u64 = 7854; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/stream/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/stream/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 206906; SumSQ.u64 = 206906; Count.u64 = 206906; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 52430; SumSQ.u64 = 52430; Count.u64 = 52430; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 12491; SumSQ.u64 = 12491; Count.u64 = 12491; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/uname/mipsel/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/uname/mipsel/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 2476; SumSQ.u64 = 2476; Count.u64 = 2476; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 4118; SumSQ.u64 = 4118; Count.u64 = 4118; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 887; SumSQ.u64 = 887; Count.u64 = 887; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/misc/uname/riscv64/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/misc/uname/riscv64/sst.stdout.gold
@@ -1,5 +1,5 @@
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 3499; SumSQ.u64 = 3499; Count.u64 = 3499; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 5013; SumSQ.u64 = 5013; Count.u64 = 5013; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 911; SumSQ.u64 = 911; Count.u64 = 911; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/multicore/openmp/riscv64/3core/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/multicore/openmp/riscv64/3core/sst.stdout.gold
@@ -1,18 +1,7 @@
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
-Warning: VANADIS_SYSCALL_RISCV_RT_SIGPROCMASK not implemented returning success
 pid=100 tid=101 has exited
 pid=100 tid=102 has exited
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 69721; SumSQ.u64 = 69721; Count.u64 = 69721; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 10641; SumSQ.u64 = 10641; Count.u64 = 10641; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 2603; SumSQ.u64 = 2603; Count.u64 = 2603; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/tests/small/rocc/basic-rocc/riscv64/2rocc/sst.stdout.gold
+++ b/src/sst/elements/vanadis/tests/small/rocc/basic-rocc/riscv64/2rocc/sst.stdout.gold
@@ -1,6 +1,6 @@
 node0.cpu0, Warning: the 'decoder0' subcomponent slot is deprecated. Use index 0 of the 'decoder' subcomponent slot instead
 pid=100 tid=100 has exited
-all process have exited
+all processes have exited
  node0.cpu0:decoder0:branch_unit.branch_cache_hit.1 : Accumulator : Sum.u64 = 5408; SumSQ.u64 = 5408; Count.u64 = 5408; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder0:branch_unit.branch_cache_miss.1 : Accumulator : Sum.u64 = 7379; SumSQ.u64 = 7379; Count.u64 = 7379; Min.u64 = 1; Max.u64 = 1; 
  node0.cpu0:decoder0:branch_unit.branch_cache_castout.1 : Accumulator : Sum.u64 = 1316; SumSQ.u64 = 1316; Count.u64 = 1316; Min.u64 = 1; Max.u64 = 1; 

--- a/src/sst/elements/vanadis/util/vcmpop.h
+++ b/src/sst/elements/vanadis/util/vcmpop.h
@@ -59,42 +59,56 @@ bool
 registerCompareValues(VanadisRegisterCompareType compareType, VanadisRegisterFile* regFile, VanadisInstruction* ins,
                       SST::Output* output, T left_value, T right_value) {
 
+    #ifdef VANADIS_BUILD_DEBUG
     register_compare_values_print_msg(CALL_INFO, output, left_value, right_value);
-
+    #endif
     bool compare_result = false;
 
     switch (compareType) {
     case REG_COMPARE_EQ: {
         compare_result = (left_value) == (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: equal     / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     case REG_COMPARE_NEQ: {
         compare_result = (left_value) != (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: not-equal / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     case REG_COMPARE_LT: {
         compare_result = (left_value) < (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: less-than / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     case REG_COMPARE_LTE: {
         compare_result = (left_value) <= (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: less-than-eq / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     case REG_COMPARE_GT: {
         compare_result = (left_value) > (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: greater-than / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     case REG_COMPARE_GTE: {
         compare_result = (left_value) >= (right_value);
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-----> compare: greater-than-eq / result: %s\n",
                         (compare_result ? "true" : "false"));
+        #endif
     } break;
     default: {
+        // Do not ifdef output, (rare) error condition
         output->verbose(CALL_INFO, 16, 0, "-----> Unknown comparison operation at instruction: 0x%" PRI_ADDR "\n",
                         ins->getInstructionAddress());
         ins->flagError();

--- a/src/sst/elements/vanadis/vbranch/vbranchbasic.h
+++ b/src/sst/elements/vanadis/vbranch/vbranchbasic.h
@@ -27,11 +27,18 @@ namespace Vanadis {
 class VanadisBasicBranchUnit : public VanadisBranchUnit {
 
 public:
-    SST_ELI_REGISTER_SUBCOMPONENT(VanadisBasicBranchUnit, "vanadis", "VanadisBasicBranchUnit",
-                                          SST_ELI_ELEMENT_VERSION(1, 0, 0),
-                                          "Implements basic branch prediction capability that stores the last "
-                                          "branch direction in a cache",
-                                          SST::Vanadis::VanadisBranchUnit)
+    SST_ELI_REGISTER_SUBCOMPONENT(
+        VanadisBasicBranchUnit,
+    #ifdef VANADIS_BUILD_DEBUG
+        "vanadisdbg",
+    #else
+        "vanadis",
+    #endif
+        "VanadisBasicBranchUnit",
+        SST_ELI_ELEMENT_VERSION(1, 0, 0),
+        "Implements basic branch prediction capability that stores the last "
+        "branch direction in a cache",
+        SST::Vanadis::VanadisBranchUnit)
 
     SST_ELI_DOCUMENT_PARAMS({ "branch_entries", "Sets the number of entries in the underlying cache "
                                                 "of branch directions", "64" })

--- a/src/sst/elements/vanadis/vfuncunit.h
+++ b/src/sst/elements/vanadis/vfuncunit.h
@@ -107,7 +107,9 @@ public:
     }
 
     void clearByHWThreadID(SST::Output* output, const uint16_t hw_thr) {
+        #ifdef VANADIS_BUILD_DEBUG
         output->verbose(CALL_INFO, 16, 0, "-> Function Unit, clearing by hardware thread %" PRIu32 "...\n", hw_thr);
+        #endif
 
         for (auto q_itr = pending_execute.begin(); q_itr != pending_execute.end();) {
             // if we get a hardware thread match, remove and carry out


### PR DESCRIPTION
Regular version has limited output and is faster. Debug version is what we have been using thus far. This changes the name of the Vanadis core to "vanadis.core" for regular and "vanadisdbg.core" for the debug version. However, "vanadis.dbg_VandisCPU" still works (map to vanadis.core though) so existing scripts will continue to work. Other elements have the same names as before.

All elements in vanadis have both a debug and regular version that can be swapped between by using "vanadisdbg" as the library instead of "vanadis".

For size reasons, we may eventually want to make the default to only compile the regular version of the library.

Code contained in an `#ifdef VANADIS_BUILD_DEBUG" is only compiled in the debug version of the library.

Also fixes a typo: "all processes have exited" instead of "all process have exited".