### PR TITLE
Ember: push some ESshmem tests off to Nightly

### DIFF
--- a/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
+++ b/src/sst/elements/ember/tests/testsuite_default_ember_ESshmem.py
@@ -91,6 +91,9 @@ class testcase_Ember_ESshmem(SSTTestCase):
     def test_Ember_ESshmem(self, testnum, hash_str, modelstr, sdlfile):
         self._checkSkipConditions(testnum)
 
+        # Run only the first 10 tests if we are not in a Nightly test
+        if not testing_check_is_nightly() and testnum > 10:
+            self.skipTest("Complete Ember ESshmem only runs on Nightly builds.")
         log_debug("Running Ember ESshmem #{0} ({1}): model={2} using sdl={3}".format(testnum, hash_str, modelstr, sdlfile))
         self.Ember_ESshmem_test_template(testnum, hash_str, modelstr, sdlfile)
 


### PR DESCRIPTION
Lots of tests add up to minutes per build.  We can defer some of these to Nightly builds.
