### PR TITLE
Change all #!/usr/bin/env python to python3

### DIFF
--- a/src/sst/elements/ember/pyember.py
+++ b/src/sst/elements/ember/pyember.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/3LevelModel.py
+++ b/src/sst/elements/ember/run/configurations/3LevelModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/3LevelModelParams.py
+++ b/src/sst/elements/ember/run/configurations/3LevelModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/basicDetailedModel.py
+++ b/src/sst/elements/ember/run/configurations/basicDetailedModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/basicDetailedModelParams.py
+++ b/src/sst/elements/ember/run/configurations/basicDetailedModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/defaultSim.py
+++ b/src/sst/elements/ember/run/configurations/defaultSim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/detailedSim.py
+++ b/src/sst/elements/ember/run/configurations/detailedSim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/detailedStreamSim.py
+++ b/src/sst/elements/ember/run/configurations/detailedStreamSim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/sandyBridgeModelParams.py
+++ b/src/sst/elements/ember/run/configurations/sandyBridgeModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/run/configurations/sandySim.py
+++ b/src/sst/elements/ember/run/configurations/sandySim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/basicDetailedModel.py
+++ b/src/sst/elements/ember/test/basicDetailedModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/basicDetailedModelParams.py
+++ b/src/sst/elements/ember/test/basicDetailedModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/cramsimDetailedModelParams.py
+++ b/src/sst/elements/ember/test/cramsimDetailedModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/detailedModel.py
+++ b/src/sst/elements/ember/test/detailedModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/detailedShmemModel.py
+++ b/src/sst/elements/ember/test/detailedShmemModel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/timingDetailedModelParams.py
+++ b/src/sst/elements/ember/test/timingDetailedModelParams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/trafficgen.py
+++ b/src/sst/elements/ember/test/trafficgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/test/tricount.py
+++ b/src/sst/elements/ember/test/tricount.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/ember/tests/dragon_128_allreduce.py
+++ b/src/sst/elements/ember/tests/dragon_128_allreduce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/firefly/pyfirefly.py
+++ b/src/sst/elements/firefly/pyfirefly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/mask-mpi/tests/test_allgather.py
+++ b/src/sst/elements/mask-mpi/tests/test_allgather.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/mask-mpi/tests/test_alltoall.py
+++ b/src/sst/elements/mask-mpi/tests/test_alltoall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/mask-mpi/tests/test_halo3d26.py
+++ b/src/sst/elements/mask-mpi/tests/test_halo3d26.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/mask-mpi/tests/test_reduce.py
+++ b/src/sst/elements/mask-mpi/tests/test_reduce.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/mask-mpi/tests/test_sendrecv.py
+++ b/src/sst/elements/mask-mpi/tests/test_sendrecv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/memHierarchy/tests/checkReqs.py
+++ b/src/sst/elements/memHierarchy/tests/checkReqs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys;

--- a/src/sst/elements/memHierarchy/tests/checkVals.py
+++ b/src/sst/elements/memHierarchy/tests/checkVals.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import sys;

--- a/src/sst/elements/mercury/pymercury.py
+++ b/src/sst/elements/mercury/pymercury.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/interfaces/pymerlin-interface.py
+++ b/src/sst/elements/merlin/interfaces/pymerlin-interface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/networkGen.py
+++ b/src/sst/elements/merlin/networkGen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/pymerlin-base.py
+++ b/src/sst/elements/merlin/pymerlin-base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/pymerlin-endpoint.py
+++ b/src/sst/elements/merlin/pymerlin-endpoint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/pymerlin-router.py
+++ b/src/sst/elements/merlin/pymerlin-router.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/pymerlin.py
+++ b/src/sst/elements/merlin/pymerlin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/target_generator/pymerlin-targetgen.py
+++ b/src/sst/elements/merlin/target_generator/pymerlin-targetgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/anytopo_complete_4_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_complete_4_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with complete graph (4 vertices)
 

--- a/src/sst/elements/merlin/tests/anytopo_cubical_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_cubical_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with cubical graph (8 vertices, 12 edges)
 

--- a/src/sst/elements/merlin/tests/anytopo_dallydragonfly_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_dallydragonfly_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Dally Dragonfly topology
 

--- a/src/sst/elements/merlin/tests/anytopo_ember_complete_4_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_ember_complete_4_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Ember using complete graph (4 vertices)
 

--- a/src/sst/elements/merlin/tests/anytopo_jellyfish_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_jellyfish_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Jellyfish topology
 

--- a/src/sst/elements/merlin/tests/anytopo_polarfly_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_polarfly_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Polarfly topology
 

--- a/src/sst/elements/merlin/tests/anytopo_slimfly_UGAL_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_slimfly_UGAL_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Slimfly topology
 

--- a/src/sst/elements/merlin/tests/anytopo_slimfly_UGAL_threshold_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_slimfly_UGAL_threshold_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Slimfly topology
 

--- a/src/sst/elements/merlin/tests/anytopo_slimfly_test.py
+++ b/src/sst/elements/merlin/tests/anytopo_slimfly_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Test for anytopo with Slimfly topology
 

--- a/src/sst/elements/merlin/tests/dragon_128_platform_test.py
+++ b/src/sst/elements/merlin/tests/dragon_128_platform_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/dragon_128_platform_test_cm.py
+++ b/src/sst/elements/merlin/tests/dragon_128_platform_test_cm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/dragon_128_test.py
+++ b/src/sst/elements/merlin/tests/dragon_128_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/dragon_128_test_deferred.py
+++ b/src/sst/elements/merlin/tests/dragon_128_test_deferred.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/dragon_128_test_fl.py
+++ b/src/sst/elements/merlin/tests/dragon_128_test_fl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/dragon_72_test.py
+++ b/src/sst/elements/merlin/tests/dragon_72_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/fattree_128_test.py
+++ b/src/sst/elements/merlin/tests/fattree_128_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/fattree_256_test.py
+++ b/src/sst/elements/merlin/tests/fattree_256_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/hyperx_128_test.py
+++ b/src/sst/elements/merlin/tests/hyperx_128_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/polarfly_455_test.py
+++ b/src/sst/elements/merlin/tests/polarfly_455_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause

--- a/src/sst/elements/merlin/tests/polarstar_504_test.py
+++ b/src/sst/elements/merlin/tests/polarstar_504_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause

--- a/src/sst/elements/merlin/tests/torus_128_test.py
+++ b/src/sst/elements/merlin/tests/torus_128_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/torus_5_trafficgen.py
+++ b/src/sst/elements/merlin/tests/torus_5_trafficgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/tests/torus_64_test.py
+++ b/src/sst/elements/merlin/tests/torus_64_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-any.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-any.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2025 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-dragonfly.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-dragonfly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-fattree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-hyperx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-mesh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2009-2026 NTESS. Under the terms
 # of Contract DE-NA0003525 with NTESS, the U.S.

--- a/src/sst/elements/merlin/topology/pymerlin-topo-polarfly.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-polarfly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause

--- a/src/sst/elements/merlin/topology/pymerlin-topo-polarstar.py
+++ b/src/sst/elements/merlin/topology/pymerlin-topo-polarstar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2023 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
All Python files should start with `#!/usr/bin/env python3`.

Closes #2705 