### PR TITLE
Add missing setCpumask/setThreadId definitions and reassignCores virt…

### DIFF
--- a/src/sst/elements/mercury/components/compute_library/operating_system_cl.cc
+++ b/src/sst/elements/mercury/components/compute_library/operating_system_cl.cc
@@ -79,5 +79,16 @@ OperatingSystemCL::execute(COMP_FUNC func, Event *data, int nthr)
   }
 }
 
+void
+OperatingSystemCL::reassignCores(Thread *thr)
+{
+  int ncores = thr->numActiveCcores();
+  //this is not equivalent to a no-op
+  //I could release cores - then based on changes
+  //to the cpumask, reserve different cores
+  compute_sched_->releaseCores(ncores, thr);
+  compute_sched_->reserveCores(ncores, thr);
+}
+
 } // namespace Hg
 } // namespace SST

--- a/src/sst/elements/mercury/components/compute_library/operating_system_cl.h
+++ b/src/sst/elements/mercury/components/compute_library/operating_system_cl.h
@@ -54,6 +54,8 @@ class OperatingSystemCL : public OperatingSystemCLAPI, public OperatingSystemImp
 
   void execute(COMP_FUNC, Event *data, int nthr = 1) override;
 
+  void reassignCores(Thread* thr) override;
+
   static size_t stacksize() {
     return sst_hg_global_stacksize;
   }

--- a/src/sst/elements/mercury/components/operating_system_api.h
+++ b/src/sst/elements/mercury/components/operating_system_api.h
@@ -120,6 +120,8 @@ public:
    virtual void unregisterEventLib(Library *lib) = 0;
 
    virtual void handleRequest(Request *req) = 0;
+
+   virtual void reassignCores(Thread* thr) { }
 };
 
 } // namespace Hg

--- a/src/sst/elements/mercury/operating_system/process/thread.cc
+++ b/src/sst/elements/mercury/operating_system/process/thread.cc
@@ -241,6 +241,19 @@ Thread::~Thread()
 }
 
 void
+Thread::setCpumask(uint64_t cpumask)
+{
+  cpumask_ = cpumask;
+  os_->reassignCores(this);
+}
+
+void
+Thread::setThreadId(int thr)
+{
+  thread_id_ = thr;
+}
+
+void
 Thread::startThread(Thread* thr)
 {
   thr->p_txt_ = p_txt_;


### PR DESCRIPTION
Updated to include some missing function definitions. 
Created virtual function virtual void reassignCores(Thread* thr) { } that previously existed in mercury.
While I think we could largely just remove the reassign core functinality, I included it as it was a part of sst-macro. We can comment this out if it's unneeded. 
