### PR TITLE
mercury libfabric/sumi and mv2 compatibility fixes

### DIFF
--- a/src/sst/elements/iris/Makefile.am
+++ b/src/sst/elements/iris/Makefile.am
@@ -7,13 +7,14 @@ SUBDIRS = libfabric
 AM_CPPFLAGS += \
 	$(MPI_CPPFLAGS) \
         -I$(top_srcdir)/src/sst/elements/iris \
+        -I$(top_srcdir)/src/sst/elements/iris/pmi \
         -I$(top_srcdir)/src/sst/elements/mercury \
         -I$(top_srcdir)/src/sst/elements
 
 # unpleasant hack to make vintage automake (e.g. 1.13.4) work
 AM_LIBTOOLFLAGS = --tag=CXX
 
-ext_LTLIBRARIES = libsumi.la
+ext_LTLIBRARIES = libsumi.la libpmi.la
 extdir = $(pkglibdir)/ext
 
 libsumi_la_SOURCES = \
@@ -79,7 +80,8 @@ nobase_library_include_HEADERS = \
   sumi/sumi_thread.h \
   sumi/timeout.h \
   sumi/transport.h \
-  sumi/transport_fwd.h
+  sumi/transport_fwd.h \
+  pmi/pmi.h
 
 if !SST_ENABLE_PREVIEW_BUILD
 libsumi_la_SOURCES += $(deprecated_libsumi_sources)
@@ -94,8 +96,19 @@ endif
 
 libsumi_la_LDFLAGS = -module -avoid-version
 
+libpmi_la_SOURCES = pmi/libpmi.cc
+libpmi_la_LDFLAGS = -avoid-version
+
 install-exec-hook:
 	$(SST_REGISTER_TOOL) SST_ELEMENT_SOURCE     iris=$(abs_srcdir)
+
+install-data-hook:
+	@$(MKDIR_P) $(DESTDIR)$(includedir)/iris
+	$(INSTALL_DATA) $(srcdir)/pmi/pmi.h $(DESTDIR)$(includedir)/iris/pmi.h
+
+uninstall-hook:
+	rm -f $(DESTDIR)$(includedir)/iris/pmi.h
+	-rmdir $(DESTDIR)$(includedir)/iris 2>/dev/null || true
 
 # This sed script converts 'od' output to a comma-separated list of byte-
 # values, suitable for #include'ing into an array definition.

--- a/src/sst/elements/iris/libfabric/include/ofi_prov.h
+++ b/src/sst/elements/iris/libfabric/include/ofi_prov.h
@@ -248,4 +248,10 @@ HOOK_DEBUG_INI ;
 #  define HOOK_NOOP_INIT fi_hook_noop_ini()
 HOOK_NOOP_INI ;
 
+#ifdef __cplusplus
+extern "C"
+#endif
+struct fi_provider* fi_prov_ini(void);
+#define SUMI_INIT fi_prov_ini()
+
 #endif /* _OFI_PROV_H_ */

