### PR TITLE
Anytopo test reference and packaging updates

### DIFF
--- a/src/sst/elements/merlin/Makefile.am
+++ b/src/sst/elements/merlin/Makefile.am
@@ -94,6 +94,12 @@ libmerlin_la_SOURCES = \
 	pymerlin-router.py \
 	interfaces/pymerlin-interface.py \
 	target_generator/pymerlin-targetgen.py \
+	topology/anytopo_utility/DallyDragonfly.py \
+	topology/anytopo_utility/HPC_topos.py \
+	topology/anytopo_utility/__init__.py \
+	topology/anytopo_utility/Jellyfish.py \
+	topology/anytopo_utility/Polarfly.py \
+	topology/anytopo_utility/Slimfly.py \
 	topology/pymerlin-topo-any.py \
 	topology/pymerlin-topo-dragonfly.py \
 	topology/pymerlin-topo-polarfly.py \

--- a/src/sst/elements/merlin/Makefile.am
+++ b/src/sst/elements/merlin/Makefile.am
@@ -104,6 +104,15 @@ libmerlin_la_SOURCES = \
 
 EXTRA_DIST = \
 	tests/testsuite_default_merlin.py \
+	tests/anytopo_complete_4_test.py \
+	tests/anytopo_cubical_test.py \
+	tests/anytopo_dallydragonfly_test.py \
+	tests/anytopo_ember_complete_4_test.py \
+	tests/anytopo_jellyfish_test.py \
+	tests/anytopo_polarfly_test.py \
+	tests/anytopo_slimfly_test.py \
+	tests/anytopo_slimfly_UGAL_test.py \
+	tests/anytopo_slimfly_UGAL_threshold_test.py \
 	tests/hyperx_128_test.py \
 	tests/dragon_128_test.py \
 	tests/dragon_72_test.py \
@@ -119,6 +128,15 @@ EXTRA_DIST = \
 	tests/dragon_128_test_deferred.py \
 	tests/polarfly_455_test.py \
 	tests/polarstar_504_test.py \
+	tests/refFiles/test_merlin_anytopo_complete_4_test.out \
+	tests/refFiles/test_merlin_anytopo_cubical_test.out \
+	tests/refFiles/test_merlin_anytopo_dallydragonfly_test.out \
+	tests/refFiles/test_merlin_anytopo_ember_complete_4_test.out \
+	tests/refFiles/test_merlin_anytopo_jellyfish_test.out \
+	tests/refFiles/test_merlin_anytopo_polarfly_test.out \
+	tests/refFiles/test_merlin_anytopo_slimfly_test.out \
+	tests/refFiles/test_merlin_anytopo_slimfly_UGAL_test.out \
+	tests/refFiles/test_merlin_anytopo_slimfly_UGAL_threshold_test.out \
 	tests/refFiles/test_merlin_dragon_128_platform_test.out \
 	tests/refFiles/test_merlin_dragon_128_platform_test_cm.out \
 	tests/refFiles/test_merlin_dragon_128_test.out \

--- a/src/sst/elements/merlin/tests/refFiles/test_merlin_anytopo_jellyfish_test.out
+++ b/src/sst/elements/merlin/tests/refFiles/test_merlin_anytopo_jellyfish_test.out
@@ -1,6 +1,6 @@
 Loaded NetworkX graph with 16 vertices and 32 edges
   Offered   Average
     Load    Latency
-     0.50      268.375 ns
+     0.50      262.401 ns
 
 Simulation is complete, simulated time: 400 us

--- a/src/sst/elements/merlin/topology/anytopo_utility/Jellyfish.py
+++ b/src/sst/elements/merlin/topology/anytopo_utility/Jellyfish.py
@@ -11,7 +11,7 @@ class JellyfishTopo(HPC_topo):
             super(JellyfishTopo, self).__init__("jellyfish")
             degree=args[1]
             num_vertices=args[0]
-            self.nx_graph = nx.random_regular_graph(degree, num_vertices, seed=0)
+            self.nx_graph = nx.random_regular_graph(degree, num_vertices, seed=10)
 
         elif len(args) == 3 and isinstance(args[0], int) and isinstance(args[1], int) and isinstance(args[2], int):
             super(JellyfishTopo, self).__init__("jellyfish")


### PR DESCRIPTION
This is a follow-up to https://github.com/sstsimulator/sst-elements/pull/2598.

The Anytopo tests weren't running because we didn't (and still don't) have the correct Python libraries installed on our testing infrastructure.  In an effort to do that (https://github.com/sstsimulator/sst-sqe/pull/1245) we discovered two things:

- One of the test references isn't correct (tested on the cluster head node)
- Testing on the result of `make dist` fails because test files were missing from `Makefile.am`.

Once this PR is in, the above SQE PR can be merged.