### PR TITLE
Some cleanup of ember stack elements

### DIFF
--- a/src/sst/elements/ember/mpi/embermpigen.cc
+++ b/src/sst/elements/ember/mpi/embermpigen.cc
@@ -49,5 +49,4 @@ EmberMessagePassingGenerator::EmberMessagePassingGenerator(
 
 EmberMessagePassingGenerator::~EmberMessagePassingGenerator()
 {
-    verbose(CALL_INFO, 2, 0, "\n");
 }

--- a/src/sst/elements/firefly/hadesNetworkIO.cc
+++ b/src/sst/elements/firefly/hadesNetworkIO.cc
@@ -45,7 +45,7 @@ void HadesNetworkIO::setup()
 
 void HadesNetworkIO::networkIORead(Hermes::Vaddr dest, uint64_t offset, uint64_t length, Callback callback)
 {
-    m_dbg.verbose(CALL_INFO, 1, 0, "network_read: dest=%lx offset=%lu length=%lu \n",
+    m_dbg.verbose(CALL_INFO, 1, 0, "network_read: dest=%" PRIx64 " offset=%" PRIu64 " length=%" PRIu64 " \n",
                   dest, offset, length);
     int targetNid = calcTargetNid(offset);
     m_nicPtr->networkIORead(targetNid, dest, length, callback);
@@ -53,7 +53,7 @@ void HadesNetworkIO::networkIORead(Hermes::Vaddr dest, uint64_t offset, uint64_t
 
 void HadesNetworkIO::networkIOWrite(uint64_t offset, Hermes::Vaddr src, uint64_t length, Callback callback)
 {
-    m_dbg.verbose(CALL_INFO, 1, 0, "network_write: offset=%lu src=%lx length=%lu \n",
+    m_dbg.verbose(CALL_INFO, 1, 0, "network_write: offset=%" PRIu64 " src=%" PRIx64 " length=%" PRIu64 " \n",
                   offset, src, length);
     int targetNid = calcTargetNid(offset);
     m_nicPtr->networkIOWrite(targetNid, src, length, callback);

--- a/src/sst/elements/firefly/nicNetworkIO.cc
+++ b/src/sst/elements/firefly/nicNetworkIO.cc
@@ -53,7 +53,7 @@ void Nic::NetworkIO::handleNetworkIORead(NicNetworkIOReadCmdEvent* event, int id
     Hermes::Vaddr destAddr = event->getDest();
     size_t length = event->getLen();
     m_dbg.verbosePrefix(prefix().c_str(), CALL_INFO, 1, NIC_DBG_NETWORKIO,
-                       "READ core=%d targetNid=%d dest=%#lx len=%zu \n",
+                       "READ core=%d targetNid=%d dest=%#" PRIx64 " len=%zu \n",
                        id, targetNid, destAddr, length);
 
     auto callback = event->getCallback();
@@ -87,7 +87,7 @@ void Nic::NetworkIO::handleNetworkIOWrite(NicNetworkIOWriteCmdEvent* event, int 
     Hermes::Vaddr srcAddr = event->getSrc();
     size_t length = event->getLen();
     m_dbg.verbosePrefix(prefix().c_str(), CALL_INFO, 1, NIC_DBG_NETWORKIO,
-                       "WRITE core=%d targetNid=%d src=%#lx len=%zu \n",
+                       "WRITE core=%d targetNid=%d src=%#" PRIx64 " len=%zu \n",
                        id, targetNid, srcAddr, length);
 
     auto callback = event->getCallback();

--- a/src/sst/elements/firefly/nicNetworkIOStream.cc
+++ b/src/sst/elements/firefly/nicNetworkIOStream.cc
@@ -106,7 +106,7 @@ void Nic::RecvMachine::NetworkIOStream::processStorageOp(FireflyNetworkEvent* ev
     ev->bufPop(sizeof(respKey));
 
     m_dbg.debug(CALL_INFO,1,NIC_DBG_RECV_STREAM,
-                "op=%u offset=%lu length=%lu respKey=%u\n",
+                "op=%u offset=%" PRIu64 " length=%zu respKey=%u\n",
                 netHdr.op, m_offset, m_length, respKey);
 
     // Submit DMA operation based on operation type

--- a/src/sst/elements/firefly/storageModel/simpleSSD.cc
+++ b/src/sst/elements/firefly/storageModel/simpleSSD.cc
@@ -27,8 +27,8 @@ SimpleSSD::SimpleSSD(ComponentId_t id, Params &params)
     int verboseLevel = params.find<int>("verboseLevel", 0);
     int verboseMask = params.find<int>("verboseMask", -1);
     m_out.init("[SimpleSSD] ", verboseLevel, verboseMask, Output::STDOUT);
-    registerClock("1GHz", new Clock::Handler2<SimpleSSD, &SimpleSSD::clockTick>(this));
-    m_selfLink = configureSelfLink("ReadWriteLatency", "1 ns", new Event::Handler2<SimpleSSD, &SimpleSSD::handleEvent>(this));
+    registerClock("1GHz", new Clock::Handler<SimpleSSD, &SimpleSSD::clockTick>(this));
+    m_selfLink = configureSelfLink("ReadWriteLatency", "1 ns", new Event::Handler<SimpleSSD, &SimpleSSD::handleEvent>(this));
 }
 
 void SimpleSSD::read(int64_t offset, size_t bytes, const SsdReqCallback &callback)

--- a/src/sst/elements/firefly/virtNic.cc
+++ b/src/sst/elements/firefly/virtNic.cc
@@ -305,12 +305,12 @@ void VirtNic::setNotifyNeedRecv(
 
 void VirtNic::networkIORead( int targetNid, Hermes::Vaddr dest, size_t len, std::function<void(int)> callback )
 {
-    m_dbg.debug(CALL_INFO,2,0,"dest=%#lx len=%zu\n", dest, len);
+    m_dbg.debug(CALL_INFO,2,0,"dest=%#" PRIx64 " len=%zu\n", dest, len);
     sendCmd(0, new NicNetworkIOReadCmdEvent(  targetNid, dest, len, callback ) );
 }
 
 void VirtNic::networkIOWrite( int targetNid, Hermes::Vaddr src, size_t len, std::function<void(int)> callback )
 {
-    m_dbg.debug(CALL_INFO,2,0,"src=%#lx len=%zu\n", src, len);
+    m_dbg.debug(CALL_INFO,2,0,"src=%#" PRIx64 " len=%zu\n", src, len);
     sendCmd(0, new NicNetworkIOWriteCmdEvent(  targetNid, src, len, callback ) );
 }

--- a/src/sst/elements/merlin/interfaces/endpointNIC/sourceRouting.cc
+++ b/src/sst/elements/merlin/interfaces/endpointNIC/sourceRouting.cc
@@ -165,7 +165,7 @@ SourceRoutingPlugin::SourceRoutingPlugin(ComponentId_t cid, Params& params) :
 
     // Validate that this endpoint is in the mapping
     if (endpoint_to_router_shared[endpoint_id] == -1) {
-        output.fatal(CALL_INFO, -1, "Endpoint ID %d not found in endpoint-to-router mapping\n", endpoint_id);
+        output.fatal(CALL_INFO, -1, "Endpoint ID %" PRId64 " not found in endpoint-to-router mapping\n", endpoint_id);
     }
 
     myRtrID = endpoint_to_router_shared[endpoint_id];


### PR DESCRIPTION
- Removed a call to Output object in a destructor that could cause segfaults on shutdown. Fixes #2703
- Updated some printf format flags to use PRI versions
