### PR TITLE
Dragonfly_untimed_broadcast_patch

### DIFF
--- a/src/sst/elements/merlin/topology/dragonfly.cc
+++ b/src/sst/elements/merlin/topology/dragonfly.cc
@@ -1010,11 +1010,11 @@ void topo_dragonfly::routeUntimedData(int port, internal_router_event* ev, std::
         }
 
         if ( broadcast_to_groups ) {
-            for ( int p = 0; p < (int)(params.g - 1); p++ ) {
+            for ( int p = 0; p < (int)(params.g); p++ ) {
                 auto dst_group = p;
                 if ( dst_group >= (int)group_id && global_route_mode==global_route_mode_t::ABSOLUTE) dst_group++;
                 const RouterPortPair& pair = group_to_global_port.getRouterPortPair(dst_group,0);
-                if ( pair.router == router_id ) outPorts.push_back((int)(pair.port));
+                if ( pair.router == router_id && p != td_ev->src_group) outPorts.push_back((int)(pair.port));
             }
         }
     } else {


### PR DESCRIPTION
Address two issues in how untimed broadcasts are routed in the dragonfly topology. Before these changes, some hosts would never receive the message while other hosts would receive duplicates of the same message.

1. fixes a off by one error that prevented to last group from receiving messages originating in any other group.
2. fixes resending a the message back to the originating group.

The result is that now the broadcast message arrives to each host exactly once.