### PR TITLE
Switch from testing_check_is_nightly to categorize decorator on test methods

### DIFF
--- a/src/sst/elements/balar/tests/testsuite_default_balar.py
+++ b/src/sst/elements/balar/tests/testsuite_default_balar.py
@@ -26,7 +26,7 @@ class testcase_balar_simple(BalarTestCase):
     #     self.balar_vanadis_clang_template("helloworld")
 
     @BalarTestCase.balar_basic_unittest
-    # @unittest.skipIf(not testing_check_is_nightly(), "balar tests only run on Nightly builds.")
+    # @categorize("nightly")
     def test_balar_vanadis_clang_vecadd(self):
         self.balar_vanadis_clang_template("vecadd", 60 * 30)
     #

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHA.py
@@ -74,12 +74,12 @@ class testcase_memHierarchy_memHA(SSTTestCase):
         self.memHA_Template("CoherenceDomains")
 
     @skip_on_sstsimulator_conf_empty_str("GOBLIN_HMCSIM", "LIBDIR", "GOBLIN_HMCSIM is not included as part of this build")
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendGoblinHMC only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendGoblinHMC(self):
         self.memHA_Template("BackendGoblinHMC", testtimeout=400)
 
     @skip_on_sstsimulator_conf_empty_str("DRAMSIM3", "LIBDIR", "DRAMSIM3 is not included as part of this build")
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendDramsim3 only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendDramsim3(self):
         self.memHA_Template("BackendDramsim3")
 
@@ -107,19 +107,19 @@ class testcase_memHierarchy_memHA(SSTTestCase):
     def test_memHierarchy_BackendRamulator2(self):
         self.memHA_Template("BackendRamulator2")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendTimingDRAM_1(self):
         self.memHA_Template("BackendTimingDRAM_1")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendTimingDRAM_2(self):
         self.memHA_Template("BackendTimingDRAM_2")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendTimingDRAM_3(self):
         self.memHA_Template("BackendTimingDRAM_3")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_memHA_BackendTimingDRAM only runs on Nightly builds.")
+    @categorize("nightly")
     def test_memHA_BackendTimingDRAM_4(self):
         self.memHA_Template("BackendTimingDRAM_4")
 

--- a/src/sst/elements/messier/tests/testsuite_default_Messier.py
+++ b/src/sst/elements/messier/tests/testsuite_default_Messier.py
@@ -16,18 +16,18 @@ class testcase_Messier_Component(SSTTestCase):
 
 #####
 
-    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
+    @categorize("nightly")
     def test_Messier_gupsgen(self):
         self.Messier_test_template("gupsgen")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
+    @categorize("nightly")
     def test_Messier_gupsgen_2RANKS(self):
         self.Messier_test_template("gupsgen_2RANKS")
 
     def test_Messier_gupsgen_fastNVM(self):
         self.Messier_test_template("gupsgen_fastNVM")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "Complete test_Messier_gupsgen only runs on Nightly builds.")
+    @categorize("nightly")
     def test_Messier_stencil3dbench_messier(self):
         self.Messier_test_template("stencil3dbench_messier")
 

--- a/src/sst/elements/miranda/tests/testsuite_default_miranda.py
+++ b/src/sst/elements/miranda/tests/testsuite_default_miranda.py
@@ -26,11 +26,11 @@ class testcase_miranda_Component(SSTTestCase):
 
     @unittest.skipIf(testing_check_get_num_ranks() > 1, "miranda: test_miranda_randomgen skipped if ranks > 1")
     @unittest.skipIf(testing_check_get_num_threads() > 1, "miranda: test_miranda_randomgen skipped if threads > 1")
-    @unittest.skipIf(not testing_check_is_nightly(), "miranda_randomgen only runs on Nightly builds.")
+    @categorize("nightly")
     def test_miranda_randomgen(self):
         self.miranda_test_template("randomgen", testtimeout=360)
 
