### PR TITLE
OSCommand is deprecated and being removed

### DIFF
--- a/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_default_Ariel.py
@@ -228,14 +228,14 @@ class testcase_Ariel(SSTTestCase):
 
         # Now build the Ariel stream example
         cmd = f"make LDFLAGS=-L{libdir}"
-        rtn1 = OSCommand(cmd, set_cwd=self.ArielElementStreamDir).run()
+        rtn1 = os_command(cmd, set_cwd=self.ArielElementStreamDir).run()
         log_debug("Ariel stream Make result = {0}; output =\n{1}".format(rtn1.result(), rtn1.output()))
         if rtn1.result() != 0:
             log_debug("Ariel {0} Make returned non-zero exit code. Error:\n{1}".format(self.ArielElementStreamDir, rtn1.error()))
 
         # Now build the ompmybarrier binary
         cmd = "make"
-        rtn2 = OSCommand(cmd, set_cwd=self.ArielElementompmybarrierDir).run()
+        rtn2 = os_command(cmd, set_cwd=self.ArielElementompmybarrierDir).run()
         log_debug("Ariel ompmybarrier Make result = {0}; output =\n{1}".format(rtn2.result(), rtn2.output()))
         if rtn2.result() != 0:
             log_debug("Ariel {0} Make returned non-zero exit code. Error:\n{1}".format(self.ArielElementompmybarrierDir, rtn2.error()))
@@ -260,7 +260,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app stream --inp +"
-                rtn3 = OSCommand(cmd, set_cwd=self.ArielElementStreamDir).run()
+                rtn3 = os_command(cmd, set_cwd=self.ArielElementStreamDir).run()
                 log_debug("Ariel stream pebil result = {0}; output =\n{1}".format(rtn3.result(), rtn3.output()))
                 if rtn3.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementStreamDir, rtn3.error()))
@@ -276,7 +276,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app stream_mlm --inp +"
-                rtn4 = OSCommand(cmd, set_cwd=self.ArielElementStreamDir).run()
+                rtn4 = os_command(cmd, set_cwd=self.ArielElementStreamDir).run()
                 log_debug("Ariel stream pebil result = {0}; output =\n{1}".format(rtn4.result(), rtn4.output()))
                 if rtn4.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementStreamDir, rtn4.error()))
@@ -292,7 +292,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app ompmybarrier --inp + --threaded"
-                rtn5 = OSCommand(cmd, set_cwd=self.ArielElementompmybarrierDir).run()
+                rtn5 = os_command(cmd, set_cwd=self.ArielElementompmybarrierDir).run()
                 log_debug("Ariel stream pebil result = {0}; output =\n{1}".format(rtn5.result(), rtn5.output()))
                 if rtn5.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementompmybarrierDir, rtnr.error()))

--- a/src/sst/elements/ariel/tests/testsuite_mpi_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_mpi_Ariel.py
@@ -288,7 +288,7 @@ class testcase_Ariel(SSTTestCase):
 
         # Build the test mpi programs
         cmd = "make"
-        rtn1 = OSCommand(cmd, set_cwd=self.ArielElementTestMPIDir).run()
+        rtn1 = os_command(cmd, set_cwd=self.ArielElementTestMPIDir).run()
         log_debug("Ariel tests/testMPI `make` result = {1}; output =\n{2}".format(self.ArielElementTestMPIDir, rtn1.result(), rtn1.output()))
 
         # Check that everything compiled OK
@@ -308,7 +308,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app hello --inp + --threaded"
-                rtn2 = OSCommand(cmd, set_cwd=self.ArielElementTestMPIDir).run()
+                rtn2 = os_command(cmd, set_cwd=self.ArielElementTestMPIDir).run()
                 log_debug("Ariel tests/testMPI pebil result = {0}; output =\n{1}".format(rtn2.result(), rtn2.output()))
                 if rtn2.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementTestMPIDir, rtn2.error()))
@@ -322,7 +322,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app reduce --inp + --threaded"
-                rtn3 = OSCommand(cmd, set_cwd=self.ArielElementTestMPIDir).run()
+                rtn3 = os_command(cmd, set_cwd=self.ArielElementTestMPIDir).run()
                 log_debug("Ariel tests/testMPI pebil result = {0}; output =\n{1}".format(rtn3.result(), rtn3.output()))
                 if rtn3.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementTestMPIDir, rtn3.error()))

