### PR TITLE
Fix dragonfly untimed broadcast_to_groups to work for both absolute a…

### DIFF
--- a/src/sst/elements/merlin/topology/dragonfly.cc
+++ b/src/sst/elements/merlin/topology/dragonfly.cc
@@ -1012,9 +1012,8 @@ void topo_dragonfly::routeUntimedData(int port, internal_router_event* ev, std::
         if ( broadcast_to_groups ) {
             for ( int p = 0; p < (int)(params.g); p++ ) {
                 auto dst_group = p;
-                if ( dst_group >= (int)group_id && global_route_mode==global_route_mode_t::ABSOLUTE) dst_group++;
                 const RouterPortPair& pair = group_to_global_port.getRouterPortPair(dst_group,0);
-                if ( pair.router == router_id && p != td_ev->src_group) outPorts.push_back((int)(pair.port));
+                if ( pair.router == router_id && dst_group != td_ev->src_group) outPorts.push_back((int)(pair.port));
             }
         }
     } else {


### PR DESCRIPTION
Fix dragonfly untimed broadcast_to_groups to work for both absolute and relative global_route_mode

fixes issue introduced in #2610, which broke routing for absolute route mode, after erroneously only checking relative routing.

Updated my internal tests to check both  absolute and relative, both modes now complete succesfully.
 