--- a/src/sst/elements/iris/libfabric/prov/sumi/include/sumi_prov.h
+++ b/src/sst/elements/iris/libfabric/prov/sumi/include/sumi_prov.h
@@ -82,17 +82,6 @@ struct sumi_mem_handle_t {
 #define SUMI_READ_ALIGN_MASK	(SUMI_READ_ALIGN - 1)
 
 /*
- * GNI IOV GET alignment
- *
- * We always pull 4byte chucks for unaligned GETs. To prevent stomping on
- * someone else's head or tail data, each segment must be four bytes
- * (i.e. SUMI_READ_ALIGN bytes).
- *
- * Note: "* 2" for head and tail
- */
-#define SUMI_INT_TX_BUF_SZ (SUMI_MAX_MSG_IOV_LIMIT * SUMI_READ_ALIGN * 2)
-
-/*
  * Flags
  * The 64-bit flag field is used as follows:
  * 1-grow up    common (usable with multiple operations)
@@ -159,7 +148,10 @@ struct sumi_mem_handle_t {
 #define SUMI_MAX_MSG_SIZE (1<<31)
 #define SUMI_CACHELINE_SIZE (64)
 #define SUMI_INJECT_SIZE 64
-#define SUMI_MAX_INJECT_SIZE 64
+#define SUMI_MAX_INJECT_SIZE 16384
+
+#define SUMI_MSG_ORDER_SUPPORTED  FI_ORDER_SAS
+#define SUMI_COMP_ORDER_SUPPORTED FI_ORDER_NONE
 
 #define SUMI_FAB_MODES	0
 
@@ -434,12 +426,11 @@ struct sumi_fid_srx {
   sumi_fid_domain* domain;
 };
 
-#define ADDR_CQ(addr)    ((addr >> 16) | 0xFFFF)
-#define ADDR_RANK(addr)  ((addr >> 32) | 0xFFFFFFFF)
-#define ADDR_QUEUE(addr) (addr | 0xFFFF)
-#define ADDR_RANK_BITS(rank)    (rank << 32)
-#define ADDR_QUEUE_BITS(queue)  (queue)
-#define ADDR_CQ_BITS(cq)        (cq << 16)
+#define ADDR_CQ(addr)    (((addr) >> 16) & 0xFFFF)
+#define ADDR_RANK(addr)  ((uint32_t)(((addr) >> 32) & 0xFFFFFFFFu))
+#define ADDR_QUEUE(addr) ((addr) & 0xFFFF)
+#define ADDR_RANK_BITS(rank)    ((rank) << 32)
+#define ADDR_CQ_BITS(cq)        ((cq) << 16)
 
 extern const char sumi_fab_name[];
 extern const char sumi_dom_name[];
@@ -529,11 +520,14 @@ struct ErrorDeallocate {
 
 struct RecvQueue {
 
+  static constexpr uint32_t ANY_SRC = ~uint32_t(0);
+
   struct Recv {
     uint32_t size;
     void* buf;
-    Recv(uint32_t s, void* b) :
-      size(s), buf(b)
+    uint32_t src_rank;
+    Recv(uint32_t s, void* b, uint32_t src) :
+      size(s), buf(b), src_rank(src)
     {
     }
   };
@@ -543,8 +537,9 @@ struct RecvQueue {
     void* buf;
     uint64_t tag;
     uint64_t tag_ignore;
-    TaggedRecv(uint32_t s, void* b, uint64_t t, uint64_t ti) :
-      size(s), buf(b), tag(t), tag_ignore(ti)
+    uint32_t src_rank;
+    TaggedRecv(uint32_t s, void* b, uint64_t t, uint64_t ti, uint32_t src) :
+      size(s), buf(b), tag(t), tag_ignore(ti), src_rank(src)
     {
     }
   };
@@ -558,6 +553,10 @@ struct RecvQueue {
     return (msg->tag() & ~ignore) == (tag & ~ignore);
   }
 
+  static bool srcMatches(uint32_t want, FabricMessage* msg){
+    return want == ANY_SRC || want == (uint32_t)msg->sender();
+  }
+
   std::list<Recv> recvs;
   std::list<TaggedRecv> tagged_recvs;
   std::list<FabricMessage*> unexp_recvs;
@@ -569,7 +568,8 @@ struct RecvQueue {
 
   void matchTaggedRecv(FabricMessage* msg);
 
-  void postRecv(uint32_t size, void* buf, uint64_t tag, uint64_t tag_ignore, bool tagged);
+  void postRecv(uint32_t size, void* buf, uint64_t tag, uint64_t tag_ignore,
+                bool tagged, uint32_t src_rank);
 
   void incoming(SST::Iris::sumi::Message* msg);
 

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_av.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_av.cc
@@ -106,9 +106,12 @@ static struct fi_ops sumi_fi_av_ops = {
   .ops_open = fi_no_ops_open
 };
 
-#define SUMI_MAX_ADDR_CHARS 7
-#define SUMI_ADDR_FORMAT_STR "%7" PRIu64
-#define SUMI_MAX_ADDR_LEN SUMI_MAX_ADDR_CHARS+1
+// FI_ADDR_STR format: "<rank10>.<cq5>" with zero-padding, exactly 16 chars
+// plus a trailing NUL = 17 bytes. Round-trips (rank, cq) through the string
+// form so av_insert(getname()) == binary-encoded fi_addr_t.
+#define SUMI_MAX_ADDR_CHARS 16
+#define SUMI_ADDR_FORMAT_STR "%010" PRIu32 ".%05" PRIu16
+#define SUMI_MAX_ADDR_LEN (SUMI_MAX_ADDR_CHARS+1)
 
 /*
  * Note: this function (according to WG), is not intended to
@@ -129,8 +132,9 @@ EXTERN_C DIRECT_FN STATIC  int sumi_av_lookup(struct fid_av *av, fi_addr_t fi_ad
     if (*addrlen < SUMI_MAX_ADDR_LEN){
       return -FI_EINVAL;
     }
-    //all addresses are just strings of the rank
-    snprintf((char*)addr, SUMI_MAX_ADDR_LEN, SUMI_ADDR_FORMAT_STR, fi_addr);
+    uint32_t rank = ADDR_RANK(fi_addr);
+    uint16_t cq   = ADDR_CQ(fi_addr);
+    snprintf((char*)addr, SUMI_MAX_ADDR_LEN, SUMI_ADDR_FORMAT_STR, rank, cq);
     *addrlen = SUMI_MAX_ADDR_LEN;
   } else {
     sst_hg_abort_printf("internal error: got addr format that isn't SSTMAC or STR");
@@ -144,10 +148,26 @@ EXTERN_C DIRECT_FN STATIC  int sumi_av_insert(struct fid_av *av, const void *add
 {
   sumi_fid_av* av_impl = (sumi_fid_av*) av;
   if (av_impl->domain->addr_format == FI_ADDR_STR){
+    static bool warned_legacy_addr = false;
     char* addr_str = (char*) addr;
     for (int i=0; i < count; ++i){
-      long long rank = std::atoll(addr_str);
-      fi_addr[i] = rank;
+      // Each slot must be NUL-terminated inside SUMI_MAX_ADDR_LEN bytes.
+      if (strnlen(addr_str, SUMI_MAX_ADDR_LEN) == (size_t)SUMI_MAX_ADDR_LEN){
+        return -FI_EINVAL;
+      }
+      // Parse "<rank>.<cq>"; accept legacy "<rank>" by defaulting cq to 0.
+      char* end = nullptr;
+      uint32_t rank = (uint32_t) std::strtoul(addr_str, &end, 10);
+      uint16_t cq = 0;
+      if (end && *end == '.'){
+        cq = (uint16_t) std::strtoul(end + 1, nullptr, 10);
+      } else if (!warned_legacy_addr){
+        fprintf(stderr,
+                "WARNING: sumi av_insert accepted legacy \"<rank>\" "
+                "FI_ADDR_STR form; expected \"<rank10>.<cq5>\" (cq=0)\n");
+        warned_legacy_addr = true;
+      }
+      fi_addr[i] = ADDR_RANK_BITS((uint64_t)rank) | ADDR_CQ_BITS((uint64_t)cq);
       addr_str += SUMI_MAX_ADDR_LEN;
     }
   } else if (av_impl->domain->addr_format == FI_ADDR_SSTMAC) {
@@ -223,6 +243,10 @@ extern "C" DIRECT_FN  int sumi_av_open(struct fid_domain *domain, struct fi_av_a
 {
   sumi_fid_av* av_impl = (sumi_fid_av*) calloc(1, sizeof(sumi_fid_av));
   av_impl->av_fid.fid.fclass = FI_CLASS_AV;
+  av_impl->av_fid.fid.context = context;
+  av_impl->av_fid.fid.ops = const_cast<fi_ops*>(&sumi_fi_av_ops);
+  av_impl->av_fid.ops = const_cast<fi_ops_av*>(&sumi_av_ops);
+  av_impl->domain = (sumi_fid_domain*) domain;
   *av = (fid_av*) av_impl;
   return FI_SUCCESS;
 }

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cm.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cm.cc
@@ -21,7 +21,9 @@
 #include "sumi_prov.h"
 #include "sumi_av.h"
 
+#include <sumi_fabric.hpp>
 #include <mercury/common/errors.h>
+#include <inttypes.h>
 
 EXTERN_C DIRECT_FN STATIC  int sumi_setname(fid_t fid, void *addr, size_t addrlen);
 EXTERN_C DIRECT_FN STATIC  int sumi_getname(fid_t fid, void *addr, size_t *addrlen);
@@ -103,83 +105,37 @@ struct fi_ops_cm sumi_pep_ops_cm = {
 EXTERN_C DIRECT_FN STATIC  int sumi_getname(fid_t fid, void *addr, size_t *addrlen)
 {
   sumi_fid_ep* ep = (sumi_fid_ep*) fid;
-  if (ep->domain->addr_format == FI_ADDR_STR){
+  FabricTransport* tport = (FabricTransport*) ep->domain->fabric->tport;
+  uint32_t rank = tport->rank();
+  uint16_t cq_id = ep->recv_cq ? ep->recv_cq->id : 0;
 
-  } else if (ep->domain->addr_format == FI_ADDR_SSTMAC){
-
-  } else {
-    sst_hg_abort_printf("internal error: got bad addr format");
+  if (ep->domain->addr_format == FI_ADDR_SSTMAC){
+    size_t need = sizeof(uint64_t);
+    if (*addrlen < need){
+      *addrlen = need;
+      return -FI_ETOOSMALL;
+    }
+    uint64_t encoded = ADDR_RANK_BITS((uint64_t)rank) | ADDR_CQ_BITS((uint64_t)cq_id);
+    memcpy(addr, &encoded, sizeof(encoded));
+    *addrlen = need;
+    return FI_SUCCESS;
   }
 
-	int ret;
-	size_t len = 0, cpylen = 0;
-#if 0
-  struct sumi_fid_ep *ep = NULL;
-  struct sumi_fid_sep *sep = NULL;
-  struct sumi_fid_pep *pep = NULL;
-	bool is_fi_addr_str;
-	struct fi_info *info;
-  struct sumi_ep_name *ep_name;
+  if (ep->domain->addr_format == FI_ADDR_STR){
+    // "<rank>.<cq>" zero-padded fixed width; round-trips through sumi_av_insert.
+    char buf[32];
+    int n = snprintf(buf, sizeof(buf), "%010" PRIu32 ".%05" PRIu16, rank, cq_id);
+    size_t need = (size_t)n + 1;
+    if (*addrlen < need){
+      *addrlen = need;
+      return -FI_ETOOSMALL;
+    }
+    memcpy(addr, buf, need);
+    *addrlen = need;
+    return FI_SUCCESS;
+  }
 
-	if (OFI_UNLIKELY(addrlen == NULL)) {
-    SUMI_INFO(FI_LOG_EP_CTRL, "parameter \"addrlen\" is NULL in "
-      "sumi_getname\n");
-		return -FI_EINVAL;
-	}
-
-	switch (fid->fclass) {
-	case FI_CLASS_EP:
-    ep = container_of(fid, struct sumi_fid_ep, ep_fid.fid);
-		info = ep->info;
-		ep_name = &ep->src_addr;
-		break;
-	case FI_CLASS_SEP:
-    sep = container_of(fid, struct sumi_fid_sep, ep_fid);
-		info = sep->info;
-		ep_name = &sep->my_name;
-		break;
-	case FI_CLASS_PEP:
-    pep = container_of(fid, struct sumi_fid_pep,
-				   pep_fid.fid);
-		info = pep->info;
-		ep_name = &pep->src_addr;
-		break;
-	default:
-    SUMI_INFO(FI_LOG_EP_CTRL,
-			  "Invalid fid class: %d\n",
-			  fid->fclass);
-		return -FI_EINVAL;
-	}
-
-	is_fi_addr_str = info->addr_format == FI_ADDR_STR;
-
-	if (!addr) {
-		if (OFI_UNLIKELY(is_fi_addr_str)) {
-      *addrlen = SUMI_FI_ADDR_STR_LEN;
-		} else {
-      *addrlen = sizeof(struct sumi_ep_name);
-		}
-
-		return -FI_ETOOSMALL;
-	}
-
-	if (OFI_UNLIKELY(is_fi_addr_str)) {
-    ret = _sumi_ep_name_to_str(ep_name, (char **) &addr);
-
-		if (ret)
-			return ret;
-
-    len = SUMI_FI_ADDR_STR_LEN;
-		cpylen = MIN(len, *addrlen);
-	} else {
-    len = sizeof(struct sumi_ep_name);
-		cpylen = MIN(len, *addrlen);
-		memcpy(addr, ep_name, cpylen);
-	}
-
-	*addrlen = len;
-#endif
-	return (len == cpylen) ? FI_SUCCESS : -FI_ETOOSMALL;
+  return -FI_EINVAL;
 }
 
 EXTERN_C DIRECT_FN STATIC  int sumi_setname(fid_t fid, void *addr, size_t addrlen)

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cq.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_cq.cc
@@ -14,12 +14,34 @@
 // distribution.
 
 #include <string.h>
+#include <stdlib.h>
 #include <assert.h>
 
 #include "sumi_prov.h"
 #include "sumi_wait.h"
 
 #include <sumi_fabric.hpp>
+#include <mercury/components/operating_system.h>
+
+// Simulated idle (in ns) applied to non-blocking CQ reads that find no
+// completion. Default 1 ns prevents the simulator from burning unbounded
+// simulated cycles in a pure spin (the native OFI behavior). Override with
+// SUMI_CQ_NONBLOCK_YIELD_NS; set to 0 to disable the yield. Resolved once.
+static uint64_t sumi_cq_nonblock_yield_ns()
+{
+  static uint64_t cached = [](){
+    uint64_t v = 1;
+    if (const char* env = getenv("SUMI_CQ_NONBLOCK_YIELD_NS")){
+      char* end = nullptr;
+      long long parsed = strtoll(env, &end, 0);
+      if (end != env && parsed >= 0){
+        v = (uint64_t)parsed;
+      }
+    }
+    return v;
+  }();
+  return cached;
+}
 
 static int sumi_cq_close(fid_t fid);
 static int sumi_cq_control(struct fid *cq, int command, void *arg);
@@ -112,8 +134,13 @@ static int sumi_cq_close(fid_t fid)
   sumi_fid_cq* cq_impl = (sumi_fid_cq*) fid;
   FabricTransport* tport = (FabricTransport*) cq_impl->domain->fabric->tport;
   tport->deallocateCq(cq_impl->id);
+  // Intentionally do not delete cq_impl->queue (RecvQueue) here. In MV2 the
+  // CQ close happens during simulator teardown; deleting the RecvQueue at
+  // this point can strand threads still blocked in its progress queue or
+  // race with late callbacks. The RecvQueue is leaked until process exit,
+  // which is acceptable for the finalize-only call path we exercise today.
   free(cq_impl);
-	return FI_SUCCESS;
+  return FI_SUCCESS;
 }
 
 static ssize_t sstmaci_cq_read(bool blocking,
@@ -125,17 +152,39 @@ static ssize_t sstmaci_cq_read(bool blocking,
   FabricTransport* tport = (FabricTransport*) cq_impl->domain->fabric->tport;
   RecvQueue* rq = (RecvQueue*) cq_impl->queue;
 
+  double pragma_timeout = -1;
+  tport->configureNextPoll(blocking, pragma_timeout);
+
   size_t done = 0;
   while (done < count){
-    double timeout_s = (blocking && timeout > 0) ? timeout*1e-3 : -1;
+    double timeout_s = -1;
+    if (blocking && timeout > 0) {
+      timeout_s = timeout * 1e-3;
+    } else if (blocking && pragma_timeout > 0) {
+      timeout_s = pragma_timeout;
+    }
     SST::Iris::sumi::Message* msg = rq->progress.front(blocking, timeout_s);
     if (!msg){
+      if (!blocking) {
+        uint64_t ns = sumi_cq_nonblock_yield_ns();
+        if (ns){
+          auto* os = SST::Hg::OperatingSystem::currentOs();
+          // Caveat: blockTimeout yields the simulated thread. If a caller
+          // holds a pthread mutex across fi_cq_read, another thread that needs
+          // that mutex to make progress can deadlock. MV2's progress engine
+          // does not hold mutexes here, but future callers should avoid that
+          // pattern. Set SUMI_CQ_NONBLOCK_YIELD_NS=0 to disable the yield.
+          os->blockTimeout(SST::Hg::TimeDelta(ns * 1e-9));
+        }
+      }
       break;
     }
     if (src_addr){
       src_addr[done] = msg->sender();
     }
     buf = sstmaci_fill_cq_entry(cq_impl->format, buf, static_cast<FabricMessage*>(msg));
+    rq->progress.pop();
+    delete msg;
     done++;
   }
   return done ? done : -FI_EAGAIN;
@@ -203,9 +252,13 @@ extern "C" DIRECT_FN  int sumi_cq_open(struct fid_domain *domain, struct fi_cq_a
 			   struct fid_cq **cq, void *context)
 {
   sumi_fid_domain* domain_impl = (sumi_fid_domain*) domain;
-  FabricTransport* tport = (FabricTransport*) domain_impl;
+  FabricTransport* tport = (FabricTransport*) domain_impl->fabric->tport;
   int id = tport->allocateCqId();
   sumi_fid_cq* cq_impl = (sumi_fid_cq*) calloc(1, sizeof(sumi_fid_cq));
+  cq_impl->cq_fid.fid.fclass = FI_CLASS_CQ;
+  cq_impl->cq_fid.fid.context = context;
+  cq_impl->cq_fid.fid.ops = const_cast<fi_ops*>(&sumi_cq_fi_ops);
+  cq_impl->cq_fid.ops = const_cast<fi_ops_cq*>(&sumi_cq_ops);
   cq_impl->domain = domain_impl;
   cq_impl->id = id;
   cq_impl->format = attr->format;
@@ -245,10 +298,11 @@ void RecvQueue::finishMatch(void* buf, uint32_t size, FabricMessage *msg)
 }
 
 void RecvQueue::matchTaggedRecv(FabricMessage* msg){
-  for (auto it = tagged_recvs.begin(); it != tagged_recvs.end(); ++it){
+  // it++ in body so we can erase tmp
+  for (auto it = tagged_recvs.begin(); it != tagged_recvs.end(); ){
     auto tmp = it++;
     TaggedRecv& r = *tmp;
-    if (matches(msg, r.tag, r.tag_ignore)){
+    if (srcMatches(r.src_rank, msg) && matches(msg, r.tag, r.tag_ignore)){
       finishMatch(r.buf, r.size, msg);
       tagged_recvs.erase(tmp);
       return;
@@ -257,30 +311,33 @@ void RecvQueue::matchTaggedRecv(FabricMessage* msg){
   unexp_tagged_recvs.push_back(msg);
 }
 
-void RecvQueue::postRecv(uint32_t size, void* buf, uint64_t tag, uint64_t tag_ignore, bool tagged){
+void RecvQueue::postRecv(uint32_t size, void* buf, uint64_t tag,
+                         uint64_t tag_ignore, bool tagged, uint32_t src_rank){
   if (tagged){
-    if (unexp_tagged_recvs.empty()){
-      tagged_recvs.emplace_back(size, buf, tag, tag_ignore);
-    } else {
-      for (auto it = unexp_tagged_recvs.begin(); it != unexp_tagged_recvs.end(); ++it){
-        auto tmp = it++;
-        FabricMessage* msg = *tmp;
-        if (matches(msg, tag, tag_ignore)){
-          finishMatch(buf, size, msg);
-          return;
-        }
+    // it++ in body so we can erase tmp
+    for (auto it = unexp_tagged_recvs.begin(); it != unexp_tagged_recvs.end(); ){
+      auto tmp = it++;
+      FabricMessage* msg = *tmp;
+      if (srcMatches(src_rank, msg) && matches(msg, tag, tag_ignore)){
+        finishMatch(buf, size, msg);
+        unexp_tagged_recvs.erase(tmp);
+        return;
       }
     }
     //nothing matched
-    tagged_recvs.emplace_back(size, buf, tag, tag_ignore);
+    tagged_recvs.emplace_back(size, buf, tag, tag_ignore, src_rank);
   } else {
-    if (unexp_recvs.empty()){
-      recvs.emplace_back(size, buf);
-    } else {
-      FabricMessage* msg = unexp_recvs.front();
-      unexp_recvs.pop_front();;
-      finishMatch(buf, size, msg);
+    // it++ in body so we can erase tmp
+    for (auto it = unexp_recvs.begin(); it != unexp_recvs.end(); ){
+      auto tmp = it++;
+      FabricMessage* msg = *tmp;
+      if (srcMatches(src_rank, msg)){
+        finishMatch(buf, size, msg);
+        unexp_recvs.erase(tmp);
+        return;
+      }
     }
+    recvs.emplace_back(size, buf, src_rank);
   }
 }
 
@@ -290,13 +347,17 @@ void RecvQueue::incoming(SST::Iris::sumi::Message* msg){
     if (fmsg->flags() & FI_TAGGED){
       matchTaggedRecv(fmsg);
     } else {
-      if (recvs.empty()){
-        unexp_recvs.push_back(fmsg);
-      } else {
-        Recv& r = recvs.front();
-        finishMatch(r.buf, r.size, fmsg);
-        recvs.pop_front();
+      // it++ in body so we can erase tmp
+      for (auto it = recvs.begin(); it != recvs.end(); ){
+        auto tmp = it++;
+        Recv& r = *tmp;
+        if (srcMatches(r.src_rank, fmsg)){
+          finishMatch(r.buf, r.size, fmsg);
+          recvs.erase(tmp);
+          return;
+        }
       }
+      unexp_recvs.push_back(fmsg);
     }
   } else {
     //all other messages go right through

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_ep.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_ep.cc
@@ -305,14 +305,12 @@ static ssize_t sstmaci_ep_recv(struct fid_ep* ep, void* buf, size_t len, fi_addr
                                uint64_t tag, uint64_t tag_ignore, uint64_t flags)
 {
   sumi_fid_ep* ep_impl = (sumi_fid_ep*) ep;
-  FabricTransport* tport = (FabricTransport*) ep_impl->domain->fabric->tport;
-
-  if (src_addr != FI_ADDR_UNSPEC){
-    return -FI_EINVAL;
-  }
 
   RecvQueue* rq = (RecvQueue*) ep_impl->recv_cq->queue;
-  rq->postRecv(len, buf, tag, tag_ignore, bool(flags & FI_TAGGED));
+  uint32_t src_rank = (src_addr == FI_ADDR_UNSPEC)
+      ? RecvQueue::ANY_SRC
+      : ADDR_RANK(src_addr);
+  rq->postRecv(len, buf, tag, tag_ignore, bool(flags & FI_TAGGED), src_rank);
 
   return 0;
 }
@@ -355,14 +353,17 @@ static ssize_t sstmaci_ep_send(struct fid_ep* ep, const void* buf, size_t len,
 
   uint32_t dest_rank = ADDR_RANK(dest_addr);
   uint16_t remote_cq = ADDR_CQ(dest_addr);
-  //uint16_t recv_queue = ADDR_QUEUE(dest_addr);
 
   flags |= FI_SEND;
 
+  int local_cq = (flags & FI_INJECT)
+      ? SST::Iris::sumi::Message::no_ack
+      : ep_impl->send_cq->id;
+
   tport->postSend<FabricMessage>(dest_rank, len, const_cast<void*>(buf),
-                                 ep_impl->send_cq->id, // rma operations go to the tx
+                                 local_cq,
                                  remote_cq, SST::Iris::sumi::Message::pt2pt, ep_impl->qos,
-                                 tag, FabricMessage::no_imm_data, flags, context);
+                                 tag, flags, data, context);
   return 0;
 }
 
@@ -566,7 +567,16 @@ DIRECT_FN STATIC ssize_t sumi_ep_trecvmsg(struct fid_ep *ep,
 					  const struct fi_msg_tagged *msg,
 					  uint64_t flags)
 {
-  return -FI_ENOSYS;
+  if (!msg || msg->iov_count < 1)
+    return -FI_EINVAL;
+  return sstmaci_ep_recv(ep,
+                         msg->msg_iov[0].iov_base,
+                         msg->msg_iov[0].iov_len,
+                         msg->addr,
+                         msg->context,
+                         msg->tag,
+                         msg->ignore,
+                         FI_TAGGED | flags);
 }
 
 DIRECT_FN STATIC ssize_t sumi_ep_tsend(struct fid_ep *ep, const void *buf,
@@ -613,14 +623,16 @@ DIRECT_FN STATIC ssize_t sumi_ep_tinject(struct fid_ep *ep, const void *buf,
 					 size_t len, fi_addr_t dest_addr,
 					 uint64_t tag)
 {
-  return -FI_ENOSYS;
+  return sstmaci_ep_send(ep, buf, len, dest_addr, nullptr, tag,
+                         FabricMessage::no_imm_data, FI_TAGGED | FI_INJECT);
 }
 
 DIRECT_FN STATIC ssize_t sumi_ep_tinjectdata(struct fid_ep *ep, const void *buf,
 					     size_t len, uint64_t data,
 					     fi_addr_t dest_addr, uint64_t tag)
 {
-  return -FI_ENOSYS;
+  return sstmaci_ep_send(ep, buf, len, dest_addr, nullptr, tag,
+                         data, FI_TAGGED | FI_INJECT | FI_REMOTE_CQ_DATA);
 }
 
 extern "C" DIRECT_FN  int sumi_ep_atomic_valid(struct fid_ep *ep,
@@ -750,7 +762,14 @@ DIRECT_FN STATIC ssize_t sumi_ep_atomic_compwritemsg(struct fid_ep *ep,
 
 EXTERN_C DIRECT_FN STATIC  int sumi_ep_control(fid_t fid, int command, void *arg)
 {
-  return -FI_ENOSYS;
+  switch (command) {
+  case FI_ENABLE:
+    return FI_SUCCESS;
+  case FI_GETOPSFLAG:
+  case FI_SETOPSFLAG:
+  default:
+    return -FI_ENOSYS;
+  }
 }
 
 extern "C" int sumi_ep_close(fid_t fid)
@@ -808,9 +827,17 @@ extern "C" DIRECT_FN  int sumi_ep_bind(fid_t fid, struct fid *bfid, uint64_t fla
         }
       }
 
-      RecvQueue* rq = new RecvQueue(SST::Hg::OperatingSystem::currentOs());
-      cq->queue = (sumi_progress_queue*) rq;
-      tport->allocateCq(cq->id, std::bind(&RecvQueue::incoming, rq, std::placeholders::_1));
+      // NOTE: this provider is not configured / tested for the case where
+      // multiple endpoints share a single CQ. We reuse the existing RecvQueue
+      // if one is already attached, but a second ep binding the same CQ would
+      // also need to register its own allocateCq() callback path. If support
+      // for 2-EP-1-CQ is ever required, revisit RecvQueue allocation and the
+      // tport->allocateCq() callback registration below.
+      if (!cq->queue) {
+        RecvQueue* rq = new RecvQueue(SST::Hg::OperatingSystem::currentOs());
+        cq->queue = (sumi_progress_queue*) rq;
+        tport->allocateCq(cq->id, std::bind(&RecvQueue::incoming, rq, std::placeholders::_1));
+      }
       break;
     }
     case FI_CLASS_AV: {
@@ -847,6 +874,7 @@ extern "C" DIRECT_FN  int sumi_ep_open(struct fid_domain *domain, struct fi_info
   ep_impl->ep_fid.fid.context = context;
   ep_impl->ep_fid.fid.ops = &sumi_ep_fi_ops;
   ep_impl->ep_fid.ops = &sumi_ep_ops;
+  ep_impl->ep_fid.cm = &sumi_ep_ops_cm;
   ep_impl->ep_fid.msg = &sumi_ep_msg_ops;
   ep_impl->ep_fid.rma = &sumi_ep_rma_ops;
   ep_impl->ep_fid.tagged = &sumi_ep_tagged_ops;

--- a/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_fabric.cc
+++ b/src/sst/elements/iris/libfabric/prov/sumi/src/sumi_fabric.cc
@@ -197,6 +197,25 @@ static void sumi_fini(void)
   FI_DIRECTED_RECV | FI_READ | FI_NAMED_RX_CTX | \
   FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE)
 
+// Advertised inject size; overridable at runtime via SUMI_FI_INJECT_SIZE,
+// clamped to [1, SUMI_MAX_INJECT_SIZE]. Resolved once on first call.
+static size_t sumi_runtime_inject_size()
+{
+  static size_t cached = [](){
+    size_t v = SUMI_INJECT_SIZE;
+    if (const char* env = getenv("SUMI_FI_INJECT_SIZE")){
+      char* end = nullptr;
+      long parsed = strtol(env, &end, 0);
+      if (end != env && parsed > 0){
+        if ((size_t)parsed > SUMI_MAX_INJECT_SIZE) parsed = SUMI_MAX_INJECT_SIZE;
+        v = (size_t)parsed;
+      }
+    }
+    return v;
+  }();
+  return cached;
+}
+
 static struct fi_info *sumi_allocinfo(void)
 {
   struct fi_info *sumi_info;
@@ -273,16 +292,16 @@ static struct fi_info *sumi_allocinfo(void)
 
 
   sumi_info->tx_attr->caps = SUMI_EP_PRIMARY_CAPS;
-  sumi_info->tx_attr->msg_order = FI_ORDER_SAS;
-  sumi_info->tx_attr->comp_order = FI_ORDER_NONE;
-  sumi_info->tx_attr->inject_size = SUMI_INJECT_SIZE;
+  sumi_info->tx_attr->msg_order = SUMI_MSG_ORDER_SUPPORTED;
+  sumi_info->tx_attr->comp_order = SUMI_COMP_ORDER_SUPPORTED;
+  sumi_info->tx_attr->inject_size = sumi_runtime_inject_size();
   sumi_info->tx_attr->size = SUMI_TX_SIZE_DEFAULT;
   sumi_info->tx_attr->iov_limit = SUMI_MAX_MSG_IOV_LIMIT;
   sumi_info->tx_attr->rma_iov_limit = SUMI_MAX_RMA_IOV_LIMIT;
 
   sumi_info->rx_attr->caps = SUMI_EP_PRIMARY_CAPS;
-  sumi_info->rx_attr->msg_order = FI_ORDER_SAS;
-  sumi_info->rx_attr->comp_order = FI_ORDER_NONE;
+  sumi_info->rx_attr->msg_order = SUMI_MSG_ORDER_SUPPORTED;
+  sumi_info->rx_attr->comp_order = SUMI_COMP_ORDER_SUPPORTED;
   sumi_info->rx_attr->size = SUMI_RX_SIZE_DEFAULT;
   sumi_info->rx_attr->iov_limit = SUMI_MAX_MSG_IOV_LIMIT;
 
@@ -319,6 +338,8 @@ static int sumi_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
     if (hints->addr_format == FI_ADDR_STR){
       info->addr_format = FI_ADDR_STR;
     } else if (hints->addr_format == FI_ADDR_SSTMAC){
+      info->addr_format = FI_ADDR_SSTMAC;
+    } else if (hints->addr_format == FI_FORMAT_UNSPEC){
       info->addr_format = FI_ADDR_SSTMAC;
     } else {
       return -FI_ENODATA;
@@ -390,14 +411,13 @@ static int sumi_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
         return -FI_ENODATA;
       }
 
-      //we current do not support any ordering relationships
-      //if the app requires ordering, we can't help it
-      if (hints->tx_attr->comp_order && hints->tx_attr->comp_order != FI_ORDER_NONE){
+      // Reject any ordering bits we cannot guarantee.
+      if ((hints->tx_attr->msg_order  & ~SUMI_MSG_ORDER_SUPPORTED) ||
+          (hints->tx_attr->comp_order & ~SUMI_COMP_ORDER_SUPPORTED)){
         return -FI_ENODATA;
       }
-      if (hints->tx_attr->msg_order && hints->tx_attr->msg_order != FI_ORDER_NONE){
-        return -FI_ENODATA;
-      }
+      info->tx_attr->comp_order = hints->tx_attr->comp_order;
+      info->tx_attr->msg_order  = hints->tx_attr->msg_order;
 
       if (hints->tx_attr->caps){
         if (hints->caps){
@@ -415,19 +435,17 @@ static int sumi_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
     }
 
     if (hints->rx_attr){
-      if ((hints->rx_attr->op_flags & SUMI_EP_OP_FLAGS) != hints->tx_attr->op_flags){
-        //the app is requesting operations I don't support
+      if ((hints->rx_attr->op_flags & SUMI_EP_OP_FLAGS) != hints->rx_attr->op_flags){
         return -FI_ENODATA;
       }
 
-      //we current do not support any ordering relationships
-      //if the app requires ordering, we can't help it
-      if (hints->rx_attr->comp_order && hints->rx_attr->comp_order != FI_ORDER_NONE){
+      // Reject any ordering bits we cannot guarantee.
+      if ((hints->rx_attr->msg_order  & ~SUMI_MSG_ORDER_SUPPORTED) ||
+          (hints->rx_attr->comp_order & ~SUMI_COMP_ORDER_SUPPORTED)){
         return -FI_ENODATA;
       }
-      if (hints->rx_attr->msg_order && hints->rx_attr->msg_order != FI_ORDER_NONE){
-        return -FI_ENODATA;
-      }
+      info->rx_attr->comp_order = hints->rx_attr->comp_order;
+      info->rx_attr->msg_order  = hints->rx_attr->msg_order;
     }
 
     if (hints->domain_attr) {
@@ -533,13 +551,8 @@ struct fi_provider sumi_prov = {
 	.cleanup = sumi_fini
 };
 
-__attribute__((visibility ("default"),EXTERNALLY_VISIBLE)) \
+extern "C" __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 struct fi_provider* fi_prov_ini(void)
 {
-	struct fi_provider *provider = NULL;
-	sumi_return_t status;
-  //sumi_version_info_t lib_version;
-	int num_devices;
-	int ret;
-	return (provider);
+	return &sumi_prov;
 }

--- a/src/sst/elements/iris/libfabric/src/fabric.c
+++ b/src/sst/elements/iris/libfabric/src/fabric.c
@@ -672,6 +672,7 @@ libdl_done:
 	ofi_register_provider(UDP_INIT, NULL);
 	ofi_register_provider(SOCKETS_INIT, NULL);
 	ofi_register_provider(TCP_INIT, NULL);
+	ofi_register_provider(SUMI_INIT, NULL);
 
 	ofi_register_provider(HOOK_PERF_INIT, NULL);
 	ofi_register_provider(HOOK_DEBUG_INIT, NULL);

--- a/src/sst/elements/iris/pmi/libpmi.cc
+++ b/src/sst/elements/iris/pmi/libpmi.cc
@@ -16,13 +16,13 @@ static SST::Iris::sumi::Transport* sstmac_pmi()
   return t->getLibrary<SST::Iris::sumi::Transport>("libfabric");
 }
 
-extern "C" int PMI_Get_rank(int *ret)
+int PMI_Get_rank(int *ret)
 {
   *ret = sstmac_pmi()->rank();
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Get_size(int* ret)
+int PMI_Get_size(int* ret)
 {
   *ret = sstmac_pmi()->nproc();
   return PMI_SUCCESS;
@@ -62,7 +62,7 @@ static std::string current_jobid_str()
   return std::string(buf);
 }
 
-extern "C" int
+int
 PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
 {
   kvs_lock.lock();
@@ -71,7 +71,7 @@ PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
 {
   kvs_lock.lock();
@@ -95,7 +95,7 @@ PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_KVS_Put(const char key[], const char value[])
 {
   std::string kvsname = current_jobid_str();
@@ -105,7 +105,7 @@ PMI2_KVS_Put(const char key[], const char value[])
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_KVS_Get(const char *jobid, int /*src_pmi_id*/, const char key[],
              char value[], int maxvalue, int *vallen)
 {
@@ -135,20 +135,20 @@ PMI2_KVS_Get(const char *jobid, int /*src_pmi_id*/, const char key[],
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_KVS_Fence(void)
 {
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_Abort(void)
 {
   SST::Hg::abort("unimplemented: PMI2_Abort");
   __builtin_unreachable();
 }
 
-extern "C" int
+int
 PMI2_Job_GetId(char jobid[], int jobid_size)
 {
   auto* api = sstmac_pmi();
@@ -156,7 +156,7 @@ PMI2_Job_GetId(char jobid[], int jobid_size)
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
 {
   auto api = sstmac_pmi();
@@ -169,19 +169,19 @@ PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Abort(int rc, const char error_msg[])
+int PMI_Abort(int rc, const char error_msg[])
 {
   SST::Hg::abort(error_msg ? error_msg : "PMI_Abort called with null message");
   __builtin_unreachable();
 }
 
-extern "C" int PMI_Initialized( PMI_BOOL *initialized )
+int PMI_Initialized( PMI_BOOL *initialized )
 {
   *initialized = pmi_flag_get(pmi_initialized_map) ? 1 : 0;
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI2_Finalize()
 {
   pmi_flag_set(pmi_finalized_map, true);
@@ -191,14 +191,14 @@ PMI2_Finalize()
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_Get_nidlist_ptr(void** nidlist)
 {
   *nidlist = sstmac_pmi()->nidlist();
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Init(int* spawned)
+int PMI_Init(int* spawned)
 {
   auto* tport = sstmac_pmi();
   tport->init();
@@ -221,7 +221,7 @@ extern "C" int PMI_Init(int* spawned)
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Finalize()
+int PMI_Finalize()
 {
   sstmac_pmi()->finish();
   pmi_flag_set(pmi_initialized_map, false);
@@ -230,7 +230,7 @@ extern "C" int PMI_Finalize()
 }
 
 
-extern "C" int PMI_Allgather(void *in, void *out, int len)
+int PMI_Allgather(void *in, void *out, int len)
 {
   auto tport = sstmac_pmi();
   int init_tag = tport->engine()->allocateGlobalCollectiveTag();
@@ -239,7 +239,7 @@ extern "C" int PMI_Allgather(void *in, void *out, int len)
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Barrier()
+int PMI_Barrier()
 {
   auto api = sstmac_pmi();
   int init_tag = api->engine()->allocateGlobalCollectiveTag();
@@ -249,7 +249,7 @@ extern "C" int PMI_Barrier()
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Ibarrier()
+int PMI_Ibarrier()
 {
   auto api = sstmac_pmi();
   int init_tag = api->engine()->allocateGlobalCollectiveTag();
@@ -258,7 +258,7 @@ extern "C" int PMI_Ibarrier()
   return PMI_SUCCESS;
 }
 
-extern "C" int PMI_Wait()
+int PMI_Wait()
 {
   if (!pmi_flag_get(ibarrier_pending_map))
     return PMI_SUCCESS;
@@ -269,49 +269,49 @@ extern "C" int PMI_Wait()
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_Get_numpes_on_smp(int* num)
 {
   *num = 1;
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_Publish_name( const char service_name[], const char port[] )
 {
   SST::Hg::abort("unimplemented error: PMI_Publish_name");
   __builtin_unreachable();
 }
 
-extern "C" int
+int
 PMI_Unpublish_name( const char service_name[] )
 {
   SST::Hg::abort("unimplemented error: PMI_Unpublish_name");
   __builtin_unreachable();
 }
 
-extern "C" int
+int
 PMI_KVS_Get_name_length_max( int *length )
 {
   *length = 256;
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_KVS_Get_key_length_max( int *length )
 {
   *length = 256;
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_KVS_Get_value_length_max( int *length )
 {
   *length = 256;
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_KVS_Get_my_name( char kvsname[], int length )
 {
   auto* api = sstmac_pmi();
@@ -323,7 +323,7 @@ PMI_KVS_Get_my_name( char kvsname[], int length )
   }
 }
 
-extern "C" int
+int
 PMI_Spawn_multiple(int count,
                        const char * cmds[],
                        const char ** argvs[],
@@ -338,20 +338,20 @@ PMI_Spawn_multiple(int count,
   __builtin_unreachable();
 }
 
-extern "C" int
+int
 PMI_Lookup_name( const char service_name[], char port[] )
 {
   SST::Hg::abort("unimplemented error: PMI_Lookup_name");
   __builtin_unreachable();
 }
 
-extern "C" int
+int
 PMI_KVS_Commit( const char kvsname[] )
 {
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_Get_universe_size( int *size )
 {
   auto* api = sstmac_pmi();
@@ -359,7 +359,7 @@ PMI_Get_universe_size( int *size )
   return PMI_SUCCESS;
 }
 
-extern "C" int
+int
 PMI_Get_appnum( int *appnum )
 {
   auto* api = sstmac_pmi();

--- a/src/sst/elements/iris/pmi/libpmi.cc
+++ b/src/sst/elements/iris/pmi/libpmi.cc
@@ -1,0 +1,368 @@
+#include "pmi.h"
+#include <mercury/common/errors.h>
+#include <mercury/common/thread_lock.h>
+#include <mercury/components/operating_system.h>
+#include <mercury/operating_system/process/app.h>
+#include <mercury/operating_system/process/thread.h>
+#include <iris/sumi/message.h>
+#include <iris/sumi/transport.h>
+#include <cstdio>
+#include <cstring>
+#include <unordered_map>
+
+static SST::Iris::sumi::Transport* sstmac_pmi()
+{
+  SST::Hg::Thread* t = SST::Hg::OperatingSystem::currentThread();
+  return t->getLibrary<SST::Iris::sumi::Transport>("libfabric");
+}
+
+extern "C" int PMI_Get_rank(int *ret)
+{
+  *ret = sstmac_pmi()->rank();
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Get_size(int* ret)
+{
+  *ret = sstmac_pmi()->nproc();
+  return PMI_SUCCESS;
+}
+
+static SST::Hg::thread_lock kvs_lock;
+static std::unordered_map<std::string,
+            std::unordered_map<std::string, std::string>> kvs;
+
+// Per-thread (per-simulated-rank) flags; shared across ranks in one OS process.
+static std::unordered_map<SST::Hg::Thread*, bool> pmi_initialized_map;
+static std::unordered_map<SST::Hg::Thread*, bool> pmi_finalized_map;
+static std::unordered_map<SST::Hg::Thread*, bool> ibarrier_pending_map;
+
+static bool pmi_flag_get(std::unordered_map<SST::Hg::Thread*, bool>& m)
+{
+  auto* t = SST::Hg::OperatingSystem::currentThread();
+  kvs_lock.lock();
+  bool v = m[t];
+  kvs_lock.unlock();
+  return v;
+}
+
+static void pmi_flag_set(std::unordered_map<SST::Hg::Thread*, bool>& m, bool v)
+{
+  auto* t = SST::Hg::OperatingSystem::currentThread();
+  kvs_lock.lock();
+  m[t] = v;
+  kvs_lock.unlock();
+}
+
+static std::string current_jobid_str()
+{
+  auto* api = sstmac_pmi();
+  char buf[64];
+  snprintf(buf, sizeof(buf), "app%d", api->sid().app_);
+  return std::string(buf);
+}
+
+extern "C" int
+PMI_KVS_Put(const char kvsname[], const char key[], const char value[])
+{
+  kvs_lock.lock();
+  kvs[kvsname][key] = value;
+  kvs_lock.unlock();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length)
+{
+  kvs_lock.lock();
+  auto outer = kvs.find(kvsname);
+  if (outer == kvs.end()){
+    kvs_lock.unlock();
+    return PMI_ERR_INVALID_KEY;
+  }
+  auto inner = outer->second.find(key);
+  if (inner == outer->second.end()){
+    kvs_lock.unlock();
+    return PMI_ERR_INVALID_KEY;
+  }
+  const std::string& str = inner->second;
+  if (length < (int)(str.length() + 1)){
+    kvs_lock.unlock();
+    return PMI_ERR_INVALID_LENGTH;
+  }
+  ::strcpy(value, str.c_str());
+  kvs_lock.unlock();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_KVS_Put(const char key[], const char value[])
+{
+  std::string kvsname = current_jobid_str();
+  kvs_lock.lock();
+  kvs[kvsname][key] = value;
+  kvs_lock.unlock();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_KVS_Get(const char *jobid, int /*src_pmi_id*/, const char key[],
+             char value[], int maxvalue, int *vallen)
+{
+  std::string kvsname = (jobid && jobid[0]) ? std::string(jobid)
+                                            : current_jobid_str();
+  kvs_lock.lock();
+  auto outer = kvs.find(kvsname);
+  if (outer == kvs.end()){
+    kvs_lock.unlock();
+    if (vallen) *vallen = 0;
+    return PMI_ERR_INVALID_KEY;
+  }
+  auto inner = outer->second.find(key);
+  if (inner == outer->second.end()){
+    kvs_lock.unlock();
+    if (vallen) *vallen = 0;
+    return PMI_ERR_INVALID_KEY;
+  }
+  const std::string& s = inner->second;
+  if ((int)(s.size() + 1) > maxvalue){
+    kvs_lock.unlock();
+    return PMI_ERR_INVALID_LENGTH;
+  }
+  std::memcpy(value, s.c_str(), s.size() + 1);
+  if (vallen) *vallen = (int)s.size();
+  kvs_lock.unlock();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_KVS_Fence(void)
+{
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_Abort(void)
+{
+  SST::Hg::abort("unimplemented: PMI2_Abort");
+  __builtin_unreachable();
+}
+
+extern "C" int
+PMI2_Job_GetId(char jobid[], int jobid_size)
+{
+  auto* api = sstmac_pmi();
+  ::snprintf(jobid, jobid_size, "app%d", api->sid().app_);
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
+{
+  auto api = sstmac_pmi();
+  api->init();
+  pmi_flag_set(pmi_initialized_map, true);
+  *size = api->nproc();
+  *rank = api->rank();
+  *appnum = 0;
+  *spawned = 0;
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Abort(int rc, const char error_msg[])
+{
+  SST::Hg::abort(error_msg ? error_msg : "PMI_Abort called with null message");
+  __builtin_unreachable();
+}
+
+extern "C" int PMI_Initialized( PMI_BOOL *initialized )
+{
+  *initialized = pmi_flag_get(pmi_initialized_map) ? 1 : 0;
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI2_Finalize()
+{
+  pmi_flag_set(pmi_finalized_map, true);
+  pmi_flag_set(pmi_initialized_map, false);
+  auto api = sstmac_pmi();
+  api->finish();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_Get_nidlist_ptr(void** nidlist)
+{
+  *nidlist = sstmac_pmi()->nidlist();
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Init(int* spawned)
+{
+  auto* tport = sstmac_pmi();
+  tport->init();
+  pmi_flag_set(pmi_initialized_map, true);
+  *spawned = 0;
+
+  int nproc = tport->nproc();
+  // TODO: multi-node topology. The mapping "(vector,(0,nproc,1))" assumes a
+  // single node with all ranks contiguous starting at node 0. Revisit when
+  // multi-node runs are exercised so that apps consuming PMI_process_mapping
+  // see a PPN/node layout that matches the simulated platform.
+  char mapping[64];
+  snprintf(mapping, sizeof(mapping), "(vector,(%d,%d,%d))", 0, nproc, 1);
+  char kvsname[256];
+  snprintf(kvsname, sizeof(kvsname), "app%d", tport->sid().app_);
+  kvs_lock.lock();
+  kvs[kvsname]["PMI_process_mapping"] = mapping;
+  kvs_lock.unlock();
+
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Finalize()
+{
+  sstmac_pmi()->finish();
+  pmi_flag_set(pmi_initialized_map, false);
+  pmi_flag_set(pmi_finalized_map, true);
+  return PMI_SUCCESS;
+}
+
+
+extern "C" int PMI_Allgather(void *in, void *out, int len)
+{
+  auto tport = sstmac_pmi();
+  int init_tag = tport->engine()->allocateGlobalCollectiveTag();
+  auto* msg = tport->engine()->allgather(out, in, len, 1, init_tag, SST::Iris::sumi::Message::default_cq, nullptr);
+  if (msg) delete msg;
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Barrier()
+{
+  auto api = sstmac_pmi();
+  int init_tag = api->engine()->allocateGlobalCollectiveTag();
+  api->engine()->barrier(init_tag, SST::Iris::sumi::Message::default_cq, nullptr);
+  auto* msg = api->engine()->blockUntilNext(SST::Iris::sumi::Message::default_cq);
+  if (msg) delete msg;
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Ibarrier()
+{
+  auto api = sstmac_pmi();
+  int init_tag = api->engine()->allocateGlobalCollectiveTag();
+  api->engine()->barrier(init_tag, SST::Iris::sumi::Message::default_cq, nullptr);
+  pmi_flag_set(ibarrier_pending_map, true);
+  return PMI_SUCCESS;
+}
+
+extern "C" int PMI_Wait()
+{
+  if (!pmi_flag_get(ibarrier_pending_map))
+    return PMI_SUCCESS;
+  auto api = sstmac_pmi();
+  auto* msg = api->engine()->blockUntilNext(SST::Iris::sumi::Message::default_cq);
+  if (msg) delete msg;
+  pmi_flag_set(ibarrier_pending_map, false);
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_Get_numpes_on_smp(int* num)
+{
+  *num = 1;
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_Publish_name( const char service_name[], const char port[] )
+{
+  SST::Hg::abort("unimplemented error: PMI_Publish_name");
+  __builtin_unreachable();
+}
+
+extern "C" int
+PMI_Unpublish_name( const char service_name[] )
+{
+  SST::Hg::abort("unimplemented error: PMI_Unpublish_name");
+  __builtin_unreachable();
+}
+
+extern "C" int
+PMI_KVS_Get_name_length_max( int *length )
+{
+  *length = 256;
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_KVS_Get_key_length_max( int *length )
+{
+  *length = 256;
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_KVS_Get_value_length_max( int *length )
+{
+  *length = 256;
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_KVS_Get_my_name( char kvsname[], int length )
+{
+  auto* api = sstmac_pmi();
+  int actual_length = snprintf(kvsname, length, "app%d", api->sid().app_);
+  if (actual_length >= length){
+    return PMI_ERR_INVALID_LENGTH;
+  } else {
+    return PMI_SUCCESS;
+  }
+}
+
+extern "C" int
+PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizesp[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[])
+{
+  SST::Hg::abort("unimplemented error: PMI_Spawn_multiple");
+  __builtin_unreachable();
+}
+
+extern "C" int
+PMI_Lookup_name( const char service_name[], char port[] )
+{
+  SST::Hg::abort("unimplemented error: PMI_Lookup_name");
+  __builtin_unreachable();
+}
+
+extern "C" int
+PMI_KVS_Commit( const char kvsname[] )
+{
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_Get_universe_size( int *size )
+{
+  auto* api = sstmac_pmi();
+  *size = api->nproc();
+  return PMI_SUCCESS;
+}
+
+extern "C" int
+PMI_Get_appnum( int *appnum )
+{
+  auto* api = sstmac_pmi();
+  *appnum = api->sid().app_;
+  return PMI_SUCCESS;
+}

--- a/src/sst/elements/iris/pmi/pmi.h
+++ b/src/sst/elements/iris/pmi/pmi.h
@@ -1,0 +1,87 @@
+#ifndef PMI_H_INCLUDED
+#define PMI_H_INCLUDED
+
+#define PMI_SUCCESS                  0
+#define PMI_FAIL                    -1
+#define PMI_ERR_INIT                 1
+#define PMI_ERR_NOMEM                2
+#define PMI_ERR_INVALID_ARG          3
+#define PMI_ERR_INVALID_KEY          4
+#define PMI_ERR_INVALID_KEY_LENGTH   5
+#define PMI_ERR_INVALID_VAL          6
+#define PMI_ERR_INVALID_VAL_LENGTH   7
+#define PMI_ERR_INVALID_LENGTH       8
+#define PMI_ERR_INVALID_NUM_ARGS     9
+#define PMI_ERR_INVALID_ARGS        10
+#define PMI_ERR_INVALID_NUM_PARSED  11
+#define PMI_ERR_INVALID_KEYVALP     12
+#define PMI_ERR_INVALID_SIZE        13
+
+typedef int PMI_BOOL;
+#define PMI_TRUE  1
+#define PMI_FALSE 0
+
+typedef struct PMI_keyval_t {
+    const char * key;
+    char * val;
+} PMI_keyval_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int PMI_Init(int *spawned);
+int PMI_Initialized(int *initialized);
+int PMI_Finalize(void);
+int PMI_Abort(int exit_code, const char error_msg[]);
+
+int PMI_Get_size(int *size);
+int PMI_Get_rank(int *rank);
+int PMI_Get_universe_size(int *size);
+int PMI_Get_appnum(int *appnum);
+
+int PMI_Barrier(void);
+int PMI_Ibarrier(void);
+int PMI_Wait(void);
+int PMI_Allgather(void *in, void *out, int len);
+
+int PMI_KVS_Get_my_name(char kvsname[], int length);
+int PMI_KVS_Get_name_length_max(int *length);
+int PMI_KVS_Get_key_length_max(int *length);
+int PMI_KVS_Get_value_length_max(int *length);
+int PMI_KVS_Put(const char kvsname[], const char key[], const char value[]);
+int PMI_KVS_Commit(const char kvsname[]);
+int PMI_KVS_Get(const char kvsname[], const char key[], char value[], int length);
+
+int PMI_Publish_name(const char service_name[], const char port[]);
+int PMI_Unpublish_name(const char service_name[]);
+int PMI_Lookup_name(const char service_name[], char port[]);
+
+int PMI_Spawn_multiple(int count,
+                       const char * cmds[],
+                       const char ** argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizesp[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[],
+                       int errors[]);
+
+int PMI_Get_nidlist_ptr(void **nidlist);
+int PMI_Get_numpes_on_smp(int *num);
+
+/* PMI-2 */
+int PMI2_Init(int *spawned, int *size, int *rank, int *appnum);
+int PMI2_Finalize(void);
+int PMI2_Abort(void);
+int PMI2_Job_GetId(char jobid[], int jobid_size);
+int PMI2_KVS_Put(const char key[], const char value[]);
+int PMI2_KVS_Get(const char *jobid, int src_pmi_id, const char key[],
+                 char value[], int maxvalue, int *vallen);
+int PMI2_KVS_Fence(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PMI_H_INCLUDED */

--- a/src/sst/elements/mercury/common/skeleton.h
+++ b/src/sst/elements/mercury/common/skeleton.h
@@ -107,7 +107,7 @@ unsigned int ssthg_nanosleep(unsigned int nsecs);
 } // namespace Hg
 } // namespace SST
 
-#include <mercury/common/skeleton_tls.h>
 #endif /* __cplusplus */
 
+#include <mercury/common/skeleton_tls.h>
 #include <mercury/common/null_buffer.h>

--- a/src/sst/elements/mercury/common/thread_lock.h
+++ b/src/sst/elements/mercury/common/thread_lock.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <sst_element_config.h>
+#include <mutex>
 #include <thread>
 
 #ifdef SST_HG_PTHREAD_MACRO_H


### PR DESCRIPTION
This PR wires Iris so Mercury-hosted simulations can run MVAPICH2 with the OFI netmod against the in-tree libfabric stack: register the SUMI provider, ship a PMI-1 (empty and untested PMI-2 support as well) compatible libpmi, and harden the SUMI provider enough for real fi_getinfo / EP / AV / CQ usage from MV2. Small Mercury tweaks keep C translation units and threading helpers consistent with that path.