--- a/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
+++ b/src/sst/elements/ariel/tests/testsuite_testio_Ariel.py
@@ -263,7 +263,7 @@ class testcase_Ariel(SSTTestCase):
 
         # Build the testio binary
         cmd = "make testio"
-        rtn1 = OSCommand(cmd, set_cwd=self.ArielElementTestIODir).run()
+        rtn1 = os_command(cmd, set_cwd=self.ArielElementTestIODir).run()
         log_debug("Ariel ariel/tests/testIO make result = {1}; output =\n{2}".format(self.ArielElementTestIODir, rtn1.result(), rtn1.output()))
 
         # Check that everything compiled OK
@@ -283,7 +283,7 @@ class testcase_Ariel(SSTTestCase):
             # Instrument with pebil
             if (pebil_loaded):
                 cmd = "pebil --tool ArielIntercept --app testio --inp +"
-                rtn2 = OSCommand(cmd, set_cwd=self.ArielElementTestIODir).run()
+                rtn2 = os_command(cmd, set_cwd=self.ArielElementTestIODir).run()
                 log_debug("Ariel ariel/tests/testIO pebil result = {0}; output =\n{1}".format(rtn2.result(), rtn2.output()))
                 if rtn2.result() != 0:
                     log_debug("Ariel {0} pebil returned non-zero exit code. Error:\n{1}".format(self.ArielElementTestIODir, rtn2.error()))

--- a/src/sst/elements/balar/tests/testBalar_testsuite_util.py
+++ b/src/sst/elements/balar/tests/testBalar_testsuite_util.py
@@ -414,25 +414,25 @@ class BalarTestCase(SSTTestCase):
 
         # Now build libcudart
         cmd = "make"