-    @unittest.skipIf(not testing_check_is_nightly(), "miranda_stencil3dbench only runs on Nightly builds.")
+    @categorize("nightly")
     def test_miranda_stencil3dbench(self):
         self.miranda_test_template("stencil3dbench")
 

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -30,7 +30,7 @@ class testcase_prospero(SSTTestCase):
     libz_missing = not sst_elements_config_include_file_get_value("HAVE_LIBZ", type=int, default=0, disable_warning=True)
 
     @unittest.skipIf(libz_missing, "test_prospero_compressed_using_TAR_traces test: Requires LIBZ, but LIBZ is not found in build configuration.")
-    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_compressed_using_TAR_traces only runs on Nightly builds.")
+    @categorize("nightly")
     def test_prospero_compressed_using_TAR_traces(self):
         self.prospero_test_template("compressed", NO_TIMINGDRAM, USE_TAR_TRACES)
 
@@ -38,11 +38,11 @@ class testcase_prospero(SSTTestCase):
     def test_prospero_compressed_withtimingdram_using_TAR_traces(self):
         self.prospero_test_template("compressed", WITH_TIMINGDRAM, USE_TAR_TRACES)
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_text_using_TAR_traces only runs on Nightly builds.")
+    @categorize("nightly")
     def test_prospero_text_using_TAR_traces(self):
         self.prospero_test_template("text", NO_TIMINGDRAM, USE_TAR_TRACES)
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_binary_using_TAR_traces only runs on Nightly builds.")
+    @categorize("nightly")
     def test_prospero_binary_using_TAR_traces(self):
         self.prospero_test_template("binary", NO_TIMINGDRAM, USE_TAR_TRACES)
 
@@ -53,12 +53,12 @@ class testcase_prospero(SSTTestCase):
         self.prospero_test_template("binary", WITH_TIMINGDRAM, USE_TAR_TRACES)
 
     @unittest.skipIf(not pin_loaded, "test_prospero_text_using_PIN_traces: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
-    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_text_using_PIN_traces only runs on Nightly builds.")
+    @categorize("nightly")
     def test_prospero_text_using_PIN_traces(self):
         self.prospero_test_template("text", NO_TIMINGDRAM, USE_PIN_TRACES)
 
     @unittest.skipIf(not pin_loaded, "test_prospero_binary_using_PIN_traces: Requires PIN, but Env Var 'INTEL_PIN_DIR' is not found or path does not exist.")
-    @unittest.skipIf(not testing_check_is_nightly(), "test_prospero_binary_using_PIN_traces only runs on Nightly builds.")
+    @categorize("nightly")
     def test_prospero_binary_using_PIN_traces(self):
         self.prospero_test_template("binary", NO_TIMINGDRAM, USE_PIN_TRACES)
 

--- a/src/sst/elements/samba/tests/testsuite_default_Samba.py
+++ b/src/sst/elements/samba/tests/testsuite_default_Samba.py
@@ -25,7 +25,7 @@ class testcase_Samba_Component(SSTTestCase):
     def test_Samba_gupsgen_mmu_three_levels(self):
         self.Samba_test_template("gupsgen_mmu_three_levels")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "test_Samba_stencil3dbench_mmu only runs on Nightly builds.")
+    @categorize("nightly")
     def test_Samba_stencil3dbench_mmu(self):
         self.Samba_test_template("stencil3dbench_mmu", testtimeout=240)
 

--- a/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
+++ b/src/sst/elements/zodiac/test/testsuite_default_SiriusZodiacTrace.py
@@ -29,7 +29,7 @@ class testcase_SiriusZodiacTrace(SSTTestCase):
     def test_Sirius_Zodiac_16(self):
         self.SiriusZodiacTrace_test_template("4x4")
 
-    @unittest.skipIf(not testing_check_is_nightly(), "Sirius_Zodiac_128 only runs on Nightly builds.")
+    @categorize("nightly")
     def test_Sirius_Zodiac_128(self):
         self.SiriusZodiacTrace_test_template("8x8x2")
 


### PR DESCRIPTION
Part of https://github.com/sstsimulator/sst-core/issues/1541

This doesn't change `testsuite_weekly_memHierarchy_examples.py` to be weekly, since it doesn't run by default anyway thanks to its filename.  Maybe it should become `testsuite_default_memHierarchy_examples.py` and be decorated with `@categorize("weekly")`?