-        rtn = OSCommand(cmd, set_cwd=self.cudartDir).run()
+        rtn = os_command(cmd, set_cwd=self.cudartDir).run()
         log_debug("Balar cudart Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "libcudart failed to compile")
 
         # Now build the vectorAdd example
         cmd = "make"
-        rtn = OSCommand(cmd, set_cwd=self.testbalarVectorAddDir).run()
+        rtn = os_command(cmd, set_cwd=self.testbalarVectorAddDir).run()
         log_debug("Balar vectorAdd Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "vecAdd.cu failed to compile")
 
         # Build vanadishandshake
 #        cmd = "make"
-#        rtn = OSCommand(cmd, set_cwd=self.testbalarVanadisHandshakeDir).run()
+#        rtn = os_command(cmd, set_cwd=self.testbalarVanadisHandshakeDir).run()
 #        log_debug("Balar vanadisHandshake Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
 #        self.assertTrue(rtn.result() == 0, "vanadisHandshake.c failed to compile")
 
         # Build vanadis_llvm_rv64, contains helloworld, vecadd, and the custom CUDA lib
         cmd = "make"
-        rtn = OSCommand(cmd, set_cwd=self.testbalarLLVMVanadisDir).run()
+        rtn = os_command(cmd, set_cwd=self.testbalarLLVMVanadisDir).run()
         log_debug("Balar vanadisLLVM Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "vanadisLLVM executables and lib failed to compile")
 
@@ -445,13 +445,13 @@ class BalarTestCase(SSTTestCase):
             # Build rodinia
             # Use the same amount of concurrent run to compile rodinia
             cmd_compile = f"make rodinia_2.0-ft -j{nthreads} -C ./src"
-            rtn = OSCommand(cmd_compile, set_cwd=os.environ["GPUAPPS_ROOT"]).run()
+            rtn = os_command(cmd_compile, set_cwd=os.environ["GPUAPPS_ROOT"]).run()
             log_debug("Balar vanadisLLVM GPU App rodinia 2.0 Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
             self.assertTrue(rtn.result() == 0, "vanadisLLVM GPU app rodinia 2.0 benchmark failed to compile in {0} with command {1}".format(os.environ["GPUAPPS_ROOT"], cmd_compile))
 
             # Pull data
             cmd_pulldata = "make data -C ./src"
-            rtn = OSCommand(cmd_pulldata, set_cwd=os.environ["GPUAPPS_ROOT"]).run()
+            rtn = os_command(cmd_pulldata, set_cwd=os.environ["GPUAPPS_ROOT"]).run()
             log_debug("Balar vanadisLLVM GPU App Data pull result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
             self.assertTrue(rtn.result() == 0, "vanadisLLVM GPU app benchmark failed to pull data")
         else:
@@ -493,14 +493,14 @@ class BalarTestCase(SSTTestCase):
 
         # Get nvcc
         cmd = "which nvcc"
-        rtn = OSCommand(cmd).run()
+        rtn = os_command(cmd).run()
         log_debug("which nvcc result = {0}; output = {1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "'which nvcc' command failed")
         os.environ["NVCC_PATH"] = rtn.output()
 
         # Set the CUDA version here as well by parsing the nvcc version string
         cmd = "nvcc --version"
-        rtn = OSCommand(cmd).run()
+        rtn = os_command(cmd).run()
         log_debug("CUDA version string: result = {0}; output = {1}".format(rtn.result(), rtn.output()))
         # Parse version string
         version_string = rtn.output()

--- a/src/sst/elements/golem/tests/testsuite_default_golem.py
+++ b/src/sst/elements/golem/tests/testsuite_default_golem.py
@@ -281,7 +281,7 @@ class testcase_golem(SSTTestCase):
 
         # Now build the array application
         cmd = "which " + isa + "-linux-musl-gcc"
-        rtn = OSCommand(cmd).run()
+        rtn = os_command(cmd).run()
         log_debug("Golem detecting musl compiler [mipsel-linux-musl-gcc] - result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         return rtn.result() == 0
 
@@ -295,7 +295,7 @@ class testcase_golem(SSTTestCase):
         makefilepath = "{0}/Makefile".format(sourcedirpath)
 
         cmd = "make ARCH=" + isa
-        rtn = OSCommand(cmd, set_cwd=sourcedirpath).run()
+        rtn = os_command(cmd, set_cwd=sourcedirpath).run()
         log_debug("Golem tests source - Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "{0} failed to build properly".format(makefilepath))
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_default_memHierarchy_memHSieve.py
@@ -226,7 +226,7 @@ class testcase_memHierarchy_memHSieve(SSTTestCase):
 
         # Now run the make on it
         cmd = "make"
-        rtn = OSCommand(cmd, set_cwd=self.testMemHSieveDir).run()
+        rtn = os_command(cmd, set_cwd=self.testMemHSieveDir).run()
         log_debug("Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "ompsievetest.c failed to compile")
 

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_dirnoncacheable.py
@@ -105,13 +105,13 @@ class testcase_memH_openMP_dirnoncacheable(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "openMP dirnoncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_diropenMP.py
@@ -109,13 +109,13 @@ class testcase_memH_openMP_diropenMP(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "openMP diropenMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_noncacheable.py
@@ -107,13 +107,13 @@ class testcase_memH_openMP_noncacheable(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "openMP noncacheable Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_openMP_memHierarchy_openMP.py
@@ -109,13 +109,13 @@ class testcase_memH_openMP_openMP(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "openMP openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dir3LevelSweep.py
@@ -235,13 +235,13 @@ class testcase_memH_sweep_dir3levelsweep(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "Sweep dir3LevelSweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweep.py
@@ -206,13 +206,13 @@ class testcase_memH_sweep_dirsweep(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "Sweep dirsweep Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepB.py
@@ -206,13 +206,13 @@ class testcase_memH_sweep_dirsweepB(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "Sweep dirsweepB Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_dirSweepI.py
@@ -218,13 +218,13 @@ class testcase_memH_sweep_dirsweepI(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "Sweep dirsweepI Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
+++ b/src/sst/elements/memHierarchy/tests/testsuite_sweep_memHierarchy_openMP.py
@@ -206,13 +206,13 @@ class testcase_memH_sweep_openMP(SSTTestCase):
                     refcount = 0
                     # Grep the ref file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, reffile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     self.assertEqual(rtn.result(), 0, "Sweep openMP Test failed running cmdline {0} - grepping reffile {1}".format(cmd, reffile))
                     refcount = int(rtn.output())
 
                     # Grep the out file for the count of this line occuring
                     cmd = 'grep -c "{0}" {1}'.format(testline, outfile)
-                    rtn = OSCommand(cmd).run()
+                    rtn = os_command(cmd).run()
                     if rtn.result() == 0:
                         outcount = int(rtn.output())
                     else:

--- a/src/sst/elements/prospero/tests/testsuite_default_prospero.py
+++ b/src/sst/elements/prospero/tests/testsuite_default_prospero.py
@@ -225,7 +225,7 @@ class testcase_prospero(SSTTestCase):
 
         # Now build the array application
         cmd = "make"
-        rtn = OSCommand(cmd, set_cwd=targetdir).run()
+        rtn = os_command(cmd, set_cwd=targetdir).run()
         log_debug("Prospero tests/array Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "array.c failed to compile")
 
@@ -238,14 +238,14 @@ class testcase_prospero(SSTTestCase):
             # Now build the text traces
             cmd = "{0} -ifeellucky -t 1 -f text -o sstprospero -- ./array".format(filepath_sst_prospero_trace_app)
             log_debug("Prospero text Traces build cmd = {0}".format(cmd))
-            rtn = OSCommand(cmd, set_cwd=targetdir).run()
+            rtn = os_command(cmd, set_cwd=targetdir).run()
             log_debug("Prospero build text Traces result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
             self.assertTrue(rtn.result() == 0, "Text Traces failed to compile")
 
             # Now build the binary traces
             cmd = "{0} -ifeellucky -t 1 -f binary -o sstprospero -- ./array".format(filepath_sst_prospero_trace_app)
             log_debug("Prospero binary Traces build cmd = {0}".format(cmd))
-            rtn = OSCommand(cmd, set_cwd=targetdir).run()
+            rtn = os_command(cmd, set_cwd=targetdir).run()
             log_debug("Prospero build binary Traces result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
             self.assertTrue(rtn.result() == 0, "Binary Traces failed to compile")
 

--- a/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
+++ b/src/sst/elements/rdmaNic/tests/testsuite_default_rdmaNic.py
@@ -208,7 +208,7 @@ class testcase_rdmaNic(SSTTestCase):
 
         # Now build the array application
         cmd = "which mipsel-linux-musl-gcc"
-        rtn = OSCommand(cmd).run()
+        rtn = os_command(cmd).run()
         log_debug("RdmaNic detecting musl compiler [mipsel-linux-musl-gcc] - result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         return rtn.result() == 0
 
@@ -237,6 +237,6 @@ class testcase_rdmaNic(SSTTestCase):
 
                 # Now build the array application
                 cmd = "make"
-                rtn = OSCommand(cmd, set_cwd=sourcedirpath).run()
+                rtn = os_command(cmd, set_cwd=sourcedirpath).run()
                 log_debug("RdmaNic tests source - Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
                 self.assertTrue(rtn.result() == 0, "{0} failed to build properly".format(makefilepath))

--- a/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
+++ b/src/sst/elements/vanadis/tests/testsuite_default_vanadis.py
@@ -282,7 +282,7 @@ class testcase_vanadis(SSTTestCase):
 
         # Now build the array application
         cmd = "which " + isa + "-linux-musl-gcc"
-        rtn = OSCommand(cmd).run()
+        rtn = os_command(cmd).run()
         log_debug("Vanadis detecting musl compiler [mipsel-linux-musl-gcc] - result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         return rtn.result() == 0
 
@@ -296,7 +296,7 @@ class testcase_vanadis(SSTTestCase):
         makefilepath = "{0}/Makefile".format(sourcedirpath)
 
         cmd = "make ARCH=" + isa
-        rtn = OSCommand(cmd, set_cwd=sourcedirpath).run()
+        rtn = os_command(cmd, set_cwd=sourcedirpath).run()
         log_debug("Vanadis tests source - Make result = {0}; output =\n{1}".format(rtn.result(), rtn.output()))
         self.assertTrue(rtn.result() == 0, "{0} failed to build properly".format(makefilepath))
 


### PR DESCRIPTION
Convert all calls into equivalent `os_command` calls